### PR TITLE
✅ Wire the docker compose stack into DB-backed integration tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           key: ubuntu-cargo-sources-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run DB-backed tests
-        run: cargo test --test user_db --no-fail-fast
+        run: cargo test -p genshin-cloud-tests --test user_db --no-fail-fast
 
   # Delegates to the org reusable workflow, which lints both the PR title
   # (the squash-merge subject) and every commit in the PR/push range.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,56 @@ jobs:
       - name: Run integration tests
         run: cargo test --workspace --tests --no-fail-fast
 
+  # DB-backed integration tests. Provisions a Postgres service and runs the
+  # `user_db` test binary (and any future `*_db` binaries). Tests self-skip when
+  # GCS_TEST_DB is unset, so this job is the only place that actually exercises
+  # them. Mirrors tests/docker/docker-compose.e2e.yml credentials.
+  integration:
+    name: DB integration
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: genshin_map
+          POSTGRES_PASSWORD: genshin_map
+          POSTGRES_DB: genshin_map
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U genshin_map"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      GCS_TEST_DB: "1"
+      DB_USERNAME: genshin_map
+      DB_PASSWORD: genshin_map
+      DB_DATABASE: genshin_map
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Cache Cargo (sources only)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ubuntu-cargo-sources-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Run DB-backed tests
+        run: cargo test --test user_db --no-fail-fast
+
   # Delegates to the org reusable workflow, which lints both the PR title
   # (the squash-merge subject) and every commit in the PR/push range.
   commit-msg:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ca-certificates` + `tini`. A `Docker` CI workflow validates the
   build on every PR, and `.dockerignore` keeps the context lean.
 
+- Add the DB-backed integration test harness: a `user_db` test binary
+  that provisions the `sys_user` table on a live Postgres via sea-orm's
+  `Schema` and exercises the `SafeEntityTrait` round-trip (insert →
+  read → soft-delete). Gated on `GCS_TEST_DB` so `cargo test --workspace`
+  stays green without a database; the new `integration` CI job
+  provisions Postgres and runs it. The `tests/docker` compose comment
+  no longer references the removed `#[ignore]` convention.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,8 +2117,10 @@ name = "genshin-cloud-tests"
 version = "0.1.0"
 dependencies = [
  "_database",
+ "_functions",
  "_utils",
  "anyhow",
+ "chrono",
  "sea-orm",
  "serde",
  "serde_json",

--- a/tests/docker/docker-compose.e2e.yml
+++ b/tests/docker/docker-compose.e2e.yml
@@ -3,8 +3,11 @@
 # Spin up with:
 #   docker compose -f tests/docker/docker-compose.e2e.yml up -d
 #
-# Provides PostgreSQL + MinIO + Redis for the `#[ignore]`d DB-backed tests in
-# tests/rust/. Mirrors the dev.compose.yml services but scoped to testing.
+# Provides PostgreSQL + MinIO + Redis for the DB-backed tests in tests/rust/.
+# Tests are gated on the GCS_TEST_DB env var (not #[ignore]): set it locally
+# with `GCS_TEST_DB=1 DB_PASSWORD=genshin_map cargo test --test user_db` (Redis
+# and MinIO are optional — the backend degrades gracefully without them). The
+# CI `integration` job provisions the same Postgres automatically.
 
 services:
   postgres:

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -8,8 +8,10 @@ publish = false
 # Workspace crates under test
 _utils = { path = "../../packages/utils" }
 _database = { path = "../../packages/database" }
+_functions = { path = "../../packages/functions" }
 
-# sea-orm traits (EntityName, Iterable) for compile-time entity assertions
+# sea-orm traits (EntityName, Iterable) for compile-time entity assertions;
+# Schema + ConnectionTrait for DB-backed tests to create tables on the fly.
 sea-orm = { workspace = true }
 
 # Test runtime
@@ -17,6 +19,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"
@@ -36,3 +39,11 @@ path = "tests/marker/marker_domain_test.rs"
 [[test]]
 name = "schema"
 path = "tests/schema_test.rs"
+
+# DB-backed integration test. Gated on the GCS_TEST_DB env var (set by the CI
+# `integration` job, which also provisions a Postgres service). Skips cleanly
+# when no database is available, so `cargo test --workspace` stays green
+# everywhere else.
+[[test]]
+name = "user_db"
+path = "tests/user_db_test.rs"

--- a/tests/rust/tests/user_db_test.rs
+++ b/tests/rust/tests/user_db_test.rs
@@ -1,0 +1,164 @@
+//! DB-backed integration test for the `sys_user` domain — the template for all
+//! future domain DB tests (M1, PLAN.md §4).
+//!
+//! Gated on the `GCS_TEST_DB` env var: the CI `integration` job sets it and
+//! provisions a Postgres service; everywhere else this test skips cleanly so
+//! `cargo test --workspace` stays green without a database.
+//!
+//! What it verifies (the full DB harness, not just schema):
+//!   1. `init_db_conn()` connects to Postgres (Redis/MinIO degrade gracefully).
+//!   2. `Schema::create_table_from_entity` builds the `sys_user` table on a live
+//!      database (so entity definitions are executable DDL, not just string
+//!      matches — a stronger guarantee than `schema_test.rs`).
+//!   3. The `SafeEntityTrait` round-trip: insert → `find_safety_by_id` read →
+//!      `delete_safety` soft-delete → read again returns `None`.
+//!
+//! Future domain ports (icon, item, tag, ...) should copy this file, swap the
+//! entity, and extend the assertions — the harness setup is reusable as-is.
+
+use sea_orm::{
+    ActiveValue::NotSet, ConnectionTrait, EntityTrait, Schema, sea_query::TableCreateStatement,
+};
+
+use _database::DB_CONN;
+use _database::models::system::sys_user;
+use _functions::functions::system::user as user_fns;
+use _utils::{
+    db_operations::SafeEntityTrait,
+    jwt::AuthInfo,
+    models::SysUserVO,
+    types::{AccessPolicyItemEnum, AccessPolicyList, SystemUserRole},
+};
+
+/// Skip the test when no database is configured. Returns the shared connection
+/// on success, or prints a skip notice and returns `None`.
+async fn db() -> Option<&'static sea_orm::DatabaseConnection> {
+    if std::env::var("GCS_TEST_DB").is_err() {
+        eprintln!("skipped: set GCS_TEST_DB=1 with a reachable Postgres to run");
+        return None;
+    }
+    if DB_CONN.get().is_none() {
+        // init_db_conn is idempotent in practice: if another test already set
+        // the global, this returns Err and we fall through to the get() below.
+        let _ = _database::init_db_conn().await;
+    }
+    DB_CONN.get().map(|m| &m.pg_conn)
+}
+
+/// Recreate the `sys_user` table in the `genshin_map` schema. Idempotent so the
+/// test can run repeatedly. `sys_user` only self-references (creator/updater),
+/// so it can be created in isolation — no foreign-key ordering concerns.
+async fn recreate_table(db: &sea_orm::DatabaseConnection) -> anyhow::Result<()> {
+    db.execute_unprepared("CREATE SCHEMA IF NOT EXISTS genshin_map")
+        .await?;
+    db.execute_unprepared(r#"DROP TABLE IF EXISTS "genshin_map"."sys_user" CASCADE"#)
+        .await?;
+
+    let schema = Schema::new(sea_orm::DbBackend::Postgres);
+    let stmt: TableCreateStatement = schema.create_table_from_entity(sys_user::Entity);
+    let sql = stmt.to_string(sea_orm::sea_query::PostgresQueryBuilder);
+    db.execute_unprepared(&sql).await?;
+    Ok(())
+}
+
+/// Insert a user row directly via the entity (bypassing `do_register`, which
+/// hard-codes id=0 and would collide on the second insert — see PLAN.md F8).
+/// Lets the IDENTITY column assign the id and returns it.
+async fn seed_user(db: &sea_orm::DatabaseConnection) -> anyhow::Result<i64> {
+    use chrono::Utc;
+    use sea_orm::ActiveValue::Set;
+
+    let am = sys_user::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(Utc::now().naive_utc()),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        username: Set("db_test_user".into()),
+        password: Set("{bcrypt}$2a$10$stub".into()),
+        nickname: Set(Some("DB Test".into())),
+        qq: Set(None),
+        phone: Set(None),
+        logo: Set(None),
+        role_id: Set(SystemUserRole::MapUser),
+        access_policy: Set(AccessPolicyList(vec![AccessPolicyItemEnum::IpSameLastIp])),
+        remark: Set(None),
+    };
+    let res = sys_user::Entity::insert(am).exec(db).await?;
+    Ok(res.last_insert_id)
+}
+
+/// A minimal `AuthInfo` for calling business functions that take it (currently
+/// unused by the assertions below, but part of the template for future tests).
+#[allow(dead_code)]
+fn stub_auth() -> AuthInfo {
+    let now = chrono::Utc::now();
+    AuthInfo {
+        info: SysUserVO {
+            id: 0,
+            username: "stub".into(),
+            nickname: None,
+            qq: None,
+            phone: None,
+            logo: None,
+            role_id: SystemUserRole::Admin,
+            access_policy: AccessPolicyList(vec![]),
+            remark: None,
+        },
+        created_at: now,
+        expires_at: now + chrono::Duration::days(1),
+    }
+}
+
+#[tokio::test]
+async fn user_db_round_trip() {
+    let Some(db) = db().await else {
+        return;
+    };
+
+    // ── Setup: rebuild the table ────────────────────────────────────────────
+    recreate_table(db).await.expect("recreate sys_user table");
+
+    // ── Seed ─────────────────────────────────────────────────────────────────
+    let id = seed_user(db).await.expect("seed user");
+    assert!(id != 0, "IDENTITY column should assign a non-zero id");
+
+    // ── Read via the business layer (do_get_info → find_safety_by_id) ────────
+    let vo = user_fns::do_get_info(stub_auth(), id)
+        .await
+        .expect("do_get_info reads the seeded user");
+    assert_eq!(vo.username, "db_test_user");
+    assert_eq!(vo.role_id, SystemUserRole::MapUser);
+
+    // ── Soft-delete via SafeEntityTrait (correct version from the fetched
+    //    model) and confirm find_safety no longer returns it. ────────────────
+    let model = sys_user::Entity::find_safety_by_id(id)
+        .one(db)
+        .await
+        .expect("fetch model for soft-delete")
+        .expect("model exists before soft-delete");
+    let am: sys_user::ActiveModel = model.into();
+    sys_user::Entity::delete_safety(am)
+        .expect("build soft-delete")
+        .exec(db)
+        .await
+        .expect("exec soft-delete");
+
+    let gone = sys_user::Entity::find_safety_by_id(id)
+        .one(db)
+        .await
+        .expect("read after soft-delete");
+    assert!(
+        gone.is_none(),
+        "soft-deleted row must be filtered out by find_safety"
+    );
+
+    // NOTE: `user_fns::do_delete` (which calls `delete_safety_by_id`) is not
+    // exercised here — it uses `..Default::default()` for the ActiveModel, so
+    // the version defaults to 1 and the optimistic-lock filter (version=1)
+    // matches 0 rows when the row is at version 0. That bug is tracked as
+    // PLAN.md F8 (user-domain placeholders) and will be fixed alongside the
+    // other user-domain stubs in M2.
+}


### PR DESCRIPTION
## Summary

Wire the existing `tests/docker` compose stack into actual DB-backed integration tests — M1 second item (PLAN.md §4). Adds the `user_db` test binary as the reusable template and a CI `integration` job that provisions Postgres.

## Motivation

The `tests/docker/docker-compose.e2e.yml` compose file had no consumer: it claimed to serve `#[ignore]`d DB tests, but no such tests existed, and the compose comment was stale. Meanwhile every domain except area/marker had zero test coverage — there was no harness to write a DB test against.

## Changes

- **`tests/rust/tests/user_db_test.rs`** (new): the template DB test for the `sys_user` domain. Verifies the full harness:
  1. `init_db_conn()` connects to Postgres (Redis/MinIO degrade gracefully).
  2. `Schema::create_table_from_entity` builds the `sys_user` table on a live DB (stronger than `schema_test.rs`, which only string-matches).
  3. The `SafeEntityTrait` round-trip: insert → `do_get_info` read → `delete_safety` soft-delete → `find_safety_by_id` returns `None`.
  Gated on `GCS_TEST_DB` so it skips cleanly without a database.
- **`tests/rust/Cargo.toml`**: add `_functions` + `chrono` deps; register the `user_db` `[[test]]` binary with a doc comment on the gate.
- **`.github/workflows/test.yml`**: new `integration` job — postgres:16-alpine service container + `cargo test --test user_db` with `GCS_TEST_DB=1`. Existing `test` job still compiles the binary (skips it) on both OSes.
- **`tests/docker/docker-compose.e2e.yml`**: fix the stale `#[ignore]` comment to describe the actual `GCS_TEST_DB` gate and local invocation.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo test -p genshin-cloud-tests --test user_db` skips locally (no `GCS_TEST_DB`) — verified
- [x] `cargo fmt --check` + `cargo check --tests` clean — verified
- [ ] The `integration` job on this PR is the live-DB verification

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no new warnings)
- [x] `cargo test --workspace` passes (new test skips without DB)
- [x] CHANGELOG entry added
- [x] Documentation updated (test file + compose comment are self-documenting; future domain tests copy this template)

## Notes

- `do_get_info` is exercised (read path). `do_delete` (which calls `delete_safety_by_id`) is intentionally **not** asserted here: it uses `..Default::default()` for the ActiveModel, so the optimistic-lock version defaults to 1 and matches 0 rows when the row is at version 0. That bug is tracked as PLAN.md F8 (user-domain placeholders) and will be fixed in M2; the test comment points to it. The `delete_safety` path (with the correct version from the fetched model) is verified directly.

## Breaking Changes

None.
