### PR TITLE
🔧 Make the CDN proxy upstream configurable and document it.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ PORT=8101
 # MINIO_ACCESS_KEY=genshin_cloud
 # MINIO_SECRET_KEY=genshin_cloud
 
+# ── CDN proxy (optional) ─────────────────────────────────────────────────────
+# Upstream for the /cdn reverse proxy. Defaults to https://v3.yuanshen.site.
+# Point it at a self-hosted CDN or an internal mirror if needed.
+# CDN_UPSTREAM=https://v3.yuanshen.site
+# Local pre-generated dadian config (bz2) served at /cdn/dadian-preview.json.bz2.
+# When unset, the endpoint falls back to an empty dev config.
+# CDN_DADIAN_CONFIG=/absolute/path/to/dadian-preview.json.bz2
+
 # ── Dev / E2E ───────────────────────────────────────────────────────────────
 # Absolute path to the Vue3 frontend project (required for `just dev`).
 # Clone from: https://github.com/kongying-tavern/vue_map_register_v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   explicitly. The stale "follow-up" items (sea-orm 2.x / minio 0.4
   migrations, which were completed long ago) are removed.
 
+- Make the CDN proxy configurable (PLAN.md M5/I4): the `/cdn` upstream
+  was hard-coded to `v3.yuanshen.site` and the dadian config was a
+  fake empty blob. New `CDN_UPSTREAM` env var overrides the upstream
+  (self-hosted CDN / internal mirror); `CDN_DADIAN_CONFIG` points at a
+  pre-generated bz2 config served for `/cdn/dadian-preview.json.bz2`
+  (falling back to the empty dev config when unset). Both are
+  documented in `.env.example`.
+
 ### Dependencies (dev branch)
 
 - Upgrade the workspace to edition 2024 across all four packages

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -40,6 +40,23 @@ async fn jwks() -> axum::response::Response {
     }
 }
 
+/// CDN 上游地址：默认 `v3.yuanshen.site`，可用 `CDN_UPSTREAM` 环境变量覆盖
+/// （例如自建 CDN 或内网镜像）。URL 不带尾斜杠。
+fn cdn_upstream() -> String {
+    std::env::var("CDN_UPSTREAM")
+        .unwrap_or_else(|_| "https://v3.yuanshen.site".into())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// 本地 dadian 配置文件路径（`CDN_DADIAN_CONFIG`，可选）。
+/// 指向一个预生成的 bz2 压缩配置；未设置时 `/cdn/dadian-preview.json.bz2`
+/// 降级为内置的空配置（开发期行为）。
+fn dadian_config_file() -> Option<Vec<u8>> {
+    let path = std::env::var("CDN_DADIAN_CONFIG").ok()?;
+    std::fs::read(path).ok()
+}
+
 /// CDN proxy with fallback. Tries remote CDN first, falls back to a locally
 /// generated minimal dadian config if the remote file is unavailable.
 fn cdn_proxy() -> axum::Router {
@@ -48,25 +65,34 @@ fn cdn_proxy() -> axum::Router {
     use axum::response::{IntoResponse, Response};
 
     let client = std::sync::Arc::new(reqwest::Client::new());
+    let upstream = cdn_upstream();
+    let dadian_override = dadian_config_file();
 
     Router::new()
         .fallback(
             move |State(client): State<std::sync::Arc<reqwest::Client>>,
                   req: Request<axum::body::Body>| {
                 let client = client.clone();
+                let upstream = upstream.clone();
+                let dadian_override = dadian_override.clone();
                 async move {
                     let path = req.uri().path().trim_start_matches("/cdn");
 
                     // Special case: serve locally generated dadian config
                     if path == "/dadian-preview.json.bz2" {
-                        let config = serde_json::json!({
-                            "tiles": {},
-                            "application": {"avatar": [], "nameCard": []},
-                            "editor": {},
-                            "plugins": {}
-                        });
-                        let json_bytes = serde_json::to_vec(&config).unwrap_or_default();
-                        let bz2_bytes = bz2_bump(&json_bytes);
+                        let bz2_bytes = match dadian_override {
+                            Some(bytes) => bytes,
+                            None => {
+                                let config = serde_json::json!({
+                                    "tiles": {},
+                                    "application": {"avatar": [], "nameCard": []},
+                                    "editor": {},
+                                    "plugins": {}
+                                });
+                                let json_bytes = serde_json::to_vec(&config).unwrap_or_default();
+                                bz2_bump(&json_bytes)
+                            },
+                        };
                         return Response::builder()
                             .status(200)
                             .header("Content-Type", "application/octet-stream")
@@ -81,8 +107,8 @@ fn cdn_proxy() -> axum::Router {
                             .into_response();
                     }
 
-                    // All other CDN paths: proxy to v3.yuanshen.site
-                    let url = format!("https://v3.yuanshen.site{}", path);
+                    // All other CDN paths: proxy to the configured upstream
+                    let url = format!("{upstream}{path}");
 
                     match client.get(&url).send().await {
                         Ok(resp) => {


### PR DESCRIPTION
## Summary

Make the CDN proxy upstream configurable and document it — M5 second item (PLAN.md §4, I4).

## Motivation

The `/cdn` reverse proxy hard-coded `https://v3.yuanshen.site` (no way to point at a self-hosted CDN or internal mirror) and the `/cdn/dadian-preview.json.bz2` special case always served a fake empty config (dev placeholder with no override path).

## Changes

- **`packages/router/src/routes/mod.rs`**:
  - `cdn_upstream()` — reads `CDN_UPSTREAM` (default `https://v3.yuanshen.site`, trailing slash trimmed). The proxy URL is now `{upstream}{path}`.
  - `dadian_config_file()` — reads `CDN_DADIAN_CONFIG` (path to a pre-generated bz2 file); when set, `/cdn/dadian-preview.json.bz2` serves those bytes; when unset, the existing empty-config fallback remains.
- **`.env.example`**: documents both variables under a `── CDN proxy (optional)` section.
- **`CHANGELOG.md`**: entry under Infrastructure.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] CI on this PR

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example)

## Breaking Changes

None — defaults preserve current behavior; both knobs are opt-in.
