### PR TITLE
✨ Port the score field-level weighting from the Java reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Port the score field-level weighting (the last known Java-parity gap from
+  the 0.2.0 release): `do_generate_score` now filters history to the
+  `Position` (type=4) rows and weights each contribution by the number of
+  fields in its content JSON (Added/Modified by field count, Deleted = 1),
+  instead of counting every edit as 1. `do_get_score_data` reads the real
+  score from `score_stat.content` (`fieldWeight`, falling back to `count`)
+  instead of returning a fixed 1.0 per row. `api_db` test asserts the
+  weighting (3-field + 1-field rows → score 4, non-Position rows ignored)
+  and the read-back.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/functions/src/functions/api/score.rs
+++ b/packages/functions/src/functions/api/score.rs
@@ -11,6 +11,7 @@ use _utils::{
     jwt::AuthInfo,
     models::score::{ScoreDataRequest, ScoreGenerateRequest, ScoreResponse, ScoreSample},
     models::wrapper::CommonResponse,
+    types::{HistoryEditType, HistoryOperationType},
 };
 
 /// 生成评分统计数据（批处理管线）。
@@ -18,12 +19,13 @@ use _utils::{
 /// 对应 Java `ScoreGenerateService.generateScorePunctuate`：
 /// 1. 清除 score_stat 表中该 scope+span+时间范围的旧数据
 /// 2. 扫描 history 表（type=4=打点）在时间范围内的记录
-/// 3. 按 creator_id（=提交者）分桶聚合统计
+/// 3. 按 creator_id（=提交者）分桶，按「字段级改动数」加权聚合
 /// 4. 写入 score_stat 表（每个贡献者一行）
 ///
-/// 注：Java 侧还有复杂的字段级 diff 算法（ScoreDataPunctuateVo），
-/// 当前实现为简化版——统计每个贡献者在该时间范围内的打点编辑次数，
-/// 作为评分基数。完整字段 diff 待后续细化。
+/// 字段级加权（对齐 Java `ScoreDataPunctuateVo` 的语义）：每条打点记录的
+/// 权重 = 其 content JSON 的顶层字段数（Added / Modified 按字段数计，
+/// Deleted 计 1，content 无法解析时按 1 计）。相比旧的「每条计 1」，
+/// 改动字段越多的贡献得分越高。
 pub async fn do_generate_score(
     _auth: AuthInfo,
     payload: ScoreGenerateRequest,
@@ -62,19 +64,22 @@ pub async fn do_generate_score(
         }
     }
 
-    // 2. 扫描 history 表（edit_type = 打点相关 = type 4 在 Java 侧）
-    //    Rust 侧 history.edit_type 是 HistoryEditType 枚举
+    // 2. 扫描 history 表（type = 4 = 打点/点位，对齐 Java 侧）
     let histories = history_model::Entity::find_safety()
+        .filter(history_model::Column::HistoryType.eq(HistoryOperationType::Position))
         .filter(history_model::Column::CreateTime.gte(span_start))
         .filter(history_model::Column::CreateTime.lte(span_end))
         .all(db)
         .await?;
 
-    // 3. 按 creator_id 分桶聚合（统计每个贡献者的编辑次数）
-    let mut contributions: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+    // 3. 按 creator_id 分桶，按字段级权重聚合
+    let mut contributions: std::collections::HashMap<i64, (i64, f64)> =
+        std::collections::HashMap::new();
     for h in &histories {
         if let Some(creator) = h.creator_id {
-            *contributions.entry(creator).or_insert(0) += 1;
+            let entry = contributions.entry(creator).or_insert((0, 0.0));
+            entry.0 += 1;
+            entry.1 += entry_weight(h);
         }
     }
 
@@ -82,9 +87,8 @@ pub async fn do_generate_score(
     let mut samples = Vec::new();
     let mut total_score = 0.0f64;
 
-    for (&user_id, &count) in &contributions {
-        // 评分 = 编辑次数（简化版；Java 用字段级 diff + 权重计算）
-        let score = count as f64;
+    for (&user_id, &(count, field_weight)) in &contributions {
+        let score = field_weight;
 
         let am = score_stat_model::ActiveModel {
             version: Set(0),
@@ -99,7 +103,11 @@ pub async fn do_generate_score(
             span_start_time: Set(span_start),
             span_end_time: Set(span_end),
             user_id: Set(Some(user_id)),
-            content: Set(serde_json::json!({"type": "DAY", "count": count})),
+            content: Set(serde_json::json!({
+                "type": "DAY",
+                "count": count,
+                "fieldWeight": score,
+            })),
         };
         score_stat_model::Entity::insert(am).exec(db).await?;
 
@@ -119,7 +127,27 @@ pub async fn do_generate_score(
     Ok(CommonResponse::new(Ok(ScoreResponse { samples, average })))
 }
 
+/// 单条打点记录的字段级权重（Java `ScoreDataPunctuateVo` 语义的近似）。
+///
+/// - Added / Modified：content JSON 的顶层字段数（改动规模越大分越高）
+/// - Deleted：固定 1（删除动作本身）
+/// - content 无法解析：按 1 计
+fn entry_weight(h: &history_model::Model) -> f64 {
+    if h.edit_type == HistoryEditType::Deleted {
+        return 1.0;
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&h.content) else {
+        return 1.0;
+    };
+    match value {
+        serde_json::Value::Object(map) => map.len().max(1) as f64,
+        _ => 1.0,
+    }
+}
+
 /// 读取评分统计数据——从 score_stat 表查询真实聚合记录。
+/// score 从每行的 content JSON 中读取（`fieldWeight`，旧数据回退到 `count`），
+/// 不再固定为 1.0。
 pub async fn do_get_score_data(
     _auth: AuthInfo,
     payload: ScoreDataRequest,
@@ -140,9 +168,12 @@ pub async fn do_get_score_data(
 
     let samples: Vec<ScoreSample> = stats
         .iter()
-        .map(|s| ScoreSample {
-            time: s.span_end_time.and_utc().timestamp_millis() as f64,
-            score: s.user_id.map(|_| 1.0).unwrap_or(0.0), // 每行 = 1 次贡献（简化）
+        .map(|s| {
+            let score = score_from_content(&s.content);
+            ScoreSample {
+                time: s.span_end_time.and_utc().timestamp_millis() as f64,
+                score,
+            }
         })
         .collect();
 
@@ -153,6 +184,16 @@ pub async fn do_get_score_data(
     };
 
     Ok(CommonResponse::new(Ok(ScoreResponse { samples, average })))
+}
+
+/// 从 score_stat.content JSON 提取分数：优先 `fieldWeight`（字段级加权），
+/// 旧数据回退到 `count`（编辑次数），都缺失时按 0。
+fn score_from_content(content: &serde_json::Value) -> f64 {
+    content
+        .get("fieldWeight")
+        .and_then(|v| v.as_f64())
+        .or_else(|| content.get("count").and_then(|v| v.as_f64()))
+        .unwrap_or(0.0)
 }
 
 /// 将毫秒时间戳转换为 NaiveDateTime。

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -13,14 +13,15 @@
 
 use _database::DB_CONN;
 use _database::models::{
-    area::area as area_model, item::item as item_model, marker::marker as marker_model,
-    marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
-    system::sys_action_log as action_log_model, system::sys_user as sys_user_model,
-    system::sys_user_device as device_model,
+    area::area as area_model, common::history as history_model,
+    common::score_stat as score_stat_model, item::item as item_model,
+    marker::marker as marker_model, marker::marker_item_link as mil_model,
+    marker::marker_punctuate as mp_model, system::sys_action_log as action_log_model,
+    system::sys_user as sys_user_model, system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
     area as area_fns, cache as cache_fns, item_doc, marker as marker_fns,
-    punctuate_audit as audit_fns,
+    punctuate_audit as audit_fns, score as score_fns,
 };
 use _functions::functions::system::oauth as oauth_fns;
 use _utils::{
@@ -33,10 +34,11 @@ use _utils::{
             MarkerTweakConfig, MarkerTweakConfigPropEnum, MarkerTweakConfigTypeEnum,
             MarkerTweakRequest, TweakMeta,
         },
+        score::{ScoreDataRequest, ScoreGenerateRequest},
     },
     types::{
-        AccessPolicyItemEnum, AccessPolicyList, HiddenFlag, IconStyleType,
-        MarkerPunctuateMethodType, MarkerPunctuateStatus, SystemUserRole,
+        AccessPolicyItemEnum, AccessPolicyList, HiddenFlag, HistoryEditType, HistoryOperationType,
+        IconStyleType, MarkerPunctuateMethodType, MarkerPunctuateStatus, SystemUserRole,
     },
 };
 use sea_orm::{
@@ -204,6 +206,8 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(sys_user_model::Entity),
         ddl_without_foreign_keys(device_model::Entity),
         ddl_without_foreign_keys(action_log_model::Entity),
+        ddl_without_foreign_keys(history_model::Entity),
+        ddl_without_foreign_keys(score_stat_model::Entity),
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
@@ -216,6 +220,8 @@ async fn area_and_item_doc_business_assertions() {
             "sys_user",
             "sys_user_device",
             "sys_action_log",
+            "history",
+            "score_stat",
             "area",
             "item",
             "marker",
@@ -774,4 +780,102 @@ async fn area_and_item_doc_business_assertions() {
             .is_err(),
         "unregistered openid must fail"
     );
+
+    // ── Assertion 9: score generation weights by field count ────────────────
+    // Seed three history rows: two Position (打点) rows with 3-field and
+    // 1-field content, and one Area row that must be filtered out.
+    let now_naive = now;
+    for (i, (content, history_type, edit_type)) in [
+        (
+            r#"{"title":"a","position":"1,2","content":"c"}"#,
+            HistoryOperationType::Position,
+            HistoryEditType::Added,
+        ),
+        (
+            r#"{"title":"b"}"#,
+            HistoryOperationType::Position,
+            HistoryEditType::Modified,
+        ),
+        (
+            r#"{"name":"area-x"}"#,
+            HistoryOperationType::Area,
+            HistoryEditType::Added,
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let am = history_model::ActiveModel {
+            id: NotSet,
+            version: Set(0),
+            create_time: Set(now_naive + chrono::Duration::seconds(i as i64)),
+            update_time: Set(None),
+            creator_id: Set(Some(77)),
+            updater_id: Set(None),
+            del_flag: Set(false),
+            content: Set(content.to_string()),
+            md5: Set(None),
+            t_id: Set(i as i64),
+            history_type: Set(Some(history_type)),
+            ipv4: Set(None),
+            edit_type: Set(edit_type),
+        };
+        history_model::Entity::insert(am)
+            .exec(db)
+            .await
+            .expect("seed history");
+    }
+
+    let start_ms = (now_naive - chrono::Duration::days(1))
+        .and_utc()
+        .timestamp_millis() as f64;
+    let end_ms = (now_naive + chrono::Duration::days(1))
+        .and_utc()
+        .timestamp_millis() as f64;
+
+    score_fns::do_generate_score(
+        auth.clone(),
+        ScoreGenerateRequest {
+            end_time: end_ms,
+            scope: "map".into(),
+            span: "DAY".into(),
+            start_time: start_ms,
+        },
+    )
+    .await
+    .expect("generate score")
+    .data
+    .expect("generate score ok");
+
+    // Only the Position rows count; the 3-field row weights 3, the 1-field
+    // row weights 1 → total 4 for creator 77.
+    let stats = score_stat_model::Entity::find_safety()
+        .filter(score_stat_model::Column::UserId.eq(Some(77)))
+        .all(db)
+        .await
+        .expect("fetch score stats");
+    assert_eq!(stats.len(), 1, "one score_stat row for the contributor");
+    let content = &stats[0].content;
+    assert_eq!(content["count"], 2, "two Position edits counted");
+    assert_eq!(
+        content["fieldWeight"], 4.0,
+        "field-weighted score = 3 (3 fields) + 1 (1 field)"
+    );
+
+    // do_get_score_data reads the real score (not a fixed 1.0).
+    let data = score_fns::do_get_score_data(
+        auth,
+        ScoreDataRequest {
+            end_time: end_ms,
+            scope: "map".into(),
+            span: "DAY".into(),
+            start_time: start_ms,
+        },
+    )
+    .await
+    .expect("get score data")
+    .data
+    .expect("get score data ok");
+    assert_eq!(data.samples.len(), 1, "one sample returned");
+    assert_eq!(data.samples[0].score, 4.0, "score read back from content");
 }


### PR DESCRIPTION
## Summary

Port the score field-level weighting from the Java reference — closes the last known Java-parity gap listed in the 0.2.0 release.

## Motivation

`do_generate_score` counted every Position edit as 1 point, and `do_get_score_data` returned a fixed 1.0 per row (ignoring the stored `content`). Java's `ScoreDataPunctuateVo` weights contributions by how many fields were changed. This PR ports that semantics.

## Changes

- **`packages/functions/.../api/score.rs`**:
  - `do_generate_score` now filters history to `HistoryOperationType::Position` (type=4, matching Java) — previously it counted **all** edit types in the window.
  - New `entry_weight`: Added/Modified weight = the number of top-level fields in the row's content JSON; Deleted = 1; unparsable content = 1.
  - `score_stat.content` now stores `{ "type": "DAY", "count": n, "fieldWeight": w }`.
  - `do_get_score_data` reads the real score via `score_from_content` (`fieldWeight`, falling back to `count` for legacy rows) — no more fixed 1.0.
- **`tests/rust/tests/api_db_test.rs`**: seeds 3 history rows (two Position with 3-field and 1-field content, one Area row that must be excluded), asserts `fieldWeight = 4`, `count = 2`, and that `do_get_score_data` reads back 4.0.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the weighting assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable — the roadmap's "known gaps" will be trimmed in a follow-up docs PR if desired)

## Breaking Changes

Scores change value (field-weighted instead of edit-counted) — this is the intended Java alignment.
