### PR TITLE
🔨 Rewrite the Dockerfile as a working multi-stage build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Keep the build context small and free of local artifacts. The Dockerfile only
+# COPYs Cargo.toml, Cargo.lock, packages/, and tests/, so everything else is
+# excluded here.
+
+# VCS & CI
+.git/
+.github/
+.gitattributes
+.gitignore
+
+# Build artifacts
+target/
+**/target/
+log/
+
+# Local env (never bake secrets into the image)
+.env
+.env.*
+!.env.example
+
+# Editor / tooling local state
+.vscode/
+.verysync/
+.zcode/
+__pycache__/
+*.pyc
+
+# Repo files not needed to build the binary
+docs/
+scripts/
+tests/docker/
+_site/
+PLAN.md
+CHANGELOG.md
+README.md
+LICENSE
+celestia-devtools.just
+justfile
+deny.toml
+.editorconfig
+rustfmt.toml
+rust-toolchain.toml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: genshin-cloud-rust:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (M1 infra & test harness, M2 tech-debt cleanup, M3 authZ/OAuth,
   M4 caching, M5 docs & release).
 
+- Rewrite the Dockerfile as a working multi-stage build: the previous
+  image could not build (duplicate `cargo new _utils`, missing
+  `COPY --from`, `ENTRYPOINT ["./a"]` pointing at a non-existent
+  binary) and shipped unrelated `wasm32`/`cargo-make` leftovers. The
+  new image builds `_router` with LTO in a `rust:1` builder (BuildKit
+  cache mounts) and runs it on `debian:bookworm-slim` with
+  `ca-certificates` + `tini`. A `Docker` CI workflow validates the
+  build on every PR, and `.dockerignore` keeps the context lean.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,63 @@
-# Preload dependencies,
-# used to speed up repeated builds and reduce traffic consumption of libraries
-FROM rust:1 as stage-deps
+# syntax=docker/dockerfile:1.7
 
-RUN rustup target add wasm32-unknown-unknown
-RUN cargo install cargo-make
+# Genshin Map Cloud — Rust backend image.
+#
+# Multi-stage: a `rust:1` builder compiles the `_router` binary with LTO, then a
+# `debian:bookworm-slim` runtime ships only the binary + ca-certificates + tini.
+# BuildKit cache mounts (registry + target) keep rebuilds fast.
 
-COPY ./Cargo.toml /home/Cargo.toml
-RUN cargo new --lib --name _database /home/packages/database
-COPY ./packages/database/Cargo.toml /home/packages/database/Cargo.toml
-RUN cargo new --lib --name _functions /home/packages/functions
-COPY ./packages/functions/Cargo.toml /home/packages/functions/Cargo.toml
-RUN cargo new --name _utils /home/packages/utils
-COPY ./packages/utils/Cargo.toml /home/packages/utils/Cargo.toml
-RUN cargo new --name _router /home/packages/router
-COPY ./packages/router/Cargo.toml /home/packages/router/Cargo.toml
-RUN cargo new --name _utils /home/packages/utils
-COPY ./packages/utils/Cargo.toml /home/packages/utils/Cargo.toml
+# ── Builder ──────────────────────────────────────────────────────────────────
+FROM rust:1-bookworm AS builder
 
-WORKDIR /home
-RUN cargo fetch
+WORKDIR /app
 
-COPY ./packages/database /home/packages/database
-COPY ./packages/functions /home/packages/functions
-COPY ./packages/router /home/packages/router
-COPY ./packages/utils /home/packages/utils
+# Copy only manifests + lockfile first so the dependency-fetch layer is cached
+# independently of source changes.
+COPY Cargo.toml Cargo.lock ./
+COPY packages/utils/Cargo.toml      packages/utils/Cargo.toml
+COPY packages/database/Cargo.toml   packages/database/Cargo.toml
+COPY packages/functions/Cargo.toml  packages/functions/Cargo.toml
+COPY packages/router/Cargo.toml     packages/router/Cargo.toml
+COPY tests/rust/Cargo.toml          tests/rust/Cargo.toml
 
-# Stage 1 for server build, used to compile server program
-FROM stage-deps as stage-server-build1
+# Stub member sources so cargo can resolve the workspace without the real code,
+# then fetch all dependencies. The stubs are overwritten when real sources land.
+RUN mkdir -p packages/utils/src packages/database/src packages/functions/src \
+        packages/router/src tests/rust/src \
+ && printf 'pub fn _stub() {}\n' > packages/utils/src/lib.rs \
+ && printf 'pub fn _stub() {}\n' > packages/database/src/lib.rs \
+ && printf 'pub fn _stub() {}\n' > packages/functions/src/lib.rs \
+ && printf 'fn main() {}\n'        > packages/router/src/main.rs \
+ && printf ''                       > tests/rust/src/lib.rs \
+ && cargo fetch --locked
 
-WORKDIR /home
-RUN cargo build --offline --package _router --release
+# Real sources + release build. The cache mounts keep cargo registry and the
+# target dir out of the image layers; the binary is copied to a stable path so
+# it survives the cache mount being unmounted.
+COPY packages/ packages/
+COPY tests/     tests/
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build --release --package _router \
+ && cp target/release/_router /usr/local/bin/_router
 
-# Stage 2 for server build, used to integrate the build result of client and generate the final image
-FROM debian:bookworm as stage-server-build2
+# ── Runtime ──────────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
 
-ENV ROOT_DIR=/home/res
-WORKDIR /home
-ENTRYPOINT [ "./a" ]
+# ca-certificates: reqwest loads the system root store via rustls-native-certs
+# for outbound HTTPS (CDN proxy, OAuth, etc.).
+# tini: reaps zombies and forwards SIGTERM to tokio for graceful shutdown.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /usr/local/bin/_router /usr/local/bin/_router
+
+# The router listens on port 80 by default (see packages/router/src/main.rs);
+# override with the PORT env var if needed.
+ENV RUST_LOG=info
 EXPOSE 80
+
+ENTRYPOINT ["/usr/bin/tini", "--", "_router"]


### PR DESCRIPTION
## Summary

Rewrite the broken Dockerfile (M1 first item, PLAN.md §4) so the image actually builds and runs, plus a CI workflow to keep it green.

## Motivation

The current Dockerfile cannot build:
- `RUN cargo new --name _utils` appears twice (lines 13 & 17); the second fails because the directory already exists.
- The final `debian:bookworm` stage has no `COPY --from=stage-server-build1` and `ENTRYPOINT ["./a"]` points at a non-existent binary (the real one is `_router`).
- Ships irrelevant `wasm32-unknown-unknown` target and `cargo-make` (the Makefile.toml was removed).

## Changes

- **Dockerfile**: clean two-stage build — `rust:1-bookworm` builder fetches deps (manifests-first layer caching + stub sources), builds `_router --release` with BuildKit cache mounts (`cargo/registry` + `target`), copies the binary out; `debian:bookworm-slim` runtime with `ca-certificates` (reqwest rustls-native-certs) + `tini` (signal forwarding to tokio). `EXPOSE 80`.
- **.dockerignore**: keeps the build context lean (excludes `.git`, `target/`, `docs/`, `scripts/`, local `.env`, etc.).
- **.github/workflows/docker.yml**: `docker/build-push-action@v6` builds the image (no push) on every PR/push to master with GHA cache, so the Dockerfile is CI-validated like every other artifact.
- **CHANGELOG**: entry under the existing Infrastructure section.

## Test Plan

- [x] The new `Docker` workflow on this PR is the verification (cold build, then cached)

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes (no Rust code touched)
- [x] CHANGELOG entry added
- [x] Documentation updated (Dockerfile is self-documenting; README build instructions unchanged)

## Breaking Changes

None — the previous image never built, so there is no working baseline to break.
