### PR TITLE
📝 Resync the zhs and en roadmaps with the actual domain status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   no-ops. `api_db` test asserts the refresh regenerates pages (fresh
   `time`).
 
+- Resync the zhs/en Java-sync roadmaps with the actual domain status
+  (PLAN.md M5/D1): both versions now carry the same Status column —
+  batches 1–3, 5, 6 done; batches 4 and 7 mostly done with the
+  remaining gaps (score field-level diff, RSA/JWKS rotation) stated
+  explicitly. The stale "follow-up" items (sea-orm 2.x / minio 0.4
+  migrations, which were completed long ago) are removed.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/docs/en/guides/sync-with-java-roadmap.md
+++ b/docs/en/guides/sync-with-java-roadmap.md
@@ -19,7 +19,7 @@ two domains, plus three pieces of non-trivial infrastructure:
 - **Binary archive export** (`*_doc` endpoints): large datasets are serialized,
 
 GZIP-compressed, and keyed by BinaryMD5 so the client can incrementally sync.
-Two-tier cache on the Java side (Caffeine → port to `moka` / `quick-cache`).
+Two-tier cache on the Java side (Caffeine → ported to `moka` in-process).
 
 - **Crowd-sourced punctuate workflow**: user marker submissions → staging
 
@@ -36,31 +36,42 @@ device/IP anomaly detection on token issuance.
 ## Porting priority
 
 The order below front-loads the entities that unblock the most downstream
-work. Each step lists the key entity/feature and an estimated complexity.
+work. Each step lists the key entity/feature, an estimated complexity, and the
+current status.
 
 | # | Area | Key entity / feature | Complexity | Status |
 | --- | --- | --- | --- | --- |
-| 1 | **area + marker** (reference samples) | `Area`, `Marker`, `hiddenFlag`, `specialFlag`. Establishes the `SafeEntityTrait` pattern and the five-layer domain template every later port copies. | Medium | Done — used as the porting template |
-| 2 | **icon / item / tag families** | `Icon`, `IconType`, `IconTypeLink`, `Item`, `ItemType`, `ItemTypeLink`, plus the `Tag` / `TagType` taxonomy. Includes the `selectPageItemByCondition` `specialFlag` filter and the icon-tag merge. | Low–Medium | In progress |
-| 3 | **notice / route / history** | `Notice` (validity-sort rule), `Route`, `History`. Read-heavy content that pairs naturally with the Redis cache layer. | Low–Medium | In progress |
-| 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit) and `ScoreStat` aggregation (scope/span bucketing). Two-phase state machine plus the score aggregate. | High | Planned |
-| 5 | **system (user / role / device / invitation)** | `SysUser`, `SysUserArchive`, `SysUserDevice` (login-anomaly detection), `SysUserInvitation`, `SysActionLog`, role listing. Depends on the bcrypt hashing already in `utils`. | Medium | In progress |
-| 6 | **BinaryMD5 archive export** | The GZIP-compressed, BinaryMD5-keyed producer for `item_doc` / `marker_doc` / `marker_link_doc`. The Rust side generates GZIP-compressed blobs on-the-fly from PostgreSQL per request (no caching yet); porting the two-tier cache layer (Redis or moka) is the work. | High | Planned |
-| 7 | **OAuth2 / JWKS** | `/oauth/token` issuance, JWKS publication, the RSA keypair + token enhancer, device/IP anomaly check, and the `qq` registration provider. Depends on `jsonwebtoken` 10 (already pinned). | High | Planned |
+| 1 | **area + marker** (reference samples) | `Area`, `Marker`, `hiddenFlag`, `specialFlag`. Establishes the `SafeEntityTrait` pattern and the five-layer domain template every later port copies. | Medium | **Done** — used as the porting template |
+| 2 | **icon / item / tag families** | `Icon`, `IconType`, `IconTypeLink`, `Item`, `ItemType`, `ItemTypeLink`, plus the `Tag` / `TagType` taxonomy. Includes the `selectPageItemByCondition` `specialFlag` filter and copy/join/move_type. | Low–Medium | **Done** (covered by the `api_db` integration tests) |
+| 3 | **notice / route / history** | `Notice` (validity-sort rule), `Route`, `History`. `RouteVO` page/search/batch queries are wired. | Low–Medium | **Done** |
+| 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit, role-gated and transactional) and `ScoreStat` aggregation. | High | **Mostly done** — the score field-level diff (`ScoreDataPunctuateVo`) is not ported yet (current aggregation is simplified) |
+| 5 | **system (user / role / device / invitation)** | `SysUser`, `SysUserArchive`, `SysUserDevice` (login-anomaly detection), `SysUserInvitation`, `SysActionLog`, role listing, archive rename/delete_slot. | Medium | **Done** — device registration + access-policy checks are wired |
+| 6 | **BinaryMD5 archive export** | The GZIP-compressed, BinaryMD5-keyed producer for `item_doc` / `marker_doc` / `marker_link_doc`, with an in-process moka cache (300s TTL) and refresh endpoints. | High | **Done** |
+| 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Mostly done** — still HMAC (HS256) signing; the RSA keypair + JWK rotation are not implemented |
 
-## Notes
+## Current state
 
-- Steps 1–5 are CRUD-shaped ports that follow the
+- All seven batches are landed end-to-end (entity → DTO → business → route →
+  test). Business assertions live in `tests/rust/tests/api_db_test.rs`
+  (live DB, CI `integration` job): area CRUD, item_doc BinaryMD5, marker
+  tweak, punctuate audit (role gate + transactional promotion), OAuth
+  policy/device/QQ login, JWKS, cache stability and refresh.
+- The `SafeEntityTrait` + `impl_safe_operation!` macros are stable; new
+  domains reuse the template.
 
-[Domain Sync Template](./domain-sync-template.md); they are low-risk and
-can land incrementally.
+## Known gaps (remaining parity with Java)
 
-- Steps 4, 6, and 7 each carry significant business or algorithmic logic
+- Batch 4: `score::do_generate_score` is a simplified aggregation (counts
+  edits); the Java field-level diff (`ScoreDataPunctuateVo`) is not ported.
+- Batch 7: tokens are HMAC-SHA256; the Java side uses an RSA keypair with JWK
+  rotation. The JWKS endpoint currently publishes the HMAC key in `oct` form;
+  switching to RSA requires key management and rotation.
+- Database schema deviations from the real database await data validation
+  (`marker_linkage` nullable columns, `sys_user_archive` structure binding).
+- Translation: only `docs/en` and `docs/zhs` are complete; the other 9
+  languages are skeletons.
 
-(the punctuate state machine, BinaryMD5 hashing + GZIP streaming, JWKS key
-rotation). Each should get its own design note under `docs/en/designs/`
-before implementation.
+## Follow-up
 
-- Update this table's Status column (and `CHANGELOG.md`) as each domain moves
-
-from *Planned* → *In progress* → *Done*.
+- The gaps above are tracked in the iteration backlog (`PLAN.md` at the repo
+  root) and land via the master-based PR workflow.

--- a/docs/zhs/guides/sync-with-java-roadmap.md
+++ b/docs/zhs/guides/sync-with-java-roadmap.md
@@ -12,30 +12,35 @@ Rust 后端的目标是与 Java 参考实现 `java-genshin-map-cloud` 功能对�
 
 ## 移植优先级
 
-| 批次 | 域 / 特性 | 关键实体与能力 | 复杂度 |
-| --- | --- | --- | --- |
-| 1 | **area + marker** | `area`、`marker` 实体；CRUD + 软删除 + 乐观锁；`SafeEntityTrait` 宏定型 | 中 — **已完成，作为参考样板** |
-| 2 | **icon / item / tag 系列** | `icon`、`icon_type`、`item`、`item_type`、`item_common`；含 copy/join/move_type | 中高 — 实体多、关联复杂 |
-| 3 | **notice / route / history** | `notice`、`route`、`history`（公共模型在 `models/common/`） | 低中 — 结构相对独立 |
-| 4 | **打点审批流 + 评分** | `punctuate`、`punctuate_audit`（audit/delete/get）、`score`（data/generate） | 高 — 状态机 + 生成逻辑 |
-| 5 | **系统域** | `user`、`role`、`device`、`invitation`、`action_log`、`archive` | 中 — 鉴权与权限耦合 |
-| 6 | **BinaryMD5 归档导出** | `item_doc`、`marker_doc`、`marker_link_doc` 的 bin/md5 分页端点；GZIP 压缩 | 高 — 二进制协议还原 |
-| 7 | **OAuth2 / JWKS** | `oauth` 路由 + JWKS 公钥分发 + 第三方登录 | 高 — 安全敏感 |
+| 批次 | 域 / 特性 | 关键实体与能力 | 复杂度 | 状态 |
+| --- | --- | --- | --- | --- |
+| 1 | **area + marker** | `area`、`marker` 实体；CRUD + 软删除 + 乐观锁；`SafeEntityTrait` 宏定型 | 中 | **已完成** — 作为参考样板 |
+| 2 | **icon / item / tag 系列** | `icon`、`icon_type`、`item`、`item_type`、`item_common`、`tag`、`tag_type`；含 copy/join/move_type、`specialFlag` 过滤 | 中高 — 实体多、关联复杂 | **已完成**（`item_doc` 等由 api_db 测试覆盖） |
+| 3 | **notice / route / history** | `notice`、`route`、`history`（公共模型在 `models/common/`）；`RouteVO` 分页/搜索/批量查询 | 低中 — 结构相对独立 | **已完成** |
+| 4 | **打点审批流 + 评分** | `punctuate`、`punctuate_audit`（pass/reject/delete，含角色校验与事务化晋升）、`score`（data/generate） | 高 — 状态机 + 生成逻辑 | **大部分完成** — score 的字段级 diff（`ScoreDataPunctuateVo`）尚未移植（当前为简化聚合） |
+| 5 | **系统域** | `user`、`role`、`device`、`invitation`、`action_log`、`archive`（rename/delete_slot 已补齐） | 中 — 鉴权与权限耦合 | **已完成** — 登录设备登记 + access_policy 校验已接线 |
+| 6 | **BinaryMD5 归档导出** | `item_doc`、`marker_doc`、`marker_link_doc` 的 bin/md5 端点；GZIP 压缩 + 进程内缓存（moka，300s TTL） | 高 — 二进制协议还原 | **已完成** |
+| 7 | **OAuth2 / JWKS** | `oauth` 路由（password / QQ / client_credentials）、`/.well-known/jwks.json`、access_policy 检查、scope 映射 | 高 — 安全敏感 | **大部分完成** — 仍为 HMAC(HS256) 签名；RSA 密钥对与 JWK 轮换尚未实现 |
 
 ## 当前状态
 
-- 批次 1 已落地：`area`、`marker` 两个域完整贯通五层（实体 → DTO → 业务 →
+- 全部七个批次已落地，五层贯通（实体 → DTO → 业务 → 路由 → 测试）。
+  业务断言由 `tests/rust/tests/api_db_test.rs`（真库，CI `integration` job）覆盖：
+  area 增删查、item_doc BinaryMD5、marker tweak、punctuate 审核（角色闸门 +
+  事务晋升）、OAuth 策略/设备/QQ 登录、JWKS、缓存稳定与刷新。
+- `SafeEntityTrait` + `impl_safe_operation!` 宏稳定，新域套用模板即可。
 
-路由 → 冒烟测试，见 `tests/rust/tests/area/` 与 `tests/rust/tests/marker/`），
-作为后续所有域的移植样板。
+## 已知差距（与 Java 的剩余差异）
 
-- `SafeEntityTrait` + `impl_safe_operation!` 宏已稳定，新域只需套用模板。
+- 批次 4：`score` 的 `do_generate_score` 为简化聚合（按编辑次数计分），
+  Java 的字段级 diff（`ScoreDataPunctuateVo`）未移植。
+- 批次 7：token 签名为 HMAC-SHA256；Java 侧为 RSA 密钥对 + JWK 轮换。
+  当前 JWKS 以 `oct` 形式公布 HMAC 密钥；切换 RSA 时需引入密钥管理与轮换。
+- 数据库 schema 与真实库的偏差待数据验证（`marker_linkage` 空值列、
+  `sys_user_archive` 结构绑定等）。
+- 文档翻译：`docs/` 下仅 en/zhs 完整，其余 9 种语言为骨架。
 
 ## 跟进事项
 
-- `sea-orm` 1.x → 2.x 迁移：2.0 的 `UpdateOne`/`ValidatedUpdateOne` 破坏性
-
-API 要求重写 `SafeEntityTrait` 宏及约 33 处业务调用点，排期为后续在 dev 分支
-推进。
-
-- `minio` 0.3 → 0.4：Client/Builder 与 bucket 置备 API 变更，待批次 6 一并处理。
+- 批次 4 / 7 的差距项排入迭代 backlog（见根目录 `PLAN.md`），
+  随 master-based PR 流程逐项合入。


### PR DESCRIPTION
## Summary

Resync the zhs/en Java-sync roadmaps with the actual domain status — M5 first item (PLAN.md §4, D1).

## Motivation

The two roadmap versions had drifted and were both stale:
- The zhs version had **no Status column** and its "follow-up" items (sea-orm 1.x→2.x, minio 0.3→0.4) described migrations that were completed long ago.
- The en version had a Status column but marked batches 4/6/7 as "Planned" — all of which are implemented (punctuate audit + score, BinaryMD5 with caching, OAuth + JWKS + QQ login).

## Changes

- **`docs/zhs/guides/sync-with-java-roadmap.md`**: rewritten with a Status column aligned to reality; stale follow-up items removed; a "已知差距" (known gaps) section states the honest remaining parity gaps (score field-level diff, RSA/JWKS rotation, schema deviations, translations).
- **`docs/en/guides/sync-with-java-roadmap.md`**: same statuses and a "Known gaps" section; batch notes updated (moka cache landed, refresh endpoints wired).
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] Docs-only change; no Rust code touched
- [x] Both versions carry the same statuses/gaps (alignment)

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes (no Rust code touched)
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None.
