### PR TITLE
⚡ Add the in-process cache for the BinaryMD5 doc endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   assigns ids. The `api_db` test adds a repeated `area::do_add`
   regression assertion.
 
+- Add the in-process BinaryMD5 page cache (PLAN.md M4/F5): item,
+  marker, and marker-link doc endpoints now serve their GZIP pages
+  from a moka cache (Java's Caffeine equivalent, 300s TTL) instead of
+  re-serializing the whole dataset on every request. The md5-list
+  `time` field is now the page's generation timestamp (stable within
+  the cache TTL) rather than the request time, so clients no longer
+  see spurious "data changed" signals. `binary_doc` exposes
+  `get_or_compute` / `invalidate` for the future refresh wiring.
+  `api_db` test asserts the md5 + time are stable across repeated
+  calls.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "log",
  "md5",
  "minio",
+ "moka",
  "once_cell",
  "oneshot",
  "percent-encoding",
@@ -3142,6 +3143,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener 5.4.1",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5167,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ bcrypt = "^0.19"
 jsonwebtoken = { version = "^10", default-features = false, features = ["rust_crypto"] }
 
 md5 = "^0.8"
+# moka: in-process cache for the BinaryMD5 archive export (Java uses Caffeine).
+moka = { version = "^0.12", features = ["future"] }
 
 env_logger = "^0.11"
 log = "^0.4"

--- a/packages/functions/Cargo.toml
+++ b/packages/functions/Cargo.toml
@@ -36,6 +36,7 @@ sqids = { workspace = true }
 bzip2 = { workspace = true }
 flate2 = { workspace = true }
 md5 = { workspace = true }
+moka = { workspace = true }
 
 bcrypt = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -5,10 +5,15 @@
 //!
 //! The compressed bytes are served as `application/octet-stream` keyed by
 //! their MD5 hex, enabling client-side incremental sync.
+//!
+//! The generated pages are cached in-process (moka, like Java's Caffeine) so
+//! repeated `list_page_bin_md5` / `list_page_bin` requests don't re-serialize
+//! the whole dataset on every call.
 
 use flate2::{Compression, write::GzEncoder};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
+use std::{io::Write, time::Duration};
 
 /// A single MD5 entry in the `list_page_bin_md5` response.
 /// Mirrors Java `BinaryMD5Vo { md5, time }`.
@@ -37,4 +42,47 @@ pub fn serialize_compress_md5<T: Serialize>(data: &T) -> anyhow::Result<(Vec<u8>
     let md5_hex = format!("{:x}", digest);
 
     Ok((compressed, md5_hex))
+}
+
+/// A cached BinaryMD5 page: the compressed bytes plus the metadata needed by
+/// both the md5 list and the bin fetch endpoints.
+#[derive(Debug, Clone)]
+pub struct CachedPage {
+    pub md5: String,
+    /// Generation timestamp (stable while the cache entry is alive — the md5
+    /// list `time` field must not change on every request).
+    pub time: i64,
+    pub bytes: Vec<u8>,
+}
+
+/// In-process page cache. Java uses Caffeine with a similar TTL; moka is the
+/// Rust equivalent. The TTL bounds staleness until the refresh endpoints are
+/// wired to an explicit invalidation channel (PLAN.md M4 / F10).
+static BIN_CACHE: Lazy<moka::future::Cache<String, CachedPage>> = Lazy::new(|| {
+    moka::future::Cache::builder()
+        .max_capacity(10_000)
+        .time_to_live(Duration::from_secs(300))
+        .build()
+});
+
+/// Fetch a page from the cache, or compute it via `compute` and store it.
+///
+/// The cache is keyed by an explicit string (e.g. `item:0`, `marker:0:123`,
+/// `link:graph`) that encodes the domain + group/page identity, so each page
+/// is computed at most once per TTL window.
+pub async fn get_or_compute(
+    key: String,
+    compute: impl std::future::Future<Output = anyhow::Result<CachedPage>>,
+) -> anyhow::Result<CachedPage> {
+    if let Some(cached) = BIN_CACHE.get(&key).await {
+        return Ok(cached);
+    }
+    let page = compute.await?;
+    BIN_CACHE.insert(key, page.clone()).await;
+    Ok(page)
+}
+
+/// Drop a cache key (used by the cache-refresh endpoints once wired).
+pub async fn invalidate(key: &str) {
+    BIN_CACHE.invalidate(key).await;
 }

--- a/packages/functions/src/functions/api/item_doc.rs
+++ b/packages/functions/src/functions/api/item_doc.rs
@@ -11,19 +11,19 @@ use std::collections::BTreeMap;
 use _database::{DB_CONN, models::item::item as item_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, serialize_compress_md5};
+use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
 
 /// `GET /item_doc/list_page_bin_md5`
 ///
 /// Returns the MD5 list for all item pages. Each `hidden_flag` group is a
-/// single page (index 0). The `time` field is the generation timestamp shared
-/// by all entries.
+/// single page (index 0). Pages are served from the in-process cache; the
+/// `time` field is the page's generation timestamp (stable within the cache
+/// TTL), not the request time.
 pub async fn do_list_page_bin_md5(
     _auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<Vec<BinaryMd5Vo>>> {
     let db = &DB_CONN.wait().pg_conn;
-    let now = chrono::Utc::now().timestamp_millis();
 
     // Query all non-deleted items
     let items = item_model::Entity::find_safety().all(db).await?;
@@ -37,18 +37,21 @@ pub async fn do_list_page_bin_md5(
             .push(item);
     }
 
-    // Each group → one page → serialize + compress + MD5
+    // Each group → one page → cached (serialize + compress + MD5)
     let mut result = Vec::with_capacity(groups.len());
-    for group_items in groups.values() {
-        let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
-        // NOTE: compressed bytes are discarded here — in the Java impl they are
-        // cached in Caffeine keyed by md5. Without an in-process cache, the
-        // list_page_bin handler regenerates on demand. A cache layer (Redis or
-        // moka) should be added for production performance.
-        let _ = compressed;
+    for (flag, group_items) in &groups {
+        let page = get_or_compute(format!("item:{flag}"), async {
+            let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
+            Ok(CachedPage {
+                md5: md5_hex,
+                time: chrono::Utc::now().timestamp_millis(),
+                bytes: compressed,
+            })
+        })
+        .await?;
         result.push(BinaryMd5Vo {
-            md5: md5_hex,
-            time: now,
+            md5: page.md5,
+            time: page.time,
         });
     }
 
@@ -58,7 +61,8 @@ pub async fn do_list_page_bin_md5(
 /// `GET /item_doc/list_page_bin/{md5}`
 ///
 /// Returns the GZIP-compressed JSON bytes for the page whose MD5 matches.
-/// Regenerates all pages and returns the matching one (no cache yet).
+/// Pages are (re)generated on miss and cached, so a second fetch of the same
+/// md5 hits the cache instead of re-serializing the whole dataset.
 pub async fn do_list_page_bin(_auth: AuthInfo, md5: String) -> Result<Vec<u8>> {
     let db = &DB_CONN.wait().pg_conn;
 
@@ -74,10 +78,18 @@ pub async fn do_list_page_bin(_auth: AuthInfo, md5: String) -> Result<Vec<u8>> {
     }
 
     // Find the page whose compressed MD5 matches
-    for group_items in groups.values() {
-        let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
-        if md5_hex == md5 {
-            return Ok(compressed);
+    for (flag, group_items) in &groups {
+        let page = get_or_compute(format!("item:{flag}"), async {
+            let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
+            Ok(CachedPage {
+                md5: md5_hex,
+                time: chrono::Utc::now().timestamp_millis(),
+                bytes: compressed,
+            })
+        })
+        .await?;
+        if page.md5 == md5 {
+            return Ok(page.bytes);
         }
     }
 

--- a/packages/functions/src/functions/api/marker_doc.rs
+++ b/packages/functions/src/functions/api/marker_doc.rs
@@ -11,10 +11,32 @@ use std::collections::BTreeMap;
 use _database::{DB_CONN, models::marker::marker as marker_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, serialize_compress_md5};
+use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
 
 /// Page size for the normal (flag 0) marker group.
 const MARKER_PAGE_SIZE: i64 = 3000;
+
+/// Cache key for a marker page: `marker:{flag}:{page_index}`.
+fn marker_page_key(flag: i32, page_index: i64) -> String {
+    format!("marker:{flag}:{page_index}")
+}
+
+/// Compute (and cache) one marker page. Returns the cached page entry.
+async fn marker_page(
+    flag: i32,
+    page_index: i64,
+    page_markers: &[&marker_model::Model],
+) -> Result<CachedPage> {
+    get_or_compute(marker_page_key(flag, page_index), async {
+        let (compressed, md5_hex) = serialize_compress_md5(&page_markers)?;
+        Ok(CachedPage {
+            md5: md5_hex,
+            time: chrono::Utc::now().timestamp_millis(),
+            bytes: compressed,
+        })
+    })
+    .await
+}
 
 /// `GET /marker_doc/list_page_bin_md5`
 pub async fn do_list_page_bin_md5(
@@ -22,7 +44,6 @@ pub async fn do_list_page_bin_md5(
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<Vec<BinaryMd5Vo>>> {
     let db = &DB_CONN.wait().pg_conn;
-    let now = chrono::Utc::now().timestamp_millis();
 
     let markers = marker_model::Entity::find_safety().all(db).await?;
 
@@ -41,19 +62,19 @@ pub async fn do_list_page_bin_md5(
                 let page_index = m.id / MARKER_PAGE_SIZE;
                 pages.entry(page_index).or_default().push(m);
             }
-            for page_markers in pages.values() {
-                let (_compressed, md5_hex) = serialize_compress_md5(page_markers)?;
+            for (page_index, page_markers) in &pages {
+                let page = marker_page(*flag, *page_index, page_markers).await?;
                 result.push(BinaryMd5Vo {
-                    md5: md5_hex,
-                    time: now,
+                    md5: page.md5,
+                    time: page.time,
                 });
             }
         } else {
-            // Other flags: single page
-            let (_compressed, md5_hex) = serialize_compress_md5(group_markers)?;
+            // Other flags: single page (index 0)
+            let page = marker_page(*flag, 0, group_markers).await?;
             result.push(BinaryMd5Vo {
-                md5: md5_hex,
-                time: now,
+                md5: page.md5,
+                time: page.time,
             });
         }
     }
@@ -79,16 +100,16 @@ pub async fn do_list_page_bin(_auth: AuthInfo, md5: String) -> Result<Vec<u8>> {
                 let page_index = m.id / MARKER_PAGE_SIZE;
                 pages.entry(page_index).or_default().push(m);
             }
-            for page_markers in pages.values() {
-                let (compressed, md5_hex) = serialize_compress_md5(page_markers)?;
-                if md5_hex == md5 {
-                    return Ok(compressed);
+            for (page_index, page_markers) in &pages {
+                let page = marker_page(*flag, *page_index, page_markers).await?;
+                if page.md5 == md5 {
+                    return Ok(page.bytes);
                 }
             }
         } else {
-            let (compressed, md5_hex) = serialize_compress_md5(group_markers)?;
-            if md5_hex == md5 {
-                return Ok(compressed);
+            let page = marker_page(*flag, 0, group_markers).await?;
+            if page.md5 == md5 {
+                return Ok(page.bytes);
             }
         }
     }

--- a/packages/functions/src/functions/api/marker_link_doc.rs
+++ b/packages/functions/src/functions/api/marker_link_doc.rs
@@ -2,14 +2,15 @@
 //!
 //! Mirrors Java `MarkerLinkageDocController`. Single-blob shape (no per-flag
 //! paging): the entire dataset is one GZIP-compressed JSON blob.
-//! Two views: `list` (flat array) and `graph` (adjacency map).
+//! Two views: `list` (flat array) and `graph` (adjacency map). Both are cached
+//! in-process via `binary_doc::get_or_compute`.
 
 use anyhow::Result;
 
 use _database::{DB_CONN, models::marker::marker_linkage as ml_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, serialize_compress_md5};
+use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
 
 /// `GET /marker_link_doc/all_list_bin_md5` — MD5 of the flat linkage list blob.
 pub async fn do_all_list_bin_md5(
@@ -17,23 +18,39 @@ pub async fn do_all_list_bin_md5(
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<BinaryMd5Vo>> {
     let db = &DB_CONN.wait().pg_conn;
-    let now = chrono::Utc::now().timestamp_millis();
 
-    let linkages = ml_model::Entity::find_safety().all(db).await?;
-    let (_compressed, md5_hex) = serialize_compress_md5(&linkages)?;
+    let page = get_or_compute("link:list".into(), async {
+        let linkages = ml_model::Entity::find_safety().all(db).await?;
+        let (compressed, md5_hex) = serialize_compress_md5(&linkages)?;
+        Ok(CachedPage {
+            md5: md5_hex,
+            time: chrono::Utc::now().timestamp_millis(),
+            bytes: compressed,
+        })
+    })
+    .await?;
 
     Ok(CommonResponse::new(Ok(BinaryMd5Vo {
-        md5: md5_hex,
-        time: now,
+        md5: page.md5,
+        time: page.time,
     })))
 }
 
 /// `GET /marker_link_doc/all_list_bin` — the flat linkage list blob (compressed bytes).
 pub async fn do_all_list_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
     let db = &DB_CONN.wait().pg_conn;
-    let linkages = ml_model::Entity::find_safety().all(db).await?;
-    let (compressed, _md5) = serialize_compress_md5(&linkages)?;
-    Ok(compressed)
+
+    let page = get_or_compute("link:list".into(), async {
+        let linkages = ml_model::Entity::find_safety().all(db).await?;
+        let (compressed, md5_hex) = serialize_compress_md5(&linkages)?;
+        Ok(CachedPage {
+            md5: md5_hex,
+            time: chrono::Utc::now().timestamp_millis(),
+            bytes: compressed,
+        })
+    })
+    .await?;
+    Ok(page.bytes)
 }
 
 /// `GET /marker_link_doc/all_graph_bin_md5` — MD5 of the graph adjacency blob.
@@ -42,33 +59,48 @@ pub async fn do_all_graph_bin_md5(
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<BinaryMd5Vo>> {
     let db = &DB_CONN.wait().pg_conn;
-    let now = chrono::Utc::now().timestamp_millis();
 
-    let linkages = ml_model::Entity::find_safety().all(db).await?;
+    let page = get_or_compute("link:graph".into(), async {
+        let linkages = ml_model::Entity::find_safety().all(db).await?;
+        let graph = build_graph(&linkages);
+        let (compressed, md5_hex) = serialize_compress_md5(&graph)?;
+        Ok(CachedPage {
+            md5: md5_hex,
+            time: chrono::Utc::now().timestamp_millis(),
+            bytes: compressed,
+        })
+    })
+    .await?;
 
-    // Build adjacency map: marker_id → list of linked marker_ids
-    let mut graph: std::collections::HashMap<i64, Vec<i64>> = std::collections::HashMap::new();
-    for l in &linkages {
-        graph.entry(l.from_id).or_default().push(l.to_id);
-    }
-
-    let (_compressed, md5_hex) = serialize_compress_md5(&graph)?;
     Ok(CommonResponse::new(Ok(BinaryMd5Vo {
-        md5: md5_hex,
-        time: now,
+        md5: page.md5,
+        time: page.time,
     })))
 }
 
 /// `GET /marker_link_doc/all_graph_bin` — the graph adjacency blob (compressed bytes).
 pub async fn do_all_graph_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
     let db = &DB_CONN.wait().pg_conn;
-    let linkages = ml_model::Entity::find_safety().all(db).await?;
 
+    let page = get_or_compute("link:graph".into(), async {
+        let linkages = ml_model::Entity::find_safety().all(db).await?;
+        let graph = build_graph(&linkages);
+        let (compressed, md5_hex) = serialize_compress_md5(&graph)?;
+        Ok(CachedPage {
+            md5: md5_hex,
+            time: chrono::Utc::now().timestamp_millis(),
+            bytes: compressed,
+        })
+    })
+    .await?;
+    Ok(page.bytes)
+}
+
+/// Build the adjacency map: marker_id → list of linked marker_ids.
+fn build_graph(linkages: &[ml_model::Model]) -> std::collections::HashMap<i64, Vec<i64>> {
     let mut graph: std::collections::HashMap<i64, Vec<i64>> = std::collections::HashMap::new();
-    for l in &linkages {
+    for l in linkages {
         graph.entry(l.from_id).or_default().push(l.to_id);
     }
-
-    let (compressed, _md5) = serialize_compress_md5(&graph)?;
-    Ok(compressed)
+    graph
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -396,6 +396,26 @@ async fn area_and_item_doc_business_assertions() {
         );
     }
 
+    // The BinaryMD5 pages are cached in-process: a second call must return the
+    // same md5 AND the same stable `time` (not a fresh request timestamp).
+    let md5_resp_2 = item_doc::do_list_page_bin_md5(auth.clone(), serde_json::Value::Null)
+        .await
+        .expect("item_doc md5 second call")
+        .data
+        .expect("item_doc md5 payload");
+    assert_eq!(
+        md5_resp_2.len(),
+        md5_resp.len(),
+        "same page count on second call"
+    );
+    for (first, second) in md5_resp.iter().zip(md5_resp_2.iter()) {
+        assert_eq!(first.md5, second.md5, "md5 must be stable across calls");
+        assert_eq!(
+            first.time, second.time,
+            "time must be stable while the page is cached"
+        );
+    }
+
     // ── Assertion 4: marker ItemList tweak maintains marker_item_link ────────
     // Seed one marker, then exercise Append / InsertIfAbsent / Replace /
     // RemoveLeft against its item links.


### PR DESCRIPTION
## Summary

Add the in-process cache for the BinaryMD5 doc endpoints — M4 first item (PLAN.md §4, F5).

## Motivation

`item_doc` / `marker_doc` / `marker_link_doc` re-serialized, GZIP-compressed, and MD5-hashed the **entire dataset on every request** (Java uses a Caffeine cache). Worse, the md5-list `time` field was the request timestamp, so every poll looked like "data changed" even when nothing moved.

## Changes

- **`packages/functions/.../api/binary_doc.rs`**: new in-process cache layer —
  - `CachedPage { md5, time, bytes }` and `BIN_CACHE` (moka `future` cache, 10k entries, 300s TTL — Java's Caffeine equivalent)
  - `get_or_compute(key, compute)` — fetch or generate-and-store, keyed by explicit domain/page ids (`item:0`, `marker:0:123`, `link:graph`)
  - `invalidate(key)` — ready for the cache-refresh endpoints (F10)
- **`item_doc.rs` / `marker_doc.rs` / `marker_link_doc.rs`**: both the `*_bin_md5` and `*_bin` handlers go through the cache; `time` is now the page's generation timestamp (stable within the TTL).
- **Workspace deps**: add `moka ^0.12` (latest; `^0.13` doesn't exist — that's a fork).
- **`tests/rust/tests/api_db_test.rs`**: asserts two consecutive `do_list_page_bin_md5` calls return identical md5 **and identical time** (cache hit).
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the cache-stability assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — same response shapes, now cached.
