### PR TITLE
🐛 Wire the archive rename handler to the rename-by-slot operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   "route exists ✓") into actual data assertions. Runs in the same
   `integration` CI job.
 
+- Wire the archive rename handler: the route previously stubbed the
+  response (it could not call `do_rename` because `auth` was moved into
+  `do_get_last`). New `do_rename_by_slot(user_id, slot_index, name)`
+  renames the latest archive in the slot; the route now returns the real
+  operation result.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -102,6 +102,26 @@ pub async fn do_rename(_auth: AuthInfo, id: i64, name: String) -> Result<CommonR
     Ok(CommonResponse::new(Ok(())))
 }
 
+/// Rename an archive slot (renames the latest archive in the slot).
+pub async fn do_rename_by_slot(
+    user_id: i64,
+    slot_index: i32,
+    new_name: String,
+) -> Result<CommonResponse<()>> {
+    let db = &DB_CONN.wait().pg_conn;
+    let a = archive_model::Entity::find_safety()
+        .filter(archive_model::Column::UserId.eq(user_id))
+        .filter(archive_model::Column::SlotIndex.eq(slot_index))
+        .order_by_desc(archive_model::Column::CreateTime)
+        .one(db)
+        .await?
+        .ok_or_else(|| anyhow!("Archive not found"))?;
+    let mut am: archive_model::ActiveModel = a.into();
+    am.name = Set(Some(new_name));
+    archive_model::Entity::update_safety(am)?.exec(db).await?;
+    Ok(CommonResponse::new(Ok(())))
+}
+
 /// Restore from an archive (return the archived data).
 pub async fn do_restore(_auth: AuthInfo, id: i64) -> Result<CommonResponse<serde_json::Value>> {
     let db = &DB_CONN.wait().pg_conn;

--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -136,16 +136,14 @@ pub async fn rename(
         return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
     }
     let user_id = auth.info.id;
-    // Find the latest archive in the slot
-    match _functions::functions::system::archive::do_get_last(auth, user_id, slot_index as i32)
-        .await
+    match _functions::functions::system::archive::do_rename_by_slot(
+        user_id,
+        slot_index as i32,
+        new_name,
+    )
+    .await
     {
-        Ok(_v) => {
-            // auth was moved into do_get_last; do_rename requires an AuthInfo.
-            // For now, just return the archive info — full rename needs &AuthInfo refactor.
-            // TODO: refactor business functions to borrow AuthInfo.
-            Ok(Json(()).into_response())
-        },
+        Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
     }
 }


### PR DESCRIPTION
## Summary

Wire the archive rename handler to a real operation — M2 first item (PLAN.md §4, F1).

## Motivation

`POST /archive/rename/{slot_index}/{new_name}` was a stub: it called `do_get_last` (which moves `auth`), then could not call `do_rename` and returned `Json(())`. The planned fix was a `&AuthInfo` refactor of business functions, but all archive business functions take `_auth` unused — the real problem is that the route destroyed the value it needed. The clean fix is a slot-scoped rename operation.

## Changes

- **`packages/functions/.../system/archive.rs`**: new `do_rename_by_slot(user_id, slot_index, new_name)` — finds the latest archive in the slot and renames it (same query shape as `do_get_last`).
- **`packages/router/.../system/archive.rs`**: the `rename` handler now calls `do_rename_by_slot` and returns the real result; the stub + TODO are removed.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] CI on this PR (Build & Check runs clippy `-D warnings` — no dead-code warnings from the now-unused `do_rename` since it remains `pub`)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (per CI)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — the route's response shape changes from `{}` to the actual operation result, which is the intended behavior.
