### PR TITLE
💚 Fix the docs workflow by installing the prebuilt lagrange binary.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build multilingual docs with lagrange
+      - name: Install lagrange (prebuilt release binary)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cargo install --git https://github.com/celestia-island/lagrange --branch dev lagrange-library --locked
-          lagrange build --src docs --out _site
+          gh release download --repo celestia-island/lagrange \
+            --pattern "*x86_64-unknown-linux-gnu.tar.gz" -O lagrange.tgz
+          tar xzf lagrange.tgz
+          sudo install -m 755 lagrange /usr/local/bin/lagrange
+          lagrange --version
+
+      - name: Build multilingual docs with lagrange
+        run: lagrange build --src docs --out _site
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Fix the Deploy Documentation workflow, which has been failing on master.

## Motivation

docs.yml installed lagrange via \cargo install --git ... --branch dev\, but \celestia-island/lagrange\ no longer has a \dev\ branch (default: \master\), so the clone failed with git exit 128 on every run.

## Changes

- Replace the git install with the prebuilt binary from lagrange's GitHub Releases (\x86_64-unknown-linux-gnu\, resolved via \gh release download\ so no version is hardcoded). Also cuts the step from a multi-minute source compile to seconds.

## Test Plan

- [x] The \Deploy Documentation\ run on the merge commit of this PR is the verification (it triggers on changes to docs.yml itself)

## Checklist

- [x] \cargo fmt --check\ passes (no Rust code touched)
- [x] \cargo clippy --workspace --all-targets -- -D warnings\ passes (no Rust code touched)
- [x] \cargo test --workspace\ passes (no Rust code touched)
- [x] CHANGELOG entry added (not user-facing; CI-only fix)
- [x] Documentation updated (not applicable)

## Breaking Changes

None.