### PR TITLE
🐛 Implement the marker ItemList tweak branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   user's Redis sessions (degrades to no-op without Redis). The
   `user_db` test now asserts all of the above plus `do_delete`.
 
+- Implement the marker `ItemList` tweak (PLAN.md F9): the
+  `do_tweak` handler previously skipped the `itemList` prop entirely.
+  It now maintains the `marker_item_link` table for
+  Append / InsertIfAbsent / InsertOrUpdate / Merge / Update (upsert
+  with count), Replace (rebuild), and RemoveLeft / RemoveRight
+  (remove listed links). `api_db` test covers the full cycle against
+  live Postgres.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -253,7 +253,8 @@ async fn insert_item_link(
     let now = Utc::now().naive_utc();
     let am = mil_model::ActiveModel {
         version: Set(0),
-        id: Set(0),
+        // id 为 IDENTITY 列：NotSet 走自增，避免多条插入共用 id=0 撞主键
+        id: sea_orm::ActiveValue::NotSet,
         create_time: Set(now),
         update_time: Set(None),
         creator_id: Set(None),

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -127,7 +127,7 @@ pub async fn do_tweak(
                     }
                 },
                 _utils::models::marker::MarkerTweakConfigPropEnum::ItemList => {
-                    // 逻辑复杂：此处跳过。Item 列表调整应由专门的 API 处理。
+                    tweak_item_list(db, *marker_id, tweak).await?;
                 },
             }
         }
@@ -137,6 +137,134 @@ pub async fn do_tweak(
     }
 
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
+}
+
+/// 解析 tweak 的 item_list 元数据为 (item_id, count) 列表。
+/// 支持裸数字 id 或 `{"id": n, "count": c}` 对象。
+fn parse_item_entries(item_list: &[Option<serde_json::Value>]) -> Vec<(i64, i32)> {
+    let mut ret = Vec::new();
+    for v in item_list.iter().flatten() {
+        match v {
+            serde_json::Value::Number(n) => {
+                if let Some(id) = n.as_i64() {
+                    ret.push((id, 1));
+                }
+            },
+            serde_json::Value::Object(obj) => {
+                if let Some(id) = obj.get("id").and_then(|x| x.as_i64()) {
+                    let count = obj.get("count").and_then(|x| x.as_i64()).unwrap_or(1) as i32;
+                    ret.push((id, count));
+                }
+            },
+            _ => {},
+        }
+    }
+    ret
+}
+
+/// 批量调整某 marker 的 item 关联（marker_item_link 表）。
+/// 支持的调整类型：Append / InsertIfAbsent / InsertOrUpdate / Merge / Update
+/// （追加或更新 count）、Replace（整表替换）、RemoveLeft / RemoveRight
+/// （移除列出的关联）。
+async fn tweak_item_list(
+    db: &sea_orm::DatabaseConnection,
+    marker_id: i64,
+    tweak: &_utils::models::marker::MarkerTweakConfig,
+) -> Result<()> {
+    use _utils::models::marker::{MarkerTweakConfigTypeEnum, TweakMeta};
+
+    let TweakMeta {
+        item_list: Some(item_list),
+        ..
+    } = &tweak.meta
+    else {
+        return Ok(());
+    };
+    let entries = parse_item_entries(item_list);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let existing = mil_model::Entity::find_safety()
+        .filter(mil_model::Column::MarkerId.eq(marker_id))
+        .all(db)
+        .await?;
+    let mut existing_map: std::collections::HashMap<i64, mil_model::Model> =
+        existing.into_iter().map(|l| (l.item_id, l)).collect();
+
+    match tweak.marker_tweak_config_type {
+        MarkerTweakConfigTypeEnum::Replace => {
+            // 软删现有全部关联，然后插入新列表
+            for (_item_id, link) in existing_map.drain() {
+                mil_model::Entity::delete_safety(link.into())?
+                    .exec(db)
+                    .await?;
+            }
+            for (item_id, count) in entries {
+                insert_item_link(db, marker_id, item_id, count).await?;
+            }
+        },
+        MarkerTweakConfigTypeEnum::RemoveLeft | MarkerTweakConfigTypeEnum::RemoveRight => {
+            for (item_id, _count) in entries {
+                if let Some(link) = existing_map.remove(&item_id) {
+                    mil_model::Entity::delete_safety(link.into())?
+                        .exec(db)
+                        .await?;
+                }
+            }
+        },
+        // Append / Prepend / InsertIfAbsent / InsertOrUpdate / Merge / Update：
+        // 追加或更新 count；InsertIfAbsent 对已存在条目跳过。
+        // 其余类型（Trim*/ReplaceRegex 等）对 item 列表无意义，忽略。
+        MarkerTweakConfigTypeEnum::Append
+        | MarkerTweakConfigTypeEnum::Prepend
+        | MarkerTweakConfigTypeEnum::InsertIfAbsent
+        | MarkerTweakConfigTypeEnum::InsertOrUpdate
+        | MarkerTweakConfigTypeEnum::Merge
+        | MarkerTweakConfigTypeEnum::Update => {
+            for (item_id, count) in entries {
+                if let Some(link) = existing_map.get(&item_id) {
+                    // 已存在：仅 InsertIfAbsent 跳过；其余更新 count
+                    if matches!(
+                        tweak.marker_tweak_config_type,
+                        MarkerTweakConfigTypeEnum::InsertIfAbsent
+                    ) {
+                        continue;
+                    }
+                    let mut am: mil_model::ActiveModel = link.clone().into();
+                    am.count = Set(count);
+                    mil_model::Entity::update_safety(am)?.exec(db).await?;
+                } else {
+                    insert_item_link(db, marker_id, item_id, count).await?;
+                }
+            }
+        },
+        _ => {},
+    }
+    Ok(())
+}
+
+async fn insert_item_link(
+    db: &sea_orm::DatabaseConnection,
+    marker_id: i64,
+    item_id: i64,
+    count: i32,
+) -> Result<()> {
+    let now = Utc::now().naive_utc();
+    let am = mil_model::ActiveModel {
+        version: Set(0),
+        id: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        item_id: Set(item_id),
+        marker_id: Set(marker_id),
+        count: Set(count),
+    };
+    mil_model::Entity::insert(am).exec(db).await?;
+    Ok(())
 }
 
 pub async fn do_add_single(

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -12,17 +12,26 @@
 //! test one domain. Future domain tests can reuse `recreate_tables_fklless`.
 
 use sea_orm::{
-    ActiveValue::NotSet, ConnectionTrait, EntityTrait, Schema, sea_query::TableCreateStatement,
+    ActiveValue::NotSet, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter,
+    Schema, sea_query::TableCreateStatement,
 };
 
 use _database::DB_CONN;
-use _database::models::{area::area as area_model, item::item as item_model};
-use _functions::functions::api::{area as area_fns, item_doc};
+use _database::models::{
+    area::area as area_model, item::item as item_model, marker::marker as marker_model,
+    marker::marker_item_link as mil_model,
+};
+use _functions::functions::api::{area as area_fns, item_doc, marker as marker_fns};
 use _utils::{
+    db_operations::SafeEntityTrait,
     jwt::AuthInfo,
     models::{
         SysUserVO,
         area::{AreaAddRequest, AreaListRequest},
+        marker::{
+            MarkerTweakConfig, MarkerTweakConfigPropEnum, MarkerTweakConfigTypeEnum,
+            MarkerTweakRequest, TweakMeta,
+        },
     },
     types::{AccessPolicyList, HiddenFlag, IconStyleType, SystemUserRole},
 };
@@ -80,6 +89,13 @@ async fn recreate_tables_fklless(
     Ok(())
 }
 
+async fn link_count(db: &sea_orm::DatabaseConnection, marker_id: i64) -> anyhow::Result<u64> {
+    Ok(mil_model::Entity::find_safety()
+        .filter(mil_model::Column::MarkerId.eq(marker_id))
+        .count(db)
+        .await?)
+}
+
 fn stub_auth() -> AuthInfo {
     let now = chrono::Utc::now();
     AuthInfo {
@@ -109,10 +125,12 @@ async fn area_and_item_doc_business_assertions() {
     let ddls = [
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
+        ddl_without_foreign_keys(marker_model::Entity),
+        ddl_without_foreign_keys(mil_model::Entity),
     ];
-    recreate_tables_fklless(db, &["area", "item"], &ddls)
+    recreate_tables_fklless(db, &["area", "item", "marker", "marker_item_link"], &ddls)
         .await
-        .expect("recreate area + item tables");
+        .expect("recreate area + item + marker tables");
 
     // ── Seed one area + two items (different hidden_flag → 2 MD5 groups) ─────
     use sea_orm::ActiveValue::Set;
@@ -227,7 +245,7 @@ async fn area_and_item_doc_business_assertions() {
     // ── Assertion 3: item_doc do_list_page_bin_md5 returns one MD5 per
     //    hidden_flag group (2 items, 2 distinct flags → 2 entries), each a
     //    32-char hex MD5. ────────────────────────────────────────────────────
-    let md5_resp = item_doc::do_list_page_bin_md5(auth, serde_json::Value::Null)
+    let md5_resp = item_doc::do_list_page_bin_md5(auth.clone(), serde_json::Value::Null)
         .await
         .expect("item_doc do_list_page_bin_md5")
         .data
@@ -250,4 +268,148 @@ async fn area_and_item_doc_business_assertions() {
             vo.md5
         );
     }
+
+    // ── Assertion 4: marker ItemList tweak maintains marker_item_link ────────
+    // Seed one marker, then exercise Append / InsertIfAbsent / Replace /
+    // RemoveLeft against its item links.
+    let marker_am = marker_model::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        marker_stamp: Set(None),
+        marker_title: Set(Some("Test Marker".into())),
+        position: Set("1.0,2.0".into()),
+        content: Set(String::new()),
+        picture: Set(None),
+        marker_creator_id: Set(1),
+        picture_creator_id: Set(None),
+        video_path: Set(None),
+        refresh_time: Set(0),
+        hidden_flag: Set(HiddenFlag::Visible),
+        extra: Set(None),
+    };
+    let marker_id = marker_model::Entity::insert(marker_am)
+        .exec(db)
+        .await
+        .expect("seed marker")
+        .last_insert_id;
+
+    // Append item 1001 + 1002
+    marker_fns::do_tweak(
+        auth.clone(),
+        MarkerTweakRequest {
+            marker_ids: vec![marker_id],
+            tweaks: vec![MarkerTweakConfig {
+                meta: TweakMeta {
+                    item_list: Some(vec![
+                        Some(serde_json::json!(1001)),
+                        Some(serde_json::json!(1002)),
+                    ]),
+                    map: None,
+                    replace: None,
+                    test: None,
+                    value: None,
+                },
+                prop: MarkerTweakConfigPropEnum::ItemList,
+                marker_tweak_config_type: MarkerTweakConfigTypeEnum::Append,
+            }],
+        },
+    )
+    .await
+    .expect("append item links")
+    .data
+    .expect("tweak ok");
+    assert_eq!(
+        link_count(db, marker_id).await.expect("count"),
+        2,
+        "append creates two links"
+    );
+
+    // InsertIfAbsent with an existing id must not duplicate
+    marker_fns::do_tweak(
+        auth.clone(),
+        MarkerTweakRequest {
+            marker_ids: vec![marker_id],
+            tweaks: vec![MarkerTweakConfig {
+                meta: TweakMeta {
+                    item_list: Some(vec![Some(serde_json::json!(1001))]),
+                    map: None,
+                    replace: None,
+                    test: None,
+                    value: None,
+                },
+                prop: MarkerTweakConfigPropEnum::ItemList,
+                marker_tweak_config_type: MarkerTweakConfigTypeEnum::InsertIfAbsent,
+            }],
+        },
+    )
+    .await
+    .expect("insert-if-absent tweak")
+    .data
+    .expect("tweak ok");
+    assert_eq!(
+        link_count(db, marker_id).await.expect("count"),
+        2,
+        "InsertIfAbsent must not duplicate an existing link"
+    );
+
+    // Replace with a single item 1003
+    marker_fns::do_tweak(
+        auth.clone(),
+        MarkerTweakRequest {
+            marker_ids: vec![marker_id],
+            tweaks: vec![MarkerTweakConfig {
+                meta: TweakMeta {
+                    item_list: Some(vec![Some(serde_json::json!(1003))]),
+                    map: None,
+                    replace: None,
+                    test: None,
+                    value: None,
+                },
+                prop: MarkerTweakConfigPropEnum::ItemList,
+                marker_tweak_config_type: MarkerTweakConfigTypeEnum::Replace,
+            }],
+        },
+    )
+    .await
+    .expect("replace tweak")
+    .data
+    .expect("tweak ok");
+    assert_eq!(
+        link_count(db, marker_id).await.expect("count"),
+        1,
+        "replace collapses to a single link"
+    );
+
+    // RemoveLeft removes 1003
+    marker_fns::do_tweak(
+        auth,
+        MarkerTweakRequest {
+            marker_ids: vec![marker_id],
+            tweaks: vec![MarkerTweakConfig {
+                meta: TweakMeta {
+                    item_list: Some(vec![Some(serde_json::json!(1003))]),
+                    map: None,
+                    replace: None,
+                    test: None,
+                    value: None,
+                },
+                prop: MarkerTweakConfigPropEnum::ItemList,
+                marker_tweak_config_type: MarkerTweakConfigTypeEnum::RemoveLeft,
+            }],
+        },
+    )
+    .await
+    .expect("remove tweak")
+    .data
+    .expect("tweak ok");
+    assert_eq!(
+        link_count(db, marker_id).await.expect("count"),
+        0,
+        "RemoveLeft removes the link"
+    );
 }


### PR DESCRIPTION
## Summary

Implement the marker `ItemList` tweak branch — M2 final item (PLAN.md §4, F9).

## Motivation

`do_tweak` handled Content/Title/Position/VideoPath/RefreshTime/Extra/HiddenFlag but skipped `itemList` entirely ("逻辑复杂：此处跳过"), so batch tweaks could never touch a marker's item associations.

## Changes

- **`packages/functions/.../api/marker.rs`**:
  - New `tweak_item_list` helper: maintains the `marker_item_link` table for the tweak's `meta.item_list` entries.
  - Supported types: `Append` / `Prepend` / `InsertIfAbsent` / `InsertOrUpdate` / `Merge` / `Update` (upsert; `InsertIfAbsent` skips existing), `Replace` (soft-delete all links then insert the new list), `RemoveLeft` / `RemoveRight` (soft-delete the listed links). Other types (Trim*/ReplaceRegex) are ignored — they have no list semantics.
  - `parse_item_entries`: accepts bare numeric ids or `{"id": n, "count": c}` objects.
  - Soft-delete is used for removals (consistent with `impl_safe_operation`, which rejects hard deletes).
- **`tests/rust/tests/api_db_test.rs`**: seeds a marker and asserts the full tweak cycle against live Postgres — Append (2 links), InsertIfAbsent (no duplicate), Replace (1 link), RemoveLeft (0 links).
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the new assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — the tweak endpoint now performs the previously-skipped operation.
