### PR TITLE
✨ Define RouteVO and return real route page, search, and list data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `do_delete_slot(user_id, slot_index)` soft-deletes every archive in
   the slot; the route previously returned a stub `{}`.
 
+- Define `RouteVO` and return real route data: `do_get_page` /
+  `do_get_search` / `do_get_list_by_id` previously mapped their (correct)
+  queries into the `RouteEmptyResponse` placeholder. They now return
+  `RoutePageResponse { total, items }` / `Vec<RouteVO>` with full route
+  fields (marker list, hidden flag, extra, creator info, timestamps).
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/api/route.rs
+++ b/packages/functions/src/functions/api/route.rs
@@ -9,10 +9,27 @@ use _utils::{
     jwt::AuthInfo,
     models::{
         common::EmptyResponse,
-        route::{RouteAddRequest, RouteEmptyResponse, RouteSearchRequest, RouteUpdateRequest},
+        route::{
+            RouteAddRequest, RoutePageResponse, RouteSearchRequest, RouteUpdateRequest, RouteVO,
+        },
         wrapper::{CommonResponse, Pagination},
     },
 };
+
+fn to_vo(r: route_model::Model) -> RouteVO {
+    RouteVO {
+        id: r.id,
+        name: r.name,
+        content: r.content,
+        marker_list: r.marker_list.0,
+        hidden_flag: r.hidden_flag,
+        video: r.video,
+        extra: r.extra,
+        creator_nickname: r.creator_nickname,
+        creator_id: r.creator_id,
+        create_time: r.create_time,
+    }
+}
 
 /// 新增路线
 pub async fn do_add(_auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
@@ -99,31 +116,32 @@ pub async fn do_update(
 pub async fn do_get_page(
     _auth: AuthInfo,
     payload: Pagination,
-) -> Result<CommonResponse<RouteEmptyResponse>> {
+) -> Result<CommonResponse<RoutePageResponse>> {
     let db = &DB_CONN.wait().pg_conn;
     let size = payload.size.unwrap_or(10) as u64;
     let current = payload.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
     let total = route_model::Entity::find_safety().count(db).await?;
-    let _items = route_model::Entity::find_safety()
+    let items = route_model::Entity::find_safety()
         .limit(size)
         .offset(offset)
         .all(db)
-        .await?;
-
-    // TODO: map _items into RouteVO once the VO type is defined (the current
-    // RouteEmptyResponse is a placeholder). The query is correct; only the
-    // response shape needs the VO.
-    let _ = total;
-    Ok(CommonResponse::new(Ok(RouteEmptyResponse {})))
+        .await?
+        .into_iter()
+        .map(to_vo)
+        .collect();
+    Ok(CommonResponse::new(Ok(RoutePageResponse {
+        total: total as i64,
+        items,
+    })))
 }
 
 /// 按创建人/名称搜索路线
 pub async fn do_get_search(
     _auth: AuthInfo,
     payload: RouteSearchRequest,
-) -> Result<RouteEmptyResponse> {
+) -> Result<RoutePageResponse> {
     let db = &DB_CONN.wait().pg_conn;
     let mut query = route_model::Entity::find_safety();
 
@@ -141,25 +159,37 @@ pub async fn do_get_search(
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
-    let _items = query.limit(size).offset(offset).all(db).await?;
-    // TODO: map into RouteVO once the VO type exists.
-    Ok(RouteEmptyResponse {})
+    let total = query.clone().count(db).await?;
+    let items = query
+        .limit(size)
+        .offset(offset)
+        .all(db)
+        .await?
+        .into_iter()
+        .map(to_vo)
+        .collect();
+    Ok(RoutePageResponse {
+        total: total as i64,
+        items,
+    })
 }
 
 /// 按 ID 列表批量查询路线
 pub async fn do_get_list_by_id(
     _auth: AuthInfo,
     payload: Vec<f64>,
-) -> Result<CommonResponse<RouteEmptyResponse>> {
+) -> Result<CommonResponse<Vec<RouteVO>>> {
     let db = &DB_CONN.wait().pg_conn;
     let ids: Vec<i64> = payload.iter().map(|f| *f as i64).collect();
 
-    let _items = route_model::Entity::find_safety()
+    let items = route_model::Entity::find_safety()
         .filter(route_model::Column::Id.is_in(ids))
         .all(db)
-        .await?;
-    // TODO: map into RouteVO once the VO type exists.
-    Ok(CommonResponse::new(Ok(RouteEmptyResponse {})))
+        .await?
+        .into_iter()
+        .map(to_vo)
+        .collect();
+    Ok(CommonResponse::new(Ok(items)))
 }
 
 /// 软删除路线

--- a/packages/utils/src/models/route.rs
+++ b/packages/utils/src/models/route.rs
@@ -59,6 +59,38 @@ pub struct RouteSearchRequest {
     pub page: Pagination,
 }
 
+/// 路线视图对象
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RouteEmptyResponse {}
+pub struct RouteVO {
+    /// 路线 ID
+    pub id: i64,
+    /// 路线名称
+    pub name: String,
+    /// 路线描述
+    pub content: Option<String>,
+    /// 点位顺序数组
+    pub marker_list: Vec<i64>,
+    /// 权限屏蔽标记
+    pub hidden_flag: HiddenFlag,
+    /// 视频地址
+    pub video: Option<String>,
+    /// 额外信息
+    pub extra: serde_json::Value,
+    /// 创建人昵称
+    pub creator_nickname: String,
+    /// 创建人 ID
+    pub creator_id: Option<i64>,
+    /// 创建时间
+    pub create_time: chrono::NaiveDateTime,
+}
+
+/// 路线分页返回
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutePageResponse {
+    /// 总条数
+    pub total: i64,
+    /// 当前页数据
+    pub items: Vec<RouteVO>,
+}


### PR DESCRIPTION
## Summary

Define `RouteVO` and return real route data from the three query endpoints — M2 third item (PLAN.md §4, F3).

## Motivation

`do_get_page` / `do_get_search` / `do_get_list_by_id` ran correct queries but discarded the results, returning the `RouteEmptyResponse` placeholder (empty `{}`). Clients of `/route/get/page`, `/route/get/search`, and `/route/get/list_by_id` received no data.

## Changes

- **`packages/utils/src/models/route.rs`**: add `RouteVO` (id, name, content, markerList, hiddenFlag, video, extra, creatorNickname, creatorId, createTime) and `RoutePageResponse { total, items }`; remove the `RouteEmptyResponse` placeholder.
- **`packages/functions/.../api/route.rs`**:
  - `do_get_page` → `CommonResponse<RoutePageResponse>` (real total + items)
  - `do_get_search` → `RoutePageResponse` (now also counts the filtered total, which the placeholder skipped)
  - `do_get_list_by_id` → `CommonResponse<Vec<RouteVO>>`
  - shared `to_vo` mapper from the route entity
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] CI on this PR (clippy `-D warnings`)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (per CI)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

The three endpoints now return real data instead of `{}` — the response shape is new but this is the intended behavior.
