### PR TITLE
✅ Upgrade e2e from smoke checks to authenticated business assertions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           key: ubuntu-cargo-sources-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run DB-backed tests
-        run: cargo test -p genshin-cloud-tests --test user_db --no-fail-fast
+        run: cargo test -p genshin-cloud-tests --test user_db --test api_db --no-fail-fast
 
   # Delegates to the org reusable workflow, which lints both the PR title
   # (the squash-merge subject) and every commit in the PR/push range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   provisions Postgres and runs it. The `tests/docker` compose comment
   no longer references the removed `#[ignore]` convention.
 
+- Add the `api_db` business-assertion test: seeds area + item rows on a
+  live Postgres (tables built FK-free via DDL rewriting so each domain
+  is independent) and asserts the business-layer functions return real
+  data — `area::do_list`/`do_add` and the BinaryMD5 `item_doc`
+  pipeline. Upgrades the e2e smoke checks (which treated 401/403 as
+  "route exists ✓") into actual data assertions. Runs in the same
+  `integration` CI job.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "_utils",
  "anyhow",
  "chrono",
+ "regex-lite",
  "sea-orm",
  "serde",
  "serde_json",
@@ -4061,6 +4062,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"
+regex-lite = "^0.1"
 
 [[test]]
 name = "utils_smoke"
@@ -47,3 +48,11 @@ path = "tests/schema_test.rs"
 [[test]]
 name = "user_db"
 path = "tests/user_db_test.rs"
+
+# DB-backed API business-assertion test. Same GCS_TEST_DB gate as user_db;
+# seeds area + item rows and asserts the business-layer functions return real
+# data (not just 401/403 smoke checks). Covers area list/add and the
+# BinaryMD5 item_doc pipeline.
+[[test]]
+name = "api_db"
+path = "tests/api_db_test.rs"

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -1,0 +1,253 @@
+//! DB-backed business-assertion test for the area + item_doc domains (M1 third
+//! item, PLAN.md §4).
+//!
+//! Same `GCS_TEST_DB` gate as `user_db_test`. Upgrades the e2e smoke checks
+//! (which treated 401/403 as "route exists ✓") into real data assertions:
+//! seeds rows and verifies the business-layer functions return them. Exercises
+//! the `SafeEntityTrait` query path and the BinaryMD5 pipeline end-to-end.
+//!
+//! Tables are created with foreign-key constraints stripped (regex on the
+//! generated DDL) so each table is independent — no need to build the full
+//! dependency graph (sys_user → icon → icon_type → area → item → ...) just to
+//! test one domain. Future domain tests can reuse `recreate_tables_fklless`.
+
+use sea_orm::{
+    ActiveValue::NotSet, ConnectionTrait, EntityTrait, Schema, sea_query::TableCreateStatement,
+};
+
+use _database::DB_CONN;
+use _database::models::{area::area as area_model, item::item as item_model};
+use _functions::functions::api::{area as area_fns, item_doc};
+use _utils::{
+    jwt::AuthInfo,
+    models::{
+        SysUserVO,
+        area::{AreaAddRequest, AreaListRequest},
+    },
+    types::{AccessPolicyList, HiddenFlag, IconStyleType, SystemUserRole},
+};
+
+/// Skip when no database is configured. Mirrors `user_db_test::db`.
+async fn db() -> Option<&'static sea_orm::DatabaseConnection> {
+    if std::env::var("GCS_TEST_DB").is_err() {
+        eprintln!("skipped: set GCS_TEST_DB=1 with a reachable Postgres to run");
+        return None;
+    }
+    if DB_CONN.get().is_none() {
+        let _ = _database::init_db_conn().await;
+    }
+    DB_CONN.get().map(|m| &m.pg_conn)
+}
+
+/// Build a CREATE TABLE statement for an entity with all FOREIGN KEY
+/// constraints stripped, so the table can be created in isolation without its
+/// dependency tables existing.
+fn ddl_without_foreign_keys<E>(entity: E) -> String
+where
+    E: sea_orm::EntityTrait,
+{
+    let schema = Schema::new(sea_orm::DbBackend::Postgres);
+    let stmt: TableCreateStatement = schema.create_table_from_entity(entity);
+    let sql = stmt.to_string(sea_orm::sea_query::PostgresQueryBuilder);
+    // Remove `, CONSTRAINT "fk-..." FOREIGN KEY (...) REFERENCES "schema"."t" (...)`
+    let stripped = regex_lite::Regex::new(
+        r#",(?:\s)*CONSTRAINT "fk-[^"]+" FOREIGN KEY \([^)]+\) REFERENCES (?:"[^"]+"\.)?"[^"]+" \([^)]+\)"#,
+    )
+    .expect("static regex")
+    .replace_all(&sql, "");
+    stripped.into_owned()
+}
+
+/// Drop (if present) and recreate the given entities' tables, FK-free, in the
+/// `genshin_map` schema. Order matters only for DROP CASCADE, not for CREATE
+/// (no FKs).
+async fn recreate_tables_fklless(
+    db: &sea_orm::DatabaseConnection,
+    table_names: &[&str],
+    ddls: &[String],
+) -> anyhow::Result<()> {
+    db.execute_unprepared("CREATE SCHEMA IF NOT EXISTS genshin_map")
+        .await?;
+    for name in table_names {
+        db.execute_unprepared(&format!(
+            r#"DROP TABLE IF EXISTS "genshin_map"."{name}" CASCADE"#
+        ))
+        .await?;
+    }
+    for ddl in ddls {
+        db.execute_unprepared(ddl).await?;
+    }
+    Ok(())
+}
+
+fn stub_auth() -> AuthInfo {
+    let now = chrono::Utc::now();
+    AuthInfo {
+        info: SysUserVO {
+            id: 1,
+            username: "stub".into(),
+            nickname: None,
+            qq: None,
+            phone: None,
+            logo: None,
+            role_id: SystemUserRole::Admin,
+            access_policy: AccessPolicyList(vec![]),
+            remark: None,
+        },
+        created_at: now,
+        expires_at: now + chrono::Duration::days(1),
+    }
+}
+
+#[tokio::test]
+async fn area_and_item_doc_business_assertions() {
+    let Some(db) = db().await else {
+        return;
+    };
+
+    // ── Setup: FK-free tables for area + item ────────────────────────────────
+    let ddls = [
+        ddl_without_foreign_keys(area_model::Entity),
+        ddl_without_foreign_keys(item_model::Entity),
+    ];
+    recreate_tables_fklless(db, &["area", "item"], &ddls)
+        .await
+        .expect("recreate area + item tables");
+
+    // ── Seed one area + two items (different hidden_flag → 2 MD5 groups) ─────
+    use sea_orm::ActiveValue::Set;
+    let now = chrono::Utc::now().naive_utc();
+
+    let area_am = area_model::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        name: Set("Test Area".into()),
+        code: Set(None),
+        content: Set(None),
+        icon_id: Set(0),
+        parent_id: Set(-1),
+        is_final: Set(true),
+        hidden_flag: Set(HiddenFlag::Visible),
+        sort_index: Set(0),
+        special_flag: Set(0),
+    };
+    let seeded_area_id = area_model::Entity::insert(area_am)
+        .exec(db)
+        .await
+        .expect("seed area")
+        .last_insert_id;
+
+    for hidden in [HiddenFlag::Visible, HiddenFlag::Hidden] {
+        let item_am = item_model::ActiveModel {
+            id: NotSet,
+            version: Set(0),
+            create_time: Set(now),
+            update_time: Set(None),
+            creator_id: Set(None),
+            updater_id: Set(None),
+            del_flag: Set(false),
+            name: Set(format!("Test Item {hidden:?}")),
+            area_id: Set(seeded_area_id),
+            default_refresh_time: Set(0),
+            default_content: Set(None),
+            default_count: Set(1),
+            icon_id: Set(0),
+            icon_style_type: Set(IconStyleType::Default),
+            hidden_flag: Set(hidden),
+            sort_index: Set(0),
+            special_flag: Set(Some(0)),
+        };
+        item_model::Entity::insert(item_am)
+            .exec(db)
+            .await
+            .expect("seed item");
+    }
+
+    let auth = stub_auth();
+
+    // ── Assertion 1: area do_list returns the seeded area ────────────────────
+    let list_resp = area_fns::do_list(
+        auth.clone(),
+        AreaListRequest {
+            is_traverse: None,
+            parent_id: None,
+            hidden_flag: None,
+        },
+    )
+    .await
+    .expect("area do_list")
+    .data
+    .expect("area list payload");
+    let areas = &list_resp.0;
+    assert_eq!(areas.len(), 1, "exactly one seeded area");
+    assert_eq!(areas[0].name, "Test Area");
+    assert_eq!(areas[0].id, seeded_area_id);
+
+    // ── Assertion 2: area do_add inserts a second area ───────────────────────
+    let add_resp = area_fns::do_add(
+        auth.clone(),
+        AreaAddRequest {
+            name: "Second Area".into(),
+            code: Some("A2".into()),
+            content: None,
+            icon_tag: "0".into(),
+            parent_id: seeded_area_id,
+            is_final: false,
+            hidden_flag: HiddenFlag::Hidden,
+            sort_index: 1,
+            special_flag: 0,
+        },
+    )
+    .await
+    .expect("area do_add")
+    .data
+    .expect("area add payload");
+    let new_id = add_resp.id;
+    assert!(new_id != seeded_area_id, "new area gets a distinct id");
+
+    let after = area_fns::do_list(
+        auth.clone(),
+        AreaListRequest {
+            is_traverse: None,
+            parent_id: None,
+            hidden_flag: None,
+        },
+    )
+    .await
+    .expect("area do_list after add")
+    .data
+    .expect("area list payload");
+    assert_eq!(after.0.len(), 2, "two areas after add");
+
+    // ── Assertion 3: item_doc do_list_page_bin_md5 returns one MD5 per
+    //    hidden_flag group (2 items, 2 distinct flags → 2 entries), each a
+    //    32-char hex MD5. ────────────────────────────────────────────────────
+    let md5_resp = item_doc::do_list_page_bin_md5(auth, serde_json::Value::Null)
+        .await
+        .expect("item_doc do_list_page_bin_md5")
+        .data
+        .expect("item_doc md5 payload");
+    assert_eq!(
+        md5_resp.len(),
+        2,
+        "two hidden_flag groups → two MD5 entries"
+    );
+    for vo in &md5_resp {
+        assert_eq!(
+            vo.md5.len(),
+            32,
+            "MD5 must be 32 hex chars, got: {}",
+            vo.md5
+        );
+        assert!(
+            vo.md5.chars().all(|c| c.is_ascii_hexdigit()),
+            "MD5 must be hex: {}",
+            vo.md5
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Upgrade the e2e smoke checks (which treated 401/403 as "route exists ✓") into real data assertions — M1 third item (PLAN.md §4). Adds an `api_db` test that seeds rows and asserts the business-layer functions return them.

## Motivation

The existing e2e tests (`scripts/e2e/run_tests.py`) proved routes existed but never verified data: a 401/403 counted as a pass. There was no test that actually exercised `SafeEntityTrait` queries or the BinaryMD5 pipeline against real rows. This PR fills that gap with a CI-runnable, DB-backed business-assertion test.

## Changes

- **`tests/rust/tests/api_db_test.rs`** (new): seeds one area + two items (distinct `hidden_flag` → 2 MD5 groups) on a live Postgres, then asserts:
  1. `area::do_list` returns the seeded area (name + id match).
  2. `area::do_add` inserts a second area; a subsequent `do_list` sees 2 rows.
  3. `item_doc::do_list_page_bin_md5` returns 2 MD5 entries (one per hidden_flag group), each a 32-char hex string.
  Tables are built **FK-free** (regex strips `CONSTRAINT "fk-..." FOREIGN KEY ...` from the generated DDL) so each domain is independent — no need to construct the full `sys_user → icon → icon_type → area → item` dependency graph just to test one domain. `recreate_tables_fklless` is reusable for future domain tests.
- **`tests/rust/Cargo.toml`**: add `regex-lite` (FK stripping) + register the `api_db` `[[test]]` binary.
- **`.github/workflows/test.yml`**: the `integration` job now runs both `--test user_db` and `--test api_db`.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Design note

The business functions take an `AuthInfo` argument, so the test passes a stub `AuthInfo` (admin role) — this represents the post-login state without needing the full OAuth/HTTP middleware stack. The HTTP + auth-middleware end-to-end path remains covered by the local browser e2e; this test targets the business+DB layer where the real logic lives, and is CI-runnable (Postgres service only).

## Test Plan

- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no `GCS_TEST_DB`) — verified
- [x] `cargo fmt --check` + `cargo check --tests` clean — verified
- [ ] The `integration` job on this PR is the live-DB verification

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no new warnings)
- [x] `cargo test --workspace` passes (new test skips without DB)
- [x] CHANGELOG entry added
- [x] Documentation updated (test file is self-documenting; `recreate_tables_fklless` is the reusable template)

## Breaking Changes

None.
