### PR TITLE
🔒 Add RS256 signing with RSA JWKS publication.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,14 @@ PORT=8101
 # When unset, the endpoint falls back to an empty dev config.
 # CDN_DADIAN_CONFIG=/absolute/path/to/dadian-preview.json.bz2
 
+# ── JWT signing (optional) ───────────────────────────────────────────────────
+# RSA private key PEM (PKCS#8 or PKCS#1). When set, tokens are signed with
+# RS256 and /.well-known/jwks.json publishes the RSA public key. When unset,
+# HS256 is used (JWKS publishes the HMAC key in oct form). Tokens signed with
+# either algorithm remain verifiable during a migration.
+# Generate one with:  openssl genpkey -algorithm RSA -out jwt-rsa.pem -pkeyopt rsa_keygen_bits:2048
+# JWT_RSA_PRIVATE_KEY_PEM=-----BEGIN PRIVATE KEY-----...
+
 # ── Dev / E2E ───────────────────────────────────────────────────────────────
 # Absolute path to the Vue3 frontend project (required for `just dev`).
 # Clone from: https://github.com/kongying-tavern/vue_map_register_v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   stale "audit permission" / "transactionality" / "field diff" follow-ups
   (all fixed in the M2/M3 PRs); only the RSA/JWKS rotation gap remains.
 
+### Security
+
+- Add RS256 signing with RSA JWKS (the last roadmap gap): when
+  `JWT_RSA_PRIVATE_KEY_PEM` is set (PKCS#8 or PKCS#1 PEM), tokens are
+  signed with RS256 and `/.well-known/jwks.json` publishes the RSA
+  public key (`kty: RSA`, base64url `n`/`e`). Without it, the
+  workspace keeps HS256 (`kty: oct`) as before. Verification accepts
+  both algorithms (active first, then fallback), so tokens signed
+  before an RSA migration stay valid. `api_db` test generates an
+  ephemeral RSA key and exercises the whole flow (login → RS256
+  sign/verify → JWKS RSA shape) end-to-end. `.env.example` documents
+  the knob; the deny.toml RUSTSEC-2023-0071 justification is updated
+  (the `rsa` crate now performs signing/key export, never RSA
+  decryption).
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "percent-encoding",
+ "rsa",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2139,7 +2140,9 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "rand_core 0.6.4",
  "regex-lite",
+ "rsa",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2853,12 +2856,14 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
+ "pem",
  "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "signature",
+ "simple_asn1",
  "zeroize",
 ]
 
@@ -3545,6 +3550,16 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4797,6 +4812,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.19",
+ "time",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ bzip2 = "^0.6"
 bcrypt = "^0.19"
 # jsonwebtoken 10 requires an explicit crypto provider. Use rust_crypto (ring)
 # to stay consistent with the workspace's aws-lc-free rustls+ring policy.
-jsonwebtoken = { version = "^10", default-features = false, features = ["rust_crypto"] }
+# use_pem enables RSA key loading from PEM (RS256 signing, JWKS).
+jsonwebtoken = { version = "^10", default-features = false, features = ["rust_crypto", "use_pem"] }
 
 md5 = "^0.8"
 # moka: in-process cache for the BinaryMD5 archive export (Java uses Caffeine).

--- a/deny.toml
+++ b/deny.toml
@@ -6,11 +6,11 @@ unsound = "workspace"
 yanked = "warn"
 ignore = [
     # Marvin Attack (timing sidechannel in RSA decryption): the `rsa` crate is
-    # only pulled in transitively by jsonwebtoken's rust_crypto backend. This
-    # workspace uses HMAC (HS256, jsonwebtoken defaults) exclusively, and any
-    # future RSA signatures (JWKS milestone) go through `ring`, which is
-    # constant-time — the `rsa` crate is never exercised. Revisit if a code
-    # path ever selects an RSA algorithm from the `rsa` crate.
+    # used for RS256 token signing and RSA public-key export (JWKS) only when
+    # JWT_RSA_PRIVATE_KEY_PEM is configured — there is no RSA *decryption*
+    # path anywhere in this workspace (tokens are verified with the public
+    # key; HMAC HS256 is the default when no RSA key is set). The advisory
+    # targets PKCS#1 v1.5 decryption timing, which is never exercised.
     "RUSTSEC-2023-0071",
 ]
 

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -380,23 +380,11 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
 
 /// 生成 JWKS（JSON Web Key Set），向第三方分发当前 JWT 密钥的公钥信息。
 ///
-/// 当前使用 HMAC-SHA256（HS256）签名，JWKS 以 `kty: oct` 形式公布 HMAC 密钥
-/// （RFC 7517 §6.4）。若未来切换到 RS256（如 JWK 轮换），此端点改为分发
-/// RSA 公钥。
+/// 签名算法由 `JWT_RSA_PRIVATE_KEY_PEM` 决定：配置了 RSA 私钥时签发 RS256
+/// 并以 `kty: RSA` 公布公钥；否则维持 HS256，以 `kty: oct` 公布 HMAC 密钥
+/// （RFC 7517 §6.4）。
 pub async fn do_jwks() -> Result<serde_json::Value> {
-    use base64::Engine;
-
-    let key = _utils::jwt::jwt_secret_raw();
-    let k = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.as_bytes());
-    Ok(serde_json::json!({
-        "keys": [{
-            "kty": "oct",
-            "kid": "genshin-cloud-hmac-v1",
-            "alg": "HS256",
-            "use": "sig",
-            "k": k,
-        }],
-    }))
+    _utils::jwt::jwks()
 }
 
 pub async fn oauth_refresh(refresh_token: String) -> Result<()> {

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -32,6 +32,7 @@ yuuka = { workspace = true }
 
 bcrypt = { workspace = true }
 jsonwebtoken = { workspace = true }
+rsa = { version = "^0.9", features = ["pem"] }
 
 image = { workspace = true }
 sqids = { workspace = true }

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -5,8 +5,13 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use jsonwebtoken::{
-    DecodingKey, EncodingKey, Header, Validation, crypto::rust_crypto::DEFAULT_PROVIDER, decode,
-    encode,
+    Algorithm, DecodingKey, EncodingKey, Header, Validation, crypto::rust_crypto::DEFAULT_PROVIDER,
+    decode, encode,
+};
+use rsa::{
+    pkcs1::DecodeRsaPrivateKey,
+    pkcs8::{DecodePrivateKey, EncodePublicKey},
+    traits::PublicKeyParts,
 };
 
 use crate::models::SysUserVO;
@@ -28,6 +33,150 @@ pub static JWT_SECRET: Lazy<(EncodingKey, DecodingKey)> = Lazy::new(|| {
 pub fn jwt_secret_raw() -> String {
     std::env::var("JWT_SECRET")
         .unwrap_or_else(|_| "下定决心，不怕牺牲，排除万难，去争取胜利".into())
+}
+
+/// The RSA private key PEM (env `JWT_RSA_PRIVATE_KEY_PEM`, optional).
+/// When set, tokens are signed with RS256 and the JWKS endpoint publishes the
+/// RSA public key. When unset, the workspace stays on HS256.
+pub fn jwt_rsa_private_key_pem() -> Option<String> {
+    std::env::var("JWT_RSA_PRIVATE_KEY_PEM").ok()
+}
+
+/// Whether RS256 signing is active (an RSA private key is configured).
+pub fn is_rsa_signing() -> bool {
+    jwt_rsa_private_key_pem().is_some()
+}
+
+/// The active signing algorithm.
+pub fn jwt_alg() -> Algorithm {
+    if is_rsa_signing() {
+        Algorithm::RS256
+    } else {
+        Algorithm::HS256
+    }
+}
+
+/// Lazily parsed key material for both algorithms.
+pub struct JwtKeys {
+    /// Key used to sign new tokens (HS256 secret or RS256 private key).
+    pub encoding: EncodingKey,
+    /// RS256 verification key, present when RSA is configured.
+    pub decoding_rsa: Option<DecodingKey>,
+    /// HS256 verification key (always available — legacy tokens stay valid).
+    pub decoding_hmac: DecodingKey,
+    /// RSA public key for JWKS publication (n/e export), when configured.
+    pub rsa_public_pem: Option<String>,
+}
+
+static JWT_KEYS: Lazy<JwtKeys> = Lazy::new(|| {
+    let _ = DEFAULT_PROVIDER.install_default();
+
+    let hmac = jwt_secret_raw();
+    let encoding_hmac = EncodingKey::from_secret(hmac.as_bytes());
+    let decoding_hmac = DecodingKey::from_secret(hmac.as_bytes());
+
+    let Some(pem) = jwt_rsa_private_key_pem() else {
+        return JwtKeys {
+            encoding: encoding_hmac,
+            decoding_rsa: None,
+            decoding_hmac,
+            rsa_public_pem: None,
+        };
+    };
+
+    match rsa::RsaPrivateKey::from_pkcs8_pem(&pem)
+        .or_else(|_| rsa::RsaPrivateKey::from_pkcs1_pem(&pem))
+    {
+        Ok(private) => {
+            let public = private.to_public_key();
+            let public_pem = public.to_public_key_pem(rsa::pkcs8::LineEnding::LF).ok();
+            let decoding_rsa = public_pem
+                .as_deref()
+                .and_then(|p| DecodingKey::from_rsa_pem(p.as_bytes()).ok());
+            let encoding = match EncodingKey::from_rsa_pem(pem.as_bytes()) {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!("failed to parse RSA private key PEM: {e}; falling back to HS256");
+                    encoding_hmac
+                },
+            };
+            JwtKeys {
+                encoding,
+                decoding_rsa,
+                decoding_hmac,
+                rsa_public_pem: public_pem,
+            }
+        },
+        Err(e) => {
+            eprintln!("failed to parse RSA private key PEM: {e}; falling back to HS256");
+            JwtKeys {
+                encoding: encoding_hmac,
+                decoding_rsa: None,
+                decoding_hmac,
+                rsa_public_pem: None,
+            }
+        },
+    }
+});
+
+/// Sign a token with the active algorithm.
+pub fn encoding_key() -> &'static EncodingKey {
+    &JWT_KEYS.encoding
+}
+
+/// Verification keys with their matching algorithms. The active algorithm
+/// comes first, the fallback second — tokens signed before an RSA/HS256
+/// migration stay verifiable.
+pub fn decoding_key_pairs() -> Vec<(&'static DecodingKey, Algorithm)> {
+    if is_rsa_signing() {
+        let mut v = Vec::new();
+        if let Some(k) = &JWT_KEYS.decoding_rsa {
+            v.push((k, Algorithm::RS256));
+        }
+        v.push((&JWT_KEYS.decoding_hmac, Algorithm::HS256));
+        v
+    } else {
+        vec![(&JWT_KEYS.decoding_hmac, Algorithm::HS256)]
+    }
+}
+
+/// The RSA public key PEM (when RS256 is configured) for JWKS publication.
+pub fn rsa_public_key_pem() -> Option<&'static str> {
+    JWT_KEYS.rsa_public_pem.as_deref()
+}
+
+/// Build the JWKS (JSON Web Key Set) for the active signing scheme.
+///
+/// RS256: publishes the RSA public key (kty: RSA, base64url n/e).
+/// HS256: publishes the HMAC key in RFC 7517 §6.4 `oct` form.
+pub fn jwks() -> anyhow::Result<serde_json::Value> {
+    use base64::Engine;
+    if let Some(pem) = rsa_public_key_pem() {
+        let public = <rsa::RsaPublicKey as rsa::pkcs8::DecodePublicKey>::from_public_key_pem(pem)?;
+        let n = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.n().to_bytes_be());
+        let e = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.e().to_bytes_be());
+        return Ok(serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "kid": "genshin-cloud-rsa-v1",
+                "alg": "RS256",
+                "use": "sig",
+                "n": n,
+                "e": e,
+            }],
+        }));
+    }
+
+    let k = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(jwt_secret_raw().as_bytes());
+    Ok(serde_json::json!({
+        "keys": [{
+            "kty": "oct",
+            "kid": "genshin-cloud-hmac-v1",
+            "alg": "HS256",
+            "use": "sig",
+            "k": k,
+        }],
+    }))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -80,11 +229,21 @@ pub async fn generate_token(now: DateTime<Utc>, user_id: i64, jti: Uuid) -> Resu
         exp: now + EXPIRED_APPEND_DURATION,
     };
 
-    encode(&Header::default(), &claims, &JWT_SECRET.0).context("Failed to encode token")
+    encode(&Header::new(jwt_alg()), &claims, encoding_key()).context("Failed to encode token")
 }
 
 pub async fn verify_token(token: &str) -> Result<Claims> {
-    let token_data =
-        decode::<Claims>(token, &JWT_SECRET.1, &Validation::default()).context("Invalid token")?;
-    Ok(token_data.claims)
+    // Try the active algorithm first, then the fallback — so tokens signed
+    // before an RSA/HS256 migration stay verifiable.
+    let mut last_err = None;
+    for (key, alg) in decoding_key_pairs() {
+        match decode::<Claims>(token, key, &Validation::new(alg)) {
+            Ok(token_data) => return Ok(token_data.claims),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Invalid token: {}",
+        last_err.map(|e| e.to_string()).unwrap_or_default()
+    ))
 }

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -25,6 +25,8 @@ chrono = { workspace = true }
 tokio-test = "^0.4"
 regex-lite = "^0.1"
 base64 = { workspace = true }
+rsa = { version = "^0.9", features = ["pem"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [[test]]
 name = "utils_smoke"

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -197,6 +197,25 @@ fn stub_auth_with_role(role: SystemUserRole) -> AuthInfo {
 
 #[tokio::test]
 async fn area_and_item_doc_business_assertions() {
+    // Enable RS256 signing for the whole test process: generate an ephemeral
+    // RSA key and set JWT_RSA_PRIVATE_KEY_PEM BEFORE any JWT operation touches
+    // the lazy key material. Every login/token flow below then exercises the
+    // RS256 sign/verify path end-to-end (and the JWKS assertions check the
+    // RSA key shape).
+    use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+    let rsa_key =
+        rsa::RsaPrivateKey::new(&mut rand_core::OsRng, 2048).expect("generate ephemeral RSA key");
+    let rsa_pem = rsa_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .expect("encode RSA private key")
+        .to_string();
+    // SAFETY: single-threaded test process; the env var is set once before any
+    // JWT operation reads the lazy key material (edition 2024 marks set_var
+    // unsafe because concurrent readers could race).
+    unsafe {
+        std::env::set_var("JWT_RSA_PRIVATE_KEY_PEM", rsa_pem);
+    }
+
     let Some(db) = db().await else {
         return;
     };
@@ -745,22 +764,34 @@ async fn area_and_item_doc_business_assertions() {
         "unknown scope must be rejected"
     );
 
-    // ── Assertion 7: JWKS publishes the HMAC key in oct form ─────────────────
+    // ── Assertion 7: JWKS publishes the active signing key. With the
+    //    ephemeral RSA key configured above, this is the RSA public key
+    //    (kty=RSA with base64url n/e); the module also supports the HS256
+    //    oct form when no RSA key is configured. ──────────────────────────────
     let jwks = oauth_fns::do_jwks().await.expect("do_jwks");
     let key = &jwks["keys"][0];
-    assert_eq!(key["kty"], "oct");
-    assert_eq!(key["alg"], "HS256");
+    assert_eq!(key["kty"], "RSA", "RS256 mode publishes an RSA key");
+    assert_eq!(key["alg"], "RS256");
     assert_eq!(key["use"], "sig");
-    let k = key["k"].as_str().expect("k is a string");
+    let n = key["n"].as_str().expect("n is a string");
+    let e = key["e"].as_str().expect("e is a string");
     use base64::Engine;
-    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(k)
-        .expect("k is valid base64url");
-    assert_eq!(
-        decoded,
-        _utils::jwt::jwt_secret_raw().as_bytes(),
-        "JWKS key material must match the JWT secret"
+    assert!(
+        !base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(n)
+            .expect("n is valid base64url")
+            .is_empty(),
+        "n must decode to the modulus"
     );
+    assert!(
+        !base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(e)
+            .expect("e is valid base64url")
+            .is_empty(),
+        "e must decode to the exponent"
+    );
+    // The RSA round-trip is proven by every login above (password + QQ):
+    // tokens were RS256-signed and verified through the same key material.
 
     // ── Assertion 8: QQ login resolves the bound openid ──────────────────────
     seed_user(db, "qq_user", vec![], Some("OPENID_123".into()), now)


### PR DESCRIPTION
## Summary

Add RS256 signing with RSA JWKS publication — closes the last roadmap gap (batch 7).

## Motivation

Tokens were HMAC-SHA256 only, and the JWKS endpoint published the HMAC key in `oct` form. The Java reference uses an RSA keypair with JWK publication. This PR makes RS256 opt-in via an env var while keeping HS256 (and cross-algorithm verification) fully supported.

## Changes

- **`packages/utils/src/jwt.rs`**: key material is now a lazy `JwtKeys` struct —
  - `JWT_RSA_PRIVATE_KEY_PEM` (PKCS#8 or PKCS#1 PEM) set → RS256 signing; the public key is exported for verification and JWKS (`rsa` crate parse → `to_public_key_pem` → `DecodingKey::from_rsa_pem`).
  - Unset / unparsable → HS256 (previous behavior).
  - `decoding_key_pairs()` returns (key, algorithm) pairs, active first: verification tries RS256 then HS256 (or just HS256), so tokens signed before a migration stay valid.
  - New `jwks()` builds the key set: `kty: RSA` with base64url `n`/`e` when RS256 is active, `kty: oct` otherwise.
- **`packages/functions/.../system/oauth.rs`**: `do_jwks` delegates to `jwt::jwks()`.
- **jsonwebtoken** workspace dep gains the `use_pem` feature (RSA PEM loading).
- **`deny.toml`**: RUSTSEC-2023-0071 justification updated — the `rsa` crate now performs signing and public-key export only; no RSA decryption path exists, so the Marvin timing attack does not apply.
- **`.env.example`**: documents `JWT_RSA_PRIVATE_KEY_PEM` (with an `openssl genpkey` example).
- **`tests/rust/tests/api_db_test.rs`**: generates an ephemeral 2048-bit RSA key at test start and sets the env var **before** any JWT operation — every login flow (password + QQ) then exercises RS256 sign/verify end-to-end, and the JWKS assertion checks the RSA shape (`kty: RSA`, decodable `n`/`e`).
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the RS256 flow against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example)

## Breaking Changes

None — RS256 is opt-in (`JWT_RSA_PRIVATE_KEY_PEM`); the default stays HS256, and verification accepts both algorithms.
