### PR TITLE
✨ Implement QQ third-party login.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `api_db` test verifies the key material round-trips with the JWT
   secret.
 
+- Implement QQ third-party login (PLAN.md M3): `POST /oauth/qq`
+  exchanges a QQ openid for a local token, matching `sys_user.qq`
+  (bound via `/user/register/qq`, which now stores the openid).
+  `oauth_qq_login` runs the same access-policy checks, device
+  registration, and login logging as password login; token issuance
+  was extracted into a shared `issue_token` helper. Unregistered
+  openids fail with an explicit error. `api_db` test covers both the
+  bound and unbound paths against live Postgres.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -2,7 +2,11 @@ use anyhow::{Result, anyhow};
 use std::net::SocketAddr;
 
 use redis::{AsyncTypedCommands, SetOptions};
-use sea_orm::{ActiveValue::Set, QueryOrder, prelude::*};
+use sea_orm::{
+    ActiveValue::{NotSet, Set},
+    QueryOrder,
+    prelude::*,
+};
 
 use _database::{DB_CONN, models};
 use _utils::{
@@ -111,7 +115,7 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
     } else {
         let am = models::system::sys_user_device::ActiveModel {
             version: Set(0),
-            id: Set(0),
+            id: NotSet,
             create_time: Set(now),
             update_time: Set(None),
             creator_id: Set(None),
@@ -243,7 +247,7 @@ pub async fn oauth_password_login(
 
     models::system::sys_action_log::ActiveModel {
         version: Set(0),
-        id: Set(0),
+        id: NotSet,
         create_time: Set(chrono::Utc::now().naive_utc()),
         update_time: Set(None),
         creator_id: Set(None),
@@ -301,7 +305,7 @@ pub async fn oauth_qq_login(
     }
     models::system::sys_action_log::ActiveModel {
         version: Set(0),
-        id: Set(0),
+        id: NotSet,
         create_time: Set(chrono::Utc::now().naive_utc()),
         update_time: Set(None),
         creator_id: Set(None),

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -130,26 +130,15 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
     Ok(())
 }
 
-async fn oauth_password_login_inner(
-    item: models::system::sys_user::Model,
-    password_raw: String,
-    ip: SocketAddr,
-    user_agent: &str,
-) -> Result<OauthLoginResponse> {
-    if !verify_password(password_raw, item.password.clone())? {
-        return Err(anyhow!("Invalid password"));
-    }
-
-    // 身份验证通过后，按用户的 access_policy 校验登录环境
-    check_access_policy(item.id, &item.access_policy.0, ip, user_agent).await?;
-
+/// 为用户签发 access/refresh token（含 Redis 会话存储，Redis 不可用时降级）。
+async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLoginResponse> {
     let jti = Uuid::now_v7();
     let now = chrono::Utc::now();
     let access_token = generate_token(now, item.id, jti).await?;
     let refresh_token = generate_token(now, item.id, jti).await?;
 
     let id = item.id;
-    let vo: SysUserVO = item.into();
+    let vo: SysUserVO = item.clone().into();
 
     // Store token in Redis if available (graceful degradation for e2e mode
     // where Redis is not running — token verification will fall back to
@@ -189,6 +178,22 @@ async fn oauth_password_login_inner(
         scope: OauthScopeType::All,
         jti,
     })
+}
+
+async fn oauth_password_login_inner(
+    item: models::system::sys_user::Model,
+    password_raw: String,
+    ip: SocketAddr,
+    user_agent: &str,
+) -> Result<OauthLoginResponse> {
+    if !verify_password(password_raw, item.password.clone())? {
+        return Err(anyhow!("Invalid password"));
+    }
+
+    // 身份验证通过后，按用户的 access_policy 校验登录环境
+    check_access_policy(item.id, &item.access_policy.0, ip, user_agent).await?;
+
+    issue_token(&item).await
 }
 
 pub async fn oauth_parse_token(token: String) -> Result<(SysUserVO, Claims)> {
@@ -266,6 +271,53 @@ pub fn map_scope(scope: &str) -> Result<OauthScopeType> {
         "" | "all" => Ok(OauthScopeType::All),
         other => Err(anyhow!("Unsupported scope: {other}")),
     }
+}
+
+/// QQ 第三方登录：客户端完成 QQ 授权后，用拿到的 openid 换取本站 token。
+///
+/// 按 `sys_user.qq` 匹配用户；未注册的 openid 返回明确错误（注册走
+/// `/user/register/qq`，把 openid 写入 `qq` 字段）。与密码登录一致地执行
+/// access_policy 检查、设备登记与登录日志。
+pub async fn oauth_qq_login(
+    qq_openid: String,
+    ip: SocketAddr,
+    user_agent: String,
+) -> Result<OauthLoginResponse> {
+    let db = &DB_CONN.wait().pg_conn;
+    let item = models::system::sys_user::Entity::find()
+        .filter(models::system::sys_user::Column::DelFlag.eq(false))
+        .filter(models::system::sys_user::Column::Qq.eq(Some(qq_openid)))
+        .one(db)
+        .await?
+        .ok_or(anyhow!("QQ account not registered"))?;
+    let user_id = item.id;
+
+    // 身份由 openid 提供；同样校验登录环境
+    check_access_policy(item.id, &item.access_policy.0, ip, &user_agent).await?;
+    let ret = issue_token(&item).await;
+
+    if ret.is_ok() {
+        let _ = record_device(user_id, ip, &user_agent).await;
+    }
+    models::system::sys_action_log::ActiveModel {
+        version: Set(0),
+        id: Set(0),
+        create_time: Set(chrono::Utc::now().naive_utc()),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        user_id: Set(Some(user_id)),
+        ipv4: Set(Some(ip.ip().to_string())),
+        device_id: Set(user_agent),
+        action: Set(SystemActionLogAction::Login),
+        is_error: Set(ret.is_err()),
+        extra_data: Set(Default::default()),
+    }
+    .insert(&DB_CONN.wait().pg_conn)
+    .await?;
+
+    ret
 }
 
 pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousResponse> {

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -50,6 +50,7 @@ pub async fn do_register(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn do_register_qq(
     _auth: AuthInfo,
     access_policy: Vec<AccessPolicyItemEnum>,
@@ -58,18 +59,34 @@ pub async fn do_register_qq(
     role_id: SystemUserRole,
     username: String,
     password: String,
+    qq: String,
 ) -> Result<()> {
-    // QQ 注册与普通注册逻辑一致（占位实现）
-    do_register(
-        _auth,
-        access_policy,
-        logo,
-        remark,
-        role_id,
-        username,
-        password,
-    )
-    .await
+    let _ = (&access_policy, &logo, &remark, &role_id, &username);
+    let db = &DB_CONN.wait().pg_conn;
+
+    let now = Utc::now().naive_utc();
+    let am = sys_user_model::ActiveModel {
+        version: Set(0),
+        id: Set(0),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+
+        username: Set(username),
+        password: Set(_utils::bcrypt::generate_storage_password(&password)?),
+        nickname: Set(None),
+        qq: Set(Some(qq)),
+        phone: Set(None),
+        logo: Set(Some(logo)),
+        role_id: Set(role_id),
+        access_policy: Set(_utils::types::AccessPolicyList(access_policy)),
+        remark: Set(Some(remark)),
+    };
+
+    sys_user_model::Entity::insert(am).exec(db).await?;
+    Ok(())
 }
 
 pub async fn do_get_info(_auth: AuthInfo, user_id: i64) -> Result<SysUserVO> {

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -1,7 +1,11 @@
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 
-use sea_orm::{ActiveValue::Set, QueryFilter, QuerySelect, prelude::*};
+use sea_orm::{
+    ActiveValue::{NotSet, Set},
+    QueryFilter, QuerySelect,
+    prelude::*,
+};
 
 use _database::DB_CONN;
 use _database::models::system::sys_user as sys_user_model;
@@ -28,7 +32,7 @@ pub async fn do_register(
     let now = Utc::now().naive_utc();
     let am = sys_user_model::ActiveModel {
         version: Set(0),
-        id: Set(0),
+        id: NotSet,
         create_time: Set(now),
         update_time: Set(None),
         creator_id: Set(None),
@@ -67,7 +71,7 @@ pub async fn do_register_qq(
     let now = Utc::now().naive_utc();
     let am = sys_user_model::ActiveModel {
         version: Set(0),
-        id: Set(0),
+        id: NotSet,
         create_time: Set(now),
         update_time: Set(None),
         creator_id: Set(None),

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -15,6 +15,7 @@ use axum::{
 pub async fn router() -> Result<Router> {
     let ret = Router::new()
         .route("/oauth/token", post(system::oauth::oauth))
+        .route("/oauth/qq", post(system::oauth::qq_login))
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/system", system::router().await?)
         .merge(api::router().await?)

--- a/packages/router/src/routes/system/oauth.rs
+++ b/packages/router/src/routes/system/oauth.rs
@@ -10,8 +10,30 @@ use axum::{
 
 use crate::middlewares::{ExtractIP, ExtractUserAgent};
 use _functions::functions::system::oauth::{
-    oauth_client_credentials, oauth_password_login, oauth_refresh,
+    oauth_client_credentials, oauth_password_login, oauth_qq_login, oauth_refresh,
 };
+
+#[derive(Debug, Deserialize)]
+pub struct QqLoginParams {
+    /// QQ 授权后客户端拿到的 openid
+    pub qq_openid: String,
+}
+
+/// QQ 第三方登录
+/// POST /oauth/qq
+#[tracing::instrument(skip(params))]
+pub async fn qq_login(
+    ConnectInfo(native_ip): ConnectInfo<SocketAddr>,
+    ExtractIP(ip): ExtractIP,
+    ExtractUserAgent(user_agent): ExtractUserAgent,
+    Json(params): Json<QqLoginParams>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let ip = ip.unwrap_or(native_ip);
+    let ret = oauth_qq_login(params.qq_openid, ip, user_agent)
+        .await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+    Ok(Json(ret).into_response())
+}
 
 #[derive(Debug, Deserialize)]
 pub struct LoginQuery {

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -62,6 +62,8 @@ pub struct UserRegisterQQParams {
     pub username: String,
     /// 初始密码
     pub password: String,
+    /// QQ openid（QQ 授权后绑定）
+    pub qq: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -179,6 +181,7 @@ pub async fn register_qq(
         payload.role_id,
         payload.username,
         payload.password,
+        payload.qq,
     )
     .await
     .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -142,6 +142,7 @@ async fn seed_user(
     db: &sea_orm::DatabaseConnection,
     username: &str,
     policy: Vec<AccessPolicyItemEnum>,
+    qq: Option<String>,
     now: chrono::NaiveDateTime,
 ) -> anyhow::Result<i64> {
     let am = sys_user_model::ActiveModel {
@@ -155,7 +156,7 @@ async fn seed_user(
         username: Set(username.to_string()),
         password: Set(_utils::bcrypt::generate_storage_password("pw123").unwrap()),
         nickname: Set(None),
-        qq: Set(None),
+        qq: Set(qq),
         phone: Set(None),
         logo: Set(None),
         role_id: Set(SystemUserRole::MapUser),
@@ -582,6 +583,7 @@ async fn area_and_item_doc_business_assertions() {
         db,
         "policy_same_ip",
         vec![AccessPolicyItemEnum::IpSameLastIp],
+        None,
         now,
     )
     .await
@@ -608,6 +610,7 @@ async fn area_and_item_doc_business_assertions() {
         db,
         "policy_block_dev",
         vec![AccessPolicyItemEnum::DevBlockDisallowDevice],
+        None,
         now,
     )
     .await
@@ -671,5 +674,24 @@ async fn area_and_item_doc_business_assertions() {
         decoded,
         _utils::jwt::jwt_secret_raw().as_bytes(),
         "JWKS key material must match the JWT secret"
+    );
+
+    // ── Assertion 8: QQ login resolves the bound openid ──────────────────────
+    seed_user(db, "qq_user", vec![], Some("OPENID_123".into()), now)
+        .await
+        .expect("seed qq user");
+
+    // Registered openid → token issued
+    let resp = oauth_fns::oauth_qq_login("OPENID_123".into(), ip_a, ua.into())
+        .await
+        .expect("qq login succeeds for a bound openid");
+    assert!(!resp.access_token.is_empty());
+
+    // Unregistered openid → error
+    assert!(
+        oauth_fns::oauth_qq_login("OPENID_UNKNOWN".into(), ip_a, ua.into())
+            .await
+            .is_err(),
+        "unregistered openid must fail"
     );
 }


### PR DESCRIPTION
## Summary

Implement QQ third-party login — M3 final item (PLAN.md §4).

## Motivation

`do_register_qq` was a placeholder that delegated to normal registration and never stored the QQ openid (`sys_user.qq` stayed `None`), and there was no way for a QQ user to sign in at all.

## Changes

- **`packages/functions/.../system/oauth.rs`**:
  - Extract `issue_token(item)` from the password-login inner flow (JWT pair + Redis session storage with graceful degradation) — shared by password and QQ login.
  - New `oauth_qq_login(qq_openid, ip, user_agent)`: resolves the user by `sys_user.qq`, runs the same `check_access_policy` gate, records the device and login log, and issues tokens. Unregistered openids fail with "QQ account not registered".
- **`packages/functions/.../system/user.rs`**: `do_register_qq` now takes the openid and stores it in `sys_user.qq` (real binding instead of the placeholder delegation).
- **`packages/router/.../system/oauth.rs`** + **`routes/mod.rs`**: new `POST /oauth/qq` handler (`{"qqOpenId": "..."}`).
- **`packages/router/.../system/user.rs`**: `UserRegisterQQParams` gains `qq`; call site passes it through.
- **`tests/rust/tests/api_db_test.rs`**: seeds a bound user and asserts — a registered openid logs in and receives a non-empty token; an unknown openid errors.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Design note

The backend takes the openid directly (the client performs the QQ OAuth dance and hands over the openid). This keeps the exchange out of the server while still binding QQ identity to a local account; a full server-side QQ OAuth flow (appid/secret, state, token exchange) can be layered on later without changing the token-issuance path.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the new assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

`POST /user/register/qq` now requires a `qq` field (previously ignored); `POST /oauth/qq` is new.
