### PR TITLE
📝 Drop the resolved gaps from the roadmaps and design docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   weighting (3-field + 1-field rows → score 4, non-Position rows ignored)
   and the read-back.
 
+- Resync the gap documentation: the roadmap batch-4 status is now **Done**
+  (score weighting landed), and the punctuate-workflow design doc drops the
+  stale "audit permission" / "transactionality" / "field diff" follow-ups
+  (all fixed in the M2/M3 PRs); only the RSA/JWKS rotation gap remains.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/docs/en/guides/sync-with-java-roadmap.md
+++ b/docs/en/guides/sync-with-java-roadmap.md
@@ -44,7 +44,7 @@ current status.
 | 1 | **area + marker** (reference samples) | `Area`, `Marker`, `hiddenFlag`, `specialFlag`. Establishes the `SafeEntityTrait` pattern and the five-layer domain template every later port copies. | Medium | **Done** — used as the porting template |
 | 2 | **icon / item / tag families** | `Icon`, `IconType`, `IconTypeLink`, `Item`, `ItemType`, `ItemTypeLink`, plus the `Tag` / `TagType` taxonomy. Includes the `selectPageItemByCondition` `specialFlag` filter and copy/join/move_type. | Low–Medium | **Done** (covered by the `api_db` integration tests) |
 | 3 | **notice / route / history** | `Notice` (validity-sort rule), `Route`, `History`. `RouteVO` page/search/batch queries are wired. | Low–Medium | **Done** |
-| 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit, role-gated and transactional) and `ScoreStat` aggregation. | High | **Mostly done** — the score field-level diff (`ScoreDataPunctuateVo`) is not ported yet (current aggregation is simplified) |
+| 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit, role-gated and transactional) and `ScoreStat` aggregation (field-weighted). | High | **Done** |
 | 5 | **system (user / role / device / invitation)** | `SysUser`, `SysUserArchive`, `SysUserDevice` (login-anomaly detection), `SysUserInvitation`, `SysActionLog`, role listing, archive rename/delete_slot. | Medium | **Done** — device registration + access-policy checks are wired |
 | 6 | **BinaryMD5 archive export** | The GZIP-compressed, BinaryMD5-keyed producer for `item_doc` / `marker_doc` / `marker_link_doc`, with an in-process moka cache (300s TTL) and refresh endpoints. | High | **Done** |
 | 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Mostly done** — still HMAC (HS256) signing; the RSA keypair + JWK rotation are not implemented |
@@ -61,8 +61,6 @@ current status.
 
 ## Known gaps (remaining parity with Java)
 
-- Batch 4: `score::do_generate_score` is a simplified aggregation (counts
-  edits); the Java field-level diff (`ScoreDataPunctuateVo`) is not ported.
 - Batch 7: tokens are HMAC-SHA256; the Java side uses an RSA keypair with JWK
   rotation. The JWKS endpoint currently publishes the HMAC key in `oct` form;
   switching to RSA requires key management and rotation.

--- a/docs/zhs/designs/punctuate-workflow.md
+++ b/docs/zhs/designs/punctuate-workflow.md
@@ -159,9 +159,10 @@ Reviewing ───────────────────────�
 1. 每个贡献者写一行进 `score_stat`，作为评分基数。
 
 这条管线把「打点 → 审核 → 晋升 → 计入评分」闭环连起来：玩家打的点越多、通过率
-越高，`score_stat` 里的分数越高，社区里就能识别出靠谱的贡献者。Java 侧还有更
-精细的**字段级 diff**（`ScoreDataPunctuateVo`，按改动了多少个字段加权），Rust 侧
-当前是简化版（按编辑次数计数），完整字段 diff 列为后续待办（见 `score.rs:25` 注释）。
+越高，`score_stat` 里的分数越高，社区里就能识别出靠谱的贡献者。评分按 Java
+`ScoreDataPunctuateVo` 的语义做了**字段级加权**：每条打点记录的权重 = 其内容
+JSON 的字段数（改动规模越大分越高），Rust 侧在 `score.rs` 的 `entry_weight`
+实现（`Added`/`Modified` 按字段数、`Deleted` 计 1、解析失败计 1）。
 
 ## 7. 与 Java 实现的对齐
 
@@ -181,14 +182,5 @@ Rust 侧复用了 `SafeEntityTrait` 的软删除 + 乐观锁语义（见
 
 ## 8. 已知简化与后续待办
 
-- **打点计数的字段级 diff**：`do_generate_score` 目前按编辑次数计分，Java 侧按
-
-字段改动数加权。待补 `ScoreDataPunctuateVo` 的等价实现。
-
-- **审核侧权限**：`do_pass` / `do_reject` 的 `_auth: AuthInfo` 目前未做角色校验，
-
-生产部署前需在路由层补「仅编辑以上角色可调用」的中间件。
-
-- **晋升的事务性**：`do_pass` 里「写 marker + 删 punctuate」目前是两条独立 SQL，
-
-极端情况下（写成功、删失败）会留下孤儿 punctuate。后续可包进一个 sea-orm 事务。
+- **RSA/JWKS 轮换**：token 签名为 HMAC-SHA256（JWKS 以 `oct` 形式公布密钥）；
+  Java 侧为 RSA 密钥对 + JWK 轮换，切换时需引入密钥管理与轮换机制。

--- a/docs/zhs/guides/sync-with-java-roadmap.md
+++ b/docs/zhs/guides/sync-with-java-roadmap.md
@@ -17,7 +17,7 @@ Rust 后端的目标是与 Java 参考实现 `java-genshin-map-cloud` 功能对�
 | 1 | **area + marker** | `area`、`marker` 实体；CRUD + 软删除 + 乐观锁；`SafeEntityTrait` 宏定型 | 中 | **已完成** — 作为参考样板 |
 | 2 | **icon / item / tag 系列** | `icon`、`icon_type`、`item`、`item_type`、`item_common`、`tag`、`tag_type`；含 copy/join/move_type、`specialFlag` 过滤 | 中高 — 实体多、关联复杂 | **已完成**（`item_doc` 等由 api_db 测试覆盖） |
 | 3 | **notice / route / history** | `notice`、`route`、`history`（公共模型在 `models/common/`）；`RouteVO` 分页/搜索/批量查询 | 低中 — 结构相对独立 | **已完成** |
-| 4 | **打点审批流 + 评分** | `punctuate`、`punctuate_audit`（pass/reject/delete，含角色校验与事务化晋升）、`score`（data/generate） | 高 — 状态机 + 生成逻辑 | **大部分完成** — score 的字段级 diff（`ScoreDataPunctuateVo`）尚未移植（当前为简化聚合） |
+| 4 | **打点审批流 + 评分** | `punctuate`、`punctuate_audit`（pass/reject/delete，含角色校验与事务化晋升）、`score`（data/generate，字段级加权） | 高 — 状态机 + 生成逻辑 | **已完成** |
 | 5 | **系统域** | `user`、`role`、`device`、`invitation`、`action_log`、`archive`（rename/delete_slot 已补齐） | 中 — 鉴权与权限耦合 | **已完成** — 登录设备登记 + access_policy 校验已接线 |
 | 6 | **BinaryMD5 归档导出** | `item_doc`、`marker_doc`、`marker_link_doc` 的 bin/md5 端点；GZIP 压缩 + 进程内缓存（moka，300s TTL） | 高 — 二进制协议还原 | **已完成** |
 | 7 | **OAuth2 / JWKS** | `oauth` 路由（password / QQ / client_credentials）、`/.well-known/jwks.json`、access_policy 检查、scope 映射 | 高 — 安全敏感 | **大部分完成** — 仍为 HMAC(HS256) 签名；RSA 密钥对与 JWK 轮换尚未实现 |
@@ -32,8 +32,6 @@ Rust 后端的目标是与 Java 参考实现 `java-genshin-map-cloud` 功能对�
 
 ## 已知差距（与 Java 的剩余差异）
 
-- 批次 4：`score` 的 `do_generate_score` 为简化聚合（按编辑次数计分），
-  Java 的字段级 diff（`ScoreDataPunctuateVo`）未移植。
 - 批次 7：token 签名为 HMAC-SHA256；Java 侧为 RSA 密钥对 + JWK 轮换。
   当前 JWKS 以 `oct` 形式公布 HMAC 密钥；切换 RSA 时需引入密钥管理与轮换。
 - 数据库 schema 与真实库的偏差待数据验证（`marker_linkage` 空值列、


### PR DESCRIPTION
## Summary

Drop the resolved gaps from the roadmaps and design docs.

## Motivation

PR #40 (score field weighting) closed the last functional Java-parity gap, and the M2/M3 PRs already fixed the punctuate audit permission + transactionality items — but the docs still listed all of them as open follow-ups.

## Changes

- **`docs/zhs/guides/sync-with-java-roadmap.md`** / **`docs/en/...`**: batch 4 status → **Done**; the score field-diff item removed from "Known gaps" (only RSA/JWKS rotation, schema validation, translations remain).
- **`docs/zhs/designs/punctuate-workflow.md`**: §6 updated to describe the field-weighted scoring as implemented; §8 now lists only the RSA/JWKS rotation gap (the audit-permission and transactionality follow-ups are gone).
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] Docs-only change; no Rust code touched

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes (no Rust code touched)
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None.
