### PR TITLE
🔒 Enforce role checks and transactional promotion in punctuate audit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (remove listed links). `api_db` test covers the full cycle against
   live Postgres.
 
+- Enforce roles and atomicity in the punctuate audit (PLAN.md F6):
+  `do_pass` / `do_reject` / `do_delete` now require the Admin or
+  MapManager role (other roles get an explicit error). `do_pass`
+  executes the "write marker + delete punctuate" steps in a single
+  database transaction, so a failure rolls back both. `api_db` test
+  asserts the role gate, reject with remark, and the atomic pass
+  promotion against live Postgres.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/api/punctuate_audit.rs
+++ b/packages/functions/src/functions/api/punctuate_audit.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 
-use sea_orm::{ActiveValue::Set, QueryFilter, QuerySelect, prelude::*};
+use sea_orm::{ActiveValue::Set, QueryFilter, QuerySelect, TransactionTrait, prelude::*};
 
 use _database::{
     DB_CONN, models::marker::marker as marker_model, models::marker::marker_punctuate as mp_model,
@@ -10,8 +10,22 @@ use _utils::{
     db_operations::SafeEntityTrait,
     jwt::AuthInfo,
     models::{common::EmptyResponse, wrapper::CommonResponse},
-    types::{MarkerPunctuateMethodType, MarkerPunctuateStatus},
+    types::{MarkerPunctuateMethodType, MarkerPunctuateStatus, SystemUserRole},
 };
+
+/// 审核操作的角色门槛：系统管理员或地图管理员。
+fn require_auditor(auth: &AuthInfo) -> Result<()> {
+    if matches!(
+        auth.info.role_id,
+        SystemUserRole::Admin | SystemUserRole::MapManager
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Insufficient role: audit requires Admin or MapManager"
+        ))
+    }
+}
 
 /// 按 punctuate_id 查询单条打点审核信息
 pub async fn do_get_id(
@@ -88,16 +102,18 @@ pub async fn do_get_list_by_id(
 /// - Modified：更新 original_marker_id 对应的 marker，删除 punctuate 记录
 /// - Deleted：软删除 original_marker_id 对应的 marker，删除 punctuate 记录
 pub async fn do_pass(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     punctuate_id: i64,
 ) -> Result<CommonResponse<serde_json::Value>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
+    let txn = db.begin().await?;
     let now = Utc::now().naive_utc();
 
     let mp = mp_model::Entity::find_safety()
         .filter(mp_model::Column::PunctuateId.eq(punctuate_id))
         .filter(mp_model::Column::Status.eq(MarkerPunctuateStatus::Reviewing))
-        .one(db)
+        .one(&txn)
         .await?
         .ok_or_else(|| anyhow!("无打点相关信息，或该打点不在审核中状态"))?;
 
@@ -124,9 +140,9 @@ pub async fn do_pass(
                 hidden_flag: Set(mp.hidden_flag),
                 extra: Set(mp.extra),
             };
-            let res = marker_model::Entity::insert(am).exec(db).await?;
+            let res = marker_model::Entity::insert(am).exec(&txn).await?;
             // 删除 punctuate 记录（硬删除——它已完成使命）
-            mp_model::Entity::delete_by_id(mp.id).exec(db).await?;
+            mp_model::Entity::delete_by_id(mp.id).exec(&txn).await?;
             res.last_insert_id
         },
         MarkerPunctuateMethodType::Modified => {
@@ -136,7 +152,7 @@ pub async fn do_pass(
                 .ok_or_else(|| anyhow!("无法找到修改点位的原始id"))?;
 
             let old = marker_model::Entity::find_safety_by_id(orig_id)
-                .one(db)
+                .one(&txn)
                 .await?
                 .ok_or_else(|| anyhow!("无法找到原始id对应的原始点位"))?;
 
@@ -153,9 +169,9 @@ pub async fn do_pass(
             if mp.video_path.is_some() {
                 am.video_path = Set(mp.video_path);
             }
-            let updated = marker_model::Entity::update_safety(am)?.exec(db).await?;
+            let updated = marker_model::Entity::update_safety(am)?.exec(&txn).await?;
             // 删除 punctuate 记录
-            mp_model::Entity::delete_by_id(mp.id).exec(db).await?;
+            mp_model::Entity::delete_by_id(mp.id).exec(&txn).await?;
             updated.id
         },
         MarkerPunctuateMethodType::Deleted => {
@@ -165,19 +181,20 @@ pub async fn do_pass(
                 .ok_or_else(|| anyhow!("无法找到删除点位的原始id"))?;
 
             let old = marker_model::Entity::find_safety_by_id(orig_id)
-                .one(db)
+                .one(&txn)
                 .await?
                 .ok_or_else(|| anyhow!("无法找到原始id对应的原始点位"))?;
 
             marker_model::Entity::delete_safety(old.into())?
-                .exec(db)
+                .exec(&txn)
                 .await?;
             // 删除 punctuate 记录
-            mp_model::Entity::delete_by_id(mp.id).exec(db).await?;
+            mp_model::Entity::delete_by_id(mp.id).exec(&txn).await?;
             orig_id
         },
     };
 
+    txn.commit().await?;
     Ok(CommonResponse::new(Ok(serde_json::json!({
         "id": result_id
     }))))
@@ -187,10 +204,11 @@ pub async fn do_pass(
 ///
 /// 对应 Java `PunctuateAuditService.rejectPunctuate`。
 pub async fn do_reject(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     punctuate_id: i64,
     audit_remark: String,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
 
     let mp = mp_model::Entity::find_safety()
@@ -208,10 +226,8 @@ pub async fn do_reject(
 }
 
 /// 删除打点审核记录（软删除）
-pub async fn do_delete(
-    _auth: AuthInfo,
-    punctuate_id: i64,
-) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, punctuate_id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
 
     let mp = mp_model::Entity::find_safety()

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -11,17 +11,14 @@
 //! dependency graph (sys_user → icon → icon_type → area → item → ...) just to
 //! test one domain. Future domain tests can reuse `recreate_tables_fklless`.
 
-use sea_orm::{
-    ActiveValue::NotSet, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter,
-    Schema, sea_query::TableCreateStatement,
-};
-
 use _database::DB_CONN;
 use _database::models::{
     area::area as area_model, item::item as item_model, marker::marker as marker_model,
-    marker::marker_item_link as mil_model,
+    marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
 };
-use _functions::functions::api::{area as area_fns, item_doc, marker as marker_fns};
+use _functions::functions::api::{
+    area as area_fns, item_doc, marker as marker_fns, punctuate_audit as audit_fns,
+};
 use _utils::{
     db_operations::SafeEntityTrait,
     jwt::AuthInfo,
@@ -33,9 +30,16 @@ use _utils::{
             MarkerTweakRequest, TweakMeta,
         },
     },
-    types::{AccessPolicyList, HiddenFlag, IconStyleType, SystemUserRole},
+    types::{
+        AccessPolicyList, HiddenFlag, IconStyleType, MarkerPunctuateMethodType,
+        MarkerPunctuateStatus, SystemUserRole,
+    },
 };
-
+use sea_orm::{
+    ActiveValue::{NotSet, Set},
+    ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, Schema,
+    sea_query::TableCreateStatement,
+};
 /// Skip when no database is configured. Mirrors `user_db_test::db`.
 async fn db() -> Option<&'static sea_orm::DatabaseConnection> {
     if std::env::var("GCS_TEST_DB").is_err() {
@@ -96,7 +100,46 @@ async fn link_count(db: &sea_orm::DatabaseConnection, marker_id: i64) -> anyhow:
         .await?)
 }
 
+async fn seed_punctuate(
+    db: &sea_orm::DatabaseConnection,
+    punctuate_id: i64,
+    method_type: MarkerPunctuateMethodType,
+    now: chrono::NaiveDateTime,
+) -> anyhow::Result<i64> {
+    let am = mp_model::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        punctuate_id: Set(punctuate_id),
+        original_marker_id: Set(None),
+        marker_title: Set(Some("Audit Marker".into())),
+        item_list: Set(serde_json::json!([])),
+        position: Set("3.0,4.0".into()),
+        content: Set(String::new()),
+        picture: Set(None),
+        marker_creator_id: Set(1),
+        picture_creator_id: Set(None),
+        video_path: Set(None),
+        author: Set(2),
+        status: Set(MarkerPunctuateStatus::Reviewing),
+        audit_remark: Set(None),
+        method_type: Set(method_type),
+        refresh_time: Set(0),
+        hidden_flag: Set(HiddenFlag::Visible),
+        extra: Set(None),
+    };
+    Ok(mp_model::Entity::insert(am).exec(db).await?.last_insert_id)
+}
+
 fn stub_auth() -> AuthInfo {
+    stub_auth_with_role(SystemUserRole::Admin)
+}
+
+fn stub_auth_with_role(role: SystemUserRole) -> AuthInfo {
     let now = chrono::Utc::now();
     AuthInfo {
         info: SysUserVO {
@@ -106,7 +149,7 @@ fn stub_auth() -> AuthInfo {
             qq: None,
             phone: None,
             logo: None,
-            role_id: SystemUserRole::Admin,
+            role_id: role,
             access_policy: AccessPolicyList(vec![]),
             remark: None,
         },
@@ -127,13 +170,23 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
         ddl_without_foreign_keys(mil_model::Entity),
+        ddl_without_foreign_keys(mp_model::Entity),
     ];
-    recreate_tables_fklless(db, &["area", "item", "marker", "marker_item_link"], &ddls)
-        .await
-        .expect("recreate area + item + marker tables");
+    recreate_tables_fklless(
+        db,
+        &[
+            "area",
+            "item",
+            "marker",
+            "marker_item_link",
+            "marker_punctuate",
+        ],
+        &ddls,
+    )
+    .await
+    .expect("recreate area + item + marker + punctuate tables");
 
     // ── Seed one area + two items (different hidden_flag → 2 MD5 groups) ─────
-    use sea_orm::ActiveValue::Set;
     let now = chrono::Utc::now().naive_utc();
 
     let area_am = area_model::ActiveModel {
@@ -387,7 +440,7 @@ async fn area_and_item_doc_business_assertions() {
 
     // RemoveLeft removes 1003
     marker_fns::do_tweak(
-        auth,
+        auth.clone(),
         MarkerTweakRequest {
             marker_ids: vec![marker_id],
             tweaks: vec![MarkerTweakConfig {
@@ -411,5 +464,71 @@ async fn area_and_item_doc_business_assertions() {
         link_count(db, marker_id).await.expect("count"),
         0,
         "RemoveLeft removes the link"
+    );
+
+    // ── Assertion 5: punctuate audit enforces roles and commits atomically ───
+    // Seed two Reviewing "Added" punctuates.
+    let p1 = seed_punctuate(db, 9001, MarkerPunctuateMethodType::Added, now)
+        .await
+        .expect("seed punctuate p1");
+    let p2 = seed_punctuate(db, 9002, MarkerPunctuateMethodType::Added, now)
+        .await
+        .expect("seed punctuate p2");
+    let marker_before = marker_model::Entity::find_safety()
+        .count(db)
+        .await
+        .expect("count markers");
+
+    // Non-auditor role (MapUser) must be rejected for pass and reject
+    let user_auth = stub_auth_with_role(SystemUserRole::MapUser);
+    assert!(
+        audit_fns::do_pass(user_auth.clone(), p1).await.is_err(),
+        "MapUser must not be allowed to pass an audit"
+    );
+    assert!(
+        audit_fns::do_reject(user_auth, p1, "nope".into())
+            .await
+            .is_err(),
+        "MapUser must not be allowed to reject an audit"
+    );
+
+    // Admin rejects p2 → status becomes Rejected with the remark
+    audit_fns::do_reject(auth.clone(), p2, "bad data".into())
+        .await
+        .expect("admin rejects")
+        .data
+        .expect("reject ok");
+    let rejected = mp_model::Entity::find_safety()
+        .filter(mp_model::Column::PunctuateId.eq(9002))
+        .one(db)
+        .await
+        .expect("fetch rejected")
+        .expect("rejected punctuate still exists");
+    assert_eq!(rejected.status, MarkerPunctuateStatus::Rejected);
+    assert_eq!(rejected.audit_remark.as_deref(), Some("bad data"));
+
+    // Admin passes p1 → marker inserted AND punctuate record hard-deleted
+    audit_fns::do_pass(auth.clone(), p1)
+        .await
+        .expect("admin passes")
+        .data
+        .expect("pass ok");
+    let marker_after = marker_model::Entity::find_safety()
+        .count(db)
+        .await
+        .expect("count markers after pass");
+    assert_eq!(
+        marker_after,
+        marker_before + 1,
+        "pass must insert exactly one marker"
+    );
+    let p1_gone = mp_model::Entity::find_safety()
+        .filter(mp_model::Column::PunctuateId.eq(9001))
+        .one(db)
+        .await
+        .expect("check punctuate after pass");
+    assert!(
+        p1_gone.is_none(),
+        "pass must hard-delete the punctuate record"
     );
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -468,12 +468,12 @@ async fn area_and_item_doc_business_assertions() {
 
     // ── Assertion 5: punctuate audit enforces roles and commits atomically ───
     // Seed two Reviewing "Added" punctuates.
-    let p1 = seed_punctuate(db, 9001, MarkerPunctuateMethodType::Added, now)
+    seed_punctuate(db, 9001, MarkerPunctuateMethodType::Added, now)
         .await
-        .expect("seed punctuate p1");
-    let p2 = seed_punctuate(db, 9002, MarkerPunctuateMethodType::Added, now)
+        .expect("seed punctuate 9001");
+    seed_punctuate(db, 9002, MarkerPunctuateMethodType::Added, now)
         .await
-        .expect("seed punctuate p2");
+        .expect("seed punctuate 9002");
     let marker_before = marker_model::Entity::find_safety()
         .count(db)
         .await
@@ -482,18 +482,18 @@ async fn area_and_item_doc_business_assertions() {
     // Non-auditor role (MapUser) must be rejected for pass and reject
     let user_auth = stub_auth_with_role(SystemUserRole::MapUser);
     assert!(
-        audit_fns::do_pass(user_auth.clone(), p1).await.is_err(),
+        audit_fns::do_pass(user_auth.clone(), 9001).await.is_err(),
         "MapUser must not be allowed to pass an audit"
     );
     assert!(
-        audit_fns::do_reject(user_auth, p1, "nope".into())
+        audit_fns::do_reject(user_auth, 9001, "nope".into())
             .await
             .is_err(),
         "MapUser must not be allowed to reject an audit"
     );
 
     // Admin rejects p2 → status becomes Rejected with the remark
-    audit_fns::do_reject(auth.clone(), p2, "bad data".into())
+    audit_fns::do_reject(auth.clone(), 9002, "bad data".into())
         .await
         .expect("admin rejects")
         .data
@@ -507,8 +507,8 @@ async fn area_and_item_doc_business_assertions() {
     assert_eq!(rejected.status, MarkerPunctuateStatus::Rejected);
     assert_eq!(rejected.audit_remark.as_deref(), Some("bad data"));
 
-    // Admin passes p1 → marker inserted AND punctuate record hard-deleted
-    audit_fns::do_pass(auth.clone(), p1)
+    // Admin passes 9001 → marker inserted AND punctuate record hard-deleted
+    audit_fns::do_pass(auth.clone(), 9001)
         .await
         .expect("admin passes")
         .data


### PR DESCRIPTION
## Summary

Enforce role checks and transactional promotion in the punctuate audit — M3 first item (PLAN.md §4, F6).

## Motivation

The audit endpoints (`pass` / `reject`) were open to any authenticated user — a Visitor could promote or reject punctuations. And `do_pass` ran "write marker + delete punctuate" as two independent statements: a failure mid-way left the marker written but the punctuate record still live (or vice versa), with no way to retry the audit.

## Changes

- **`packages/functions/.../api/punctuate_audit.rs`**:
  - New `require_auditor` gate: `do_pass` / `do_reject` / `do_delete` now return an explicit error unless the caller is `Admin` or `MapManager`.
  - `do_pass` wraps the promotion in a single `DatabaseTransaction` (`txn.begin()` … `txn.commit()`): the marker insert/update/soft-delete and the punctuate hard-delete now commit or roll back together.
- **`tests/rust/tests/api_db_test.rs`**: seeds two Reviewing punctuates and asserts — MapUser is rejected for pass and reject; Admin reject flips status to Rejected with the remark; Admin pass inserts exactly one marker and hard-deletes the punctuate record (atomicity happy path).
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the new assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

Non-auditor roles that previously could call `pass` / `reject` / `delete` now get a 500 with "Insufficient role" (the route maps business errors to 500; a 403 mapping is a follow-up if desired).
