### PR TITLE
✨ Add the archive delete_slot operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   renames the latest archive in the slot; the route now returns the real
   operation result.
 
+- Implement the archive `delete_slot` handler: new
+  `do_delete_slot(user_id, slot_index)` soft-deletes every archive in
+  the slot; the route previously returned a stub `{}`.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -132,6 +132,22 @@ pub async fn do_restore(_auth: AuthInfo, id: i64) -> Result<CommonResponse<serde
     Ok(CommonResponse::new(Ok(a.data)))
 }
 
+/// Delete an archive slot (soft-delete every archive in the slot).
+pub async fn do_delete_slot(user_id: i64, slot_index: i32) -> Result<CommonResponse<()>> {
+    let db = &DB_CONN.wait().pg_conn;
+    let items = archive_model::Entity::find_safety()
+        .filter(archive_model::Column::UserId.eq(user_id))
+        .filter(archive_model::Column::SlotIndex.eq(slot_index))
+        .all(db)
+        .await?;
+    for a in items {
+        archive_model::Entity::delete_safety(a.into())?
+            .exec(db)
+            .await?;
+    }
+    Ok(CommonResponse::new(Ok(())))
+}
+
 /// Delete an archive slot (soft delete).
 pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
     let db = &DB_CONN.wait().pg_conn;

--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -172,11 +172,14 @@ pub async fn restore(
 #[tracing::instrument(skip(auth))]
 pub async fn delete_slot(
     ExtractAuthInfo(auth): ExtractAuthInfo,
-    Path(_slot_index): Path<i64>,
+    Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     if auth.info.role_id != SystemUserRole::Admin {
         return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
     }
-    // TODO: add do_delete_slot(user_id, slot_index) to the archive module.
-    Ok(Json(()).into_response())
+    let user_id = auth.info.id;
+    match _functions::functions::system::archive::do_delete_slot(user_id, slot_index as i32).await {
+        Ok(v) => Ok(Json(v).into_response()),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+    }
 }


### PR DESCRIPTION
## Summary

Implement the archive `delete_slot` handler — M2 second item (PLAN.md §4, F2).

## Motivation

`DELETE /archive/slot/{slot_index}` was a stub returning `{}` — it never soft-deleted anything. There was no `do_delete_slot` business function.

## Changes

- **`packages/functions/.../system/archive.rs`**: new `do_delete_slot(user_id, slot_index)` — soft-deletes every archive in the slot (via `SafeEntityTrait::delete_safety`, so the optimistic-lock version matches).
- **`packages/router/.../system/archive.rs`**: the `delete_slot` handler now calls `do_delete_slot` and returns the real result; the TODO + stub are removed.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] CI on this PR

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (per CI)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None.
