### PR TITLE
🔒 Enforce oauth access policies and scope mapping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   asserts the role gate, reject with remark, and the atomic pass
   promotion against live Postgres.
 
+- Enforce OAuth access policies and scope mapping (PLAN.md F7):
+  password login now checks the user's `access_policy` against
+  `sys_user_device` history — `ip:same_last_ip` / `dev:same_last_device`
+  reject mismatched environments, `ip:block_disallow_ip` /
+  `dev:block_disallow_device` reject entries marked disabled
+  (`status != 0`); successful logins register/refresh the device row.
+  `oauth_client_credentials` now validates the scope string (`all` /
+  empty → `All`, anything else rejected) instead of silently returning
+  `All`. `api_db` test covers the policy gates, device registration,
+  and scope mapping against live Postgres.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -64,7 +64,9 @@ async fn check_access_policy(
                 let blocked = models::system::sys_user_device::Entity::find_safety()
                     .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
                     .filter(models::system::sys_user_device::Column::Status.ne(0))
-                    .filter(models::system::sys_user_device::Column::Ipv4.eq(Some(ip.ip().to_string())))
+                    .filter(
+                        models::system::sys_user_device::Column::Ipv4.eq(Some(ip.ip().to_string())),
+                    )
                     .one(db)
                     .await?;
                 if blocked.is_some() {

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -43,7 +43,7 @@ async fn check_access_policy(
             AccessPolicyItemEnum::IpSameLastIp => {
                 if let Some(dev) = &last
                     && let Some(last_ip) = &dev.ipv4
-                    && ip.to_string() != *last_ip
+                    && ip.ip().to_string() != *last_ip
                 {
                     return Err(anyhow!(
                         "Access denied: IP {} does not match the last login IP {last_ip}",
@@ -64,7 +64,7 @@ async fn check_access_policy(
                 let blocked = models::system::sys_user_device::Entity::find_safety()
                     .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
                     .filter(models::system::sys_user_device::Column::Status.ne(0))
-                    .filter(models::system::sys_user_device::Column::Ipv4.eq(Some(ip.to_string())))
+                    .filter(models::system::sys_user_device::Column::Ipv4.eq(Some(ip.ip().to_string())))
                     .one(db)
                     .await?;
                 if blocked.is_some() {
@@ -101,7 +101,7 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
     let now = chrono::Utc::now().naive_utc();
     if let Some(dev) = existing {
         let mut am: models::system::sys_user_device::ActiveModel = dev.into();
-        am.ipv4 = Set(Some(ip.to_string()));
+        am.ipv4 = Set(Some(ip.ip().to_string()));
         am.last_login_time = Set(Some(now));
         models::system::sys_user_device::Entity::update_safety(am)?
             .exec(db)
@@ -117,7 +117,7 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
             del_flag: Set(false),
             user_id: Set(Some(user_id)),
             device_id: Set(user_agent.to_string()),
-            ipv4: Set(Some(ip.to_string())),
+            ipv4: Set(Some(ip.ip().to_string())),
             status: Set(0),
             last_login_time: Set(Some(now)),
         };
@@ -243,7 +243,7 @@ pub async fn oauth_password_login(
         updater_id: Set(None),
         del_flag: Set(false),
         user_id: Set(Some(user_id)),
-        ipv4: Set(Some(ip.to_string())),
+        ipv4: Set(Some(ip.ip().to_string())),
         device_id: Set(user_agent),
         action: Set(SystemActionLogAction::Login),
         is_error: Set(ret.is_err()),

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -235,13 +235,19 @@ pub async fn oauth_password_login(
     }
 
     models::system::sys_action_log::ActiveModel {
+        version: Set(0),
+        id: Set(0),
+        create_time: Set(chrono::Utc::now().naive_utc()),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
         user_id: Set(Some(user_id)),
         ipv4: Set(Some(ip.to_string())),
         device_id: Set(user_agent),
         action: Set(SystemActionLogAction::Login),
         is_error: Set(ret.is_err()),
         extra_data: Set(Default::default()),
-        ..Default::default()
     }
     .insert(&DB_CONN.wait().pg_conn)
     .await?;

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -2,26 +2,144 @@ use anyhow::{Result, anyhow};
 use std::net::SocketAddr;
 
 use redis::{AsyncTypedCommands, SetOptions};
-use sea_orm::{ActiveValue::Set, prelude::*};
+use sea_orm::{ActiveValue::Set, QueryOrder, prelude::*};
 
 use _database::{DB_CONN, models};
 use _utils::{
     bcrypt::verify_password,
+    db_operations::SafeEntityTrait,
     jwt::{Claims, EXPIRED_APPEND_DURATION, generate_token, verify_token},
     models::SysUserVO,
     types::{
-        SystemActionLogAction,
+        AccessPolicyItemEnum, SystemActionLogAction,
         auth::{OauthAnonymousResponse, OauthLoginResponse, OauthScopeType, OauthTokenType},
     },
 };
 
+/// 按用户的 access_policy 校验登录环境（IP / 设备）。
+///
+/// 数据源为 `sys_user_device` 表：
+/// - `ip:same_last_ip`：请求 IP 必须等于该用户最近一次登录的 IP
+/// - `dev:same_last_device`：请求 User-Agent 必须等于最近一次登录的设备
+/// - `ip:block_disallow_ip` / `dev:block_disallow_device`：命中 `status != 0`
+///   （禁用）的登记条目时拒绝
+/// - 其余策略（允许列表、地区等）在当前数据模型下无对应存储，放行
+/// - 无任何历史记录（首次登录）时，same_* 类策略放行
+async fn check_access_policy(
+    user_id: i64,
+    access_policy: &[AccessPolicyItemEnum],
+    ip: SocketAddr,
+    user_agent: &str,
+) -> Result<()> {
+    let db = &DB_CONN.wait().pg_conn;
+    let last = models::system::sys_user_device::Entity::find_safety()
+        .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
+        .order_by_desc(models::system::sys_user_device::Column::LastLoginTime)
+        .one(db)
+        .await?;
+
+    for policy in access_policy {
+        match policy {
+            AccessPolicyItemEnum::IpSameLastIp => {
+                if let Some(dev) = &last
+                    && let Some(last_ip) = &dev.ipv4
+                    && ip.to_string() != *last_ip
+                {
+                    return Err(anyhow!(
+                        "Access denied: IP {} does not match the last login IP {last_ip}",
+                        ip
+                    ));
+                }
+            },
+            AccessPolicyItemEnum::DevSameLastDevice => {
+                if let Some(dev) = &last
+                    && dev.device_id != *user_agent
+                {
+                    return Err(anyhow!(
+                        "Access denied: device does not match the last login device"
+                    ));
+                }
+            },
+            AccessPolicyItemEnum::IpBlockDisallowIp => {
+                let blocked = models::system::sys_user_device::Entity::find_safety()
+                    .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
+                    .filter(models::system::sys_user_device::Column::Status.ne(0))
+                    .filter(models::system::sys_user_device::Column::Ipv4.eq(Some(ip.to_string())))
+                    .one(db)
+                    .await?;
+                if blocked.is_some() {
+                    return Err(anyhow!("Access denied: IP {} is blocked", ip));
+                }
+            },
+            AccessPolicyItemEnum::DevBlockDisallowDevice => {
+                let blocked = models::system::sys_user_device::Entity::find_safety()
+                    .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
+                    .filter(models::system::sys_user_device::Column::Status.ne(0))
+                    .filter(models::system::sys_user_device::Column::DeviceId.eq(user_agent))
+                    .one(db)
+                    .await?;
+                if blocked.is_some() {
+                    return Err(anyhow!("Access denied: device is blocked"));
+                }
+            },
+            // 允许列表 / 地区类策略：当前数据模型无对应存储，放行
+            _ => {},
+        }
+    }
+    Ok(())
+}
+
+/// 登录成功后登记设备（upsert `sys_user_device`：user_id + device_id 唯一）。
+async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result<()> {
+    let db = &DB_CONN.wait().pg_conn;
+    let existing = models::system::sys_user_device::Entity::find_safety()
+        .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
+        .filter(models::system::sys_user_device::Column::DeviceId.eq(user_agent))
+        .one(db)
+        .await?;
+
+    let now = chrono::Utc::now().naive_utc();
+    if let Some(dev) = existing {
+        let mut am: models::system::sys_user_device::ActiveModel = dev.into();
+        am.ipv4 = Set(Some(ip.to_string()));
+        am.last_login_time = Set(Some(now));
+        models::system::sys_user_device::Entity::update_safety(am)?
+            .exec(db)
+            .await?;
+    } else {
+        let am = models::system::sys_user_device::ActiveModel {
+            version: Set(0),
+            id: Set(0),
+            create_time: Set(now),
+            update_time: Set(None),
+            creator_id: Set(None),
+            updater_id: Set(None),
+            del_flag: Set(false),
+            user_id: Set(Some(user_id)),
+            device_id: Set(user_agent.to_string()),
+            ipv4: Set(Some(ip.to_string())),
+            status: Set(0),
+            last_login_time: Set(Some(now)),
+        };
+        models::system::sys_user_device::Entity::insert(am)
+            .exec(db)
+            .await?;
+    }
+    Ok(())
+}
+
 async fn oauth_password_login_inner(
     item: models::system::sys_user::Model,
     password_raw: String,
+    ip: SocketAddr,
+    user_agent: &str,
 ) -> Result<OauthLoginResponse> {
     if !verify_password(password_raw, item.password.clone())? {
         return Err(anyhow!("Invalid password"));
     }
+
+    // 身份验证通过后，按用户的 access_policy 校验登录环境
+    check_access_policy(item.id, &item.access_policy.0, ip, user_agent).await?;
 
     let jti = Uuid::now_v7();
     let now = chrono::Utc::now();
@@ -109,8 +227,12 @@ pub async fn oauth_password_login(
         .ok_or(anyhow!("User not found"))?;
     let user_id = item.id;
 
-    // TODO: 根据 access_policy 指定的模式，对请求做各种检查
-    let ret = oauth_password_login_inner(item, password_raw).await;
+    let ret = oauth_password_login_inner(item, password_raw, ip, &user_agent).await;
+
+    if ret.is_ok() {
+        // 登录成功：登记设备（幂等 upsert）
+        let _ = record_device(user_id, ip, &user_agent).await;
+    }
 
     models::system::sys_action_log::ActiveModel {
         user_id: Set(Some(user_id)),
@@ -127,9 +249,22 @@ pub async fn oauth_password_login(
     ret
 }
 
-pub async fn oauth_client_credentials(_scope: String) -> Result<OauthAnonymousResponse> {
+/// 把请求中的 scope 字符串映射为 `OauthScopeType`。
+/// 当前仅支持 `all`（默认，大小写不敏感）；未知 scope 直接拒绝，避免
+/// 静默降级为全局权限。
+pub fn map_scope(scope: &str) -> Result<OauthScopeType> {
+    let normalized = scope.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" | "all" => Ok(OauthScopeType::All),
+        other => Err(anyhow!("Unsupported scope: {other}")),
+    }
+}
+
+pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousResponse> {
     // 使用系统匿名用户 id = 0 表示客户端凭据/匿名访问
     let id: i64 = 0;
+
+    let scope_enum = map_scope(&scope)?;
 
     let jti = Uuid::now_v7();
     let now = chrono::Utc::now();
@@ -174,7 +309,7 @@ pub async fn oauth_client_credentials(_scope: String) -> Result<OauthAnonymousRe
         access_token,
         token_type: OauthTokenType::Bearer,
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
-        scope: OauthScopeType::All, // TODO: map scope string to enum if needed
+        scope: scope_enum,
         jti,
     })
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -15,10 +15,12 @@ use _database::DB_CONN;
 use _database::models::{
     area::area as area_model, item::item as item_model, marker::marker as marker_model,
     marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
+    system::sys_user as sys_user_model, system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
     area as area_fns, item_doc, marker as marker_fns, punctuate_audit as audit_fns,
 };
+use _functions::functions::system::oauth as oauth_fns;
 use _utils::{
     db_operations::SafeEntityTrait,
     jwt::AuthInfo,
@@ -31,8 +33,8 @@ use _utils::{
         },
     },
     types::{
-        AccessPolicyList, HiddenFlag, IconStyleType, MarkerPunctuateMethodType,
-        MarkerPunctuateStatus, SystemUserRole,
+        AccessPolicyItemEnum, AccessPolicyList, HiddenFlag, IconStyleType,
+        MarkerPunctuateMethodType, MarkerPunctuateStatus, SystemUserRole,
     },
 };
 use sea_orm::{
@@ -135,6 +137,36 @@ async fn seed_punctuate(
     Ok(mp_model::Entity::insert(am).exec(db).await?.last_insert_id)
 }
 
+async fn seed_user(
+    db: &sea_orm::DatabaseConnection,
+    username: &str,
+    policy: Vec<AccessPolicyItemEnum>,
+    now: chrono::NaiveDateTime,
+) -> anyhow::Result<i64> {
+    let am = sys_user_model::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        username: Set(username.to_string()),
+        password: Set(_utils::bcrypt::generate_storage_password("pw123").unwrap()),
+        nickname: Set(None),
+        qq: Set(None),
+        phone: Set(None),
+        logo: Set(None),
+        role_id: Set(SystemUserRole::MapUser),
+        access_policy: Set(AccessPolicyList(policy)),
+        remark: Set(None),
+    };
+    Ok(sys_user_model::Entity::insert(am)
+        .exec(db)
+        .await?
+        .last_insert_id)
+}
+
 fn stub_auth() -> AuthInfo {
     stub_auth_with_role(SystemUserRole::Admin)
 }
@@ -166,6 +198,8 @@ async fn area_and_item_doc_business_assertions() {
 
     // ── Setup: FK-free tables for area + item ────────────────────────────────
     let ddls = [
+        ddl_without_foreign_keys(sys_user_model::Entity),
+        ddl_without_foreign_keys(device_model::Entity),
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
@@ -175,6 +209,8 @@ async fn area_and_item_doc_business_assertions() {
     recreate_tables_fklless(
         db,
         &[
+            "sys_user",
+            "sys_user_device",
             "area",
             "item",
             "marker",
@@ -530,5 +566,90 @@ async fn area_and_item_doc_business_assertions() {
     assert!(
         p1_gone.is_none(),
         "pass must hard-delete the punctuate record"
+    );
+
+    // ── Assertion 6: oauth access_policy checks + device registration ────────
+    let ip_a = "1.2.3.4:5678".parse::<std::net::SocketAddr>().unwrap();
+    let ip_b = "9.9.9.9:5678".parse::<std::net::SocketAddr>().unwrap();
+    let ua = "test-agent/1.0";
+
+    // 1) same_last_ip: first login from ip_a succeeds and registers the device;
+    //    a second login from ip_b is rejected.
+    seed_user(
+        db,
+        "policy_same_ip",
+        vec![AccessPolicyItemEnum::IpSameLastIp],
+        now,
+    )
+    .await
+    .expect("seed policy user");
+    oauth_fns::oauth_password_login("policy_same_ip".into(), "pw123".into(), ip_a, ua.into())
+        .await
+        .expect("first login from ip_a succeeds");
+    let device = device_model::Entity::find_safety()
+        .filter(device_model::Column::DeviceId.eq(ua))
+        .one(db)
+        .await
+        .expect("fetch registered device")
+        .expect("device registered after login");
+    assert_eq!(device.ipv4.as_deref(), Some("1.2.3.4"));
+    assert!(
+        oauth_fns::oauth_password_login("policy_same_ip".into(), "pw123".into(), ip_b, ua.into())
+            .await
+            .is_err(),
+        "same_last_ip policy must reject a different IP"
+    );
+
+    // 2) dev:block_disallow_device: a disabled device entry blocks login.
+    let seed_user2 = seed_user(
+        db,
+        "policy_block_dev",
+        vec![AccessPolicyItemEnum::DevBlockDisallowDevice],
+        now,
+    )
+    .await
+    .expect("seed blocked-device user");
+    let blocked_am = device_model::ActiveModel {
+        id: NotSet,
+        version: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        user_id: Set(Some(seed_user2)),
+        device_id: Set("evil-agent".into()),
+        ipv4: Set(None),
+        status: Set(1),
+        last_login_time: Set(None),
+    };
+    device_model::Entity::insert(blocked_am)
+        .exec(db)
+        .await
+        .expect("seed disabled device");
+    assert!(
+        oauth_fns::oauth_password_login(
+            "policy_block_dev".into(),
+            "pw123".into(),
+            ip_a,
+            "evil-agent".into(),
+        )
+        .await
+        .is_err(),
+        "dev:block_disallow_device must reject a blocked device"
+    );
+
+    // 3) scope mapping: "all"/"" → All, unknown → error.
+    assert!(matches!(
+        oauth_fns::map_scope("all").expect("all"),
+        _utils::types::auth::OauthScopeType::All
+    ));
+    assert!(matches!(
+        oauth_fns::map_scope("").expect("empty"),
+        _utils::types::auth::OauthScopeType::All
+    ));
+    assert!(
+        oauth_fns::map_scope("write").is_err(),
+        "unknown scope must be rejected"
     );
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -15,7 +15,8 @@ use _database::DB_CONN;
 use _database::models::{
     area::area as area_model, item::item as item_model, marker::marker as marker_model,
     marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
-    system::sys_user as sys_user_model, system::sys_user_device as device_model,
+    system::sys_action_log as action_log_model, system::sys_user as sys_user_model,
+    system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
     area as area_fns, item_doc, marker as marker_fns, punctuate_audit as audit_fns,
@@ -200,6 +201,7 @@ async fn area_and_item_doc_business_assertions() {
     let ddls = [
         ddl_without_foreign_keys(sys_user_model::Entity),
         ddl_without_foreign_keys(device_model::Entity),
+        ddl_without_foreign_keys(action_log_model::Entity),
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
@@ -211,6 +213,7 @@ async fn area_and_item_doc_business_assertions() {
         &[
             "sys_user",
             "sys_user_device",
+            "sys_action_log",
             "area",
             "item",
             "marker",


### PR DESCRIPTION
## Summary

Enforce OAuth access policies and scope mapping — M3 second item (PLAN.md §4, F7).

## Motivation

Two placeholder behaviors in the OAuth flow:
- `oauth_password_login` ignored the user's `access_policy` entirely ("TODO: 根据 access_policy 指定的模式，对请求做各种检查") — a policy like `ip:same_last_ip` had no effect.
- `oauth_client_credentials` always returned `OauthScopeType::All`, silently ignoring the `scope` parameter.

## Changes

- **`packages/functions/.../system/oauth.rs`**:
  - New `check_access_policy` runs after password verification, using `sys_user_device` as the data source:
    - `ip:same_last_ip` — request IP must equal the user's last registered IP.
    - `dev:same_last_device` — request User-Agent must equal the last registered device.
    - `ip:block_disallow_ip` / `dev:block_disallow_device` — reject when a matching entry has `status != 0` (disabled).
    - Other policies (allow-list/region) have no storage in the current model — pass through. First login (no history) passes the `same_*` checks.
  - New `record_device`: on successful login, upserts the `sys_user_device` row (user_id + device_id), refreshing ipv4 / last_login_time.
  - New `pub fn map_scope`: `"all"` / empty → `All`; anything else → explicit error (no silent privilege escalation). `oauth_client_credentials` now uses it.
- **`tests/rust/tests/api_db_test.rs`**: seeds users + device rows and asserts — `same_last_ip` accepts the registered IP and rejects a different one; a disabled device entry blocks `dev:block_disallow_device` login; `map_scope("all"|"")` → All and `map_scope("write")` → error.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the new assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

- Logins that violate `same_last_ip` / `same_last_device` / block policies now fail (previously they succeeded).
- `oauth_client_credentials` with a scope other than `all`/empty now errors instead of silently granting `All`.
