### PR TITLE
✨ Wire the cache refresh endpoints to the BinaryMD5 cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `api_db` test asserts the md5 + time are stable across repeated
   calls.
 
+- Wire the cache-refresh endpoints (PLAN.md M4/F10): `DELETE
+  /cache/item`, `/cache/marker`, and `/cache/marker_link` now flush
+  the in-process BinaryMD5 cache (`binary_doc::invalidate_all`)
+  instead of being no-ops. The remaining domains (area / common_item /
+  icon_tag / notice) have no in-process cache yet and stay honest
+  no-ops. `api_db` test asserts the refresh regenerates pages (fresh
+  `time`).
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -86,3 +86,10 @@ pub async fn get_or_compute(
 pub async fn invalidate(key: &str) {
     BIN_CACHE.invalidate(key).await;
 }
+
+/// Drop every cached page. The cache-refresh endpoints call this — the keys
+/// are domain-scoped (`item:*`, `marker:*`, `link:*`) but not enumerable
+/// cheaply, so a full flush is the simple correct invalidation.
+pub fn invalidate_all() {
+    BIN_CACHE.invalidate_all();
+}

--- a/packages/functions/src/functions/api/cache.rs
+++ b/packages/functions/src/functions/api/cache.rs
@@ -1,15 +1,11 @@
 //! Cache invalidation endpoints.
 //!
 //! In the Java backend, these wire to `CacheService.clean*` which evicts
-//! Caffeine in-process cache entries. The Rust backend uses Redis for caching
-//! (not in-process Caffeine), but the Redis read-through cache layer and the
-//! BinaryMD5 `*_doc` archive pipeline are not yet implemented — so there is
-//! currently no cache to invalidate.
-//!
-//! These handlers are honest no-ops: they return success without claiming to
-//! have cleared anything. Once the Redis cache layer is wired (keyed by
-//! `cache:{domain}` patterns), each handler should issue a `DEL cache:{domain}`
-//! against `DB_CONN.redis_conn`.
+//! Caffeine in-process cache entries. The Rust backend keeps the BinaryMD5
+//! `*_doc` pages in an in-process moka cache (see `binary_doc`), so the item /
+//! marker / marker-link refresh handlers flush it. The other domains
+//! (area / common_item / icon_tag / notice) have no in-process cache yet, so
+//! their handlers remain honest no-ops.
 
 use anyhow::Result;
 
@@ -18,37 +14,42 @@ use _utils::{
     models::{common::EmptyResponse, wrapper::CommonResponse},
 };
 
-/// 清除地区缓存。当前无缓存层，为 no-op。
+use super::binary_doc;
+
+/// 清除地区缓存。当前无对应缓存层，为 no-op。
 pub async fn do_delete_area_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除物品缓存。当前无缓存层，为 no-op。
+/// 清除物品缓存（BinaryMD5 item 页）。
 pub async fn do_delete_item_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除公共物品缓存。当前无缓存层，为 no-op。
+/// 清除公共物品缓存。当前无对应缓存层，为 no-op。
 pub async fn do_delete_common_item_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除图标标签缓存。当前无缓存层，为 no-op。
+/// 清除图标标签缓存。当前无对应缓存层，为 no-op。
 pub async fn do_delete_icon_tag_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除点位缓存。当前无缓存层，为 no-op。
+/// 清除点位缓存（BinaryMD5 marker 页）。
 pub async fn do_delete_marker_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除点位连线缓存。当前无缓存层，为 no-op。
+/// 清除点位连线缓存（BinaryMD5 link list/graph 页）。
 pub async fn do_delete_marker_link_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-/// 清除公告缓存。当前无缓存层，为 no-op。
+/// 清除公告缓存。当前无对应缓存层，为 no-op。
 pub async fn do_delete_notice_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -19,7 +19,8 @@ use _database::models::{
     system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
-    area as area_fns, item_doc, marker as marker_fns, punctuate_audit as audit_fns,
+    area as area_fns, cache as cache_fns, item_doc, marker as marker_fns,
+    punctuate_audit as audit_fns,
 };
 use _functions::functions::system::oauth as oauth_fns;
 use _utils::{
@@ -413,6 +414,31 @@ async fn area_and_item_doc_business_assertions() {
         assert_eq!(
             first.time, second.time,
             "time must be stable while the page is cached"
+        );
+    }
+
+    // The refresh endpoint must invalidate the cache: the next md5 list is
+    // regenerated (fresh time), proving the flush is wired.
+    cache_fns::do_delete_item_cache(auth.clone())
+        .await
+        .expect("delete item cache")
+        .data
+        .expect("cache delete ok");
+    let md5_resp_3 = item_doc::do_list_page_bin_md5(auth.clone(), serde_json::Value::Null)
+        .await
+        .expect("item_doc md5 after refresh")
+        .data
+        .expect("item_doc md5 payload");
+    assert_eq!(
+        md5_resp_3.len(),
+        md5_resp.len(),
+        "same page count after refresh"
+    );
+    for (before, after) in md5_resp_2.iter().zip(md5_resp_3.iter()) {
+        assert_eq!(before.md5, after.md5, "md5 must be deterministic");
+        assert_ne!(
+            before.time, after.time,
+            "refresh must regenerate the page (fresh time)"
         );
     }
 


### PR DESCRIPTION
## Summary

Wire the cache-refresh endpoints to the BinaryMD5 cache — M4 final item (PLAN.md §4, F10).

## Motivation

The 7 `DELETE /cache/*` endpoints were all no-ops ("there is currently no cache to invalidate"). PR #35 added the in-process moka cache, so the item / marker / marker-link refresh handlers now have something real to flush.

## Changes

- **`packages/functions/.../api/binary_doc.rs`**: new `invalidate_all()` (moka's synchronous full flush — keys are domain-scoped but not cheaply enumerable).
- **`packages/functions/.../api/cache.rs`**: `do_delete_item_cache` / `do_delete_marker_cache` / `do_delete_marker_link_cache` now flush the BinaryMD5 cache. `area` / `common_item` / `icon_tag` / `notice` still have no in-process cache and remain honest no-ops (comments updated).
- **`tests/rust/tests/api_db_test.rs`**: asserts the refresh flow — two md5-list calls are stable (cached), then `do_delete_item_cache` forces a regeneration (same md5, fresh `time`).
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the refresh-flow assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — the endpoints now actually invalidate the cache instead of pretending to.
