### PR TITLE
🌐 Translate the nine scaffolded documentation entry pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (the `rsa` crate now performs signing/key export, never RSA
   decryption).
 
+### Documentation
+
+- Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):
+  each language's `README.md` is now a real translated landing page (project
+  intro + full document index linking to the English content, which remains
+  the source of truth), and every `SUMMARY.md` language switcher now lists
+  all 11 languages with the current one highlighted. The previously
+  Chinese-only placeholders and truncated switchers are gone.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/docs/ar/README.md
+++ b/docs/ar/README.md
@@ -1,19 +1,43 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — الخادم الخلفي بلغة Rust
 
-> **العربية** 翻译正在进行中（Translation in progress）。
+> إعادة كتابة الخادم الخلفي «空荧酒馆 Genshin Map» بلغة Rust، بميزات متزامنة
+> مع التنفيذ المرجعي بلغة Java
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+هذا هو قسم التوثيق باللغة العربية. الخادم الخلفي هو مساحة عمل Cargo من أربع
+حزم (`utils → database → functions → router`) مبنية على `axum` و`sea-orm`
+(PostgreSQL) و`redis` و`minio`، مع `jsonwebtoken` + `bcrypt` للمصادقة. هذا
+القسم هو صفحة دخول فقط حاليًا؛ التوثيق الكامل متاح باللغة
+[الإنجليزية](../en/README.md) أو [الصينية المبسطة](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## فهرس التوثيق
+
+### الأدلة
+
+| الدليل | المحتوى |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | نظرة عامة على المشروع وتقنياته وبدء سريع |
+| [Glossary](../en/guides/glossary.md) | مصطلحات المجال (صيني-إنجليزي) |
+| [Architecture](../en/guides/architecture.md) | طبقات الحزم الأربع وتدفق الطلبات ونمط `SafeEntityTrait` |
+| [Building](../en/guides/building.md) | المتطلبات وأوامر `just` وملف `.env` وdocker-compose المحلي |
+| [API Reference](../en/guides/api-reference.md) | مجالات API التي يعرضها الموجّه (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | اصطلاح الالتزامات gitmoji |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | أولويات النقل من تنفيذ Java |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | قالب من خمس طبقات لنقل مجال Java إلى Rust |
+
+### التصميمات
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## لغات أخرى
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · **العربية** ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/ar/SUMMARY.md
+++ b/docs/ar/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · **[العربية]**(../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -1,19 +1,44 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Rust-Backend
 
-> **Deutsch** 翻译正在进行中（Translation in progress）。
+> Die Rust-Neuimplementierung des „空荧酒馆 Genshin Map“-Backends, funktionsgleich
+> mit der Java-Referenzimplementierung
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+Dies ist der deutschsprachige Dokumentationsbereich. Das Backend ist ein
+Cargo-Workspace aus vier Paketen (`utils → database → functions → router`) auf
+Basis von `axum`, `sea-orm` (PostgreSQL), `redis`, `minio` sowie
+`jsonwebtoken` + `bcrypt` für die Authentifizierung. Dieser Bereich ist derzeit
+nur eine Einstiegsseite; die vollständige Dokumentation finden Sie auf
+[English](../en/README.md) oder [简体中文](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## Dokumentationsindex
+
+### Anleitungen
+
+| Anleitung | Inhalt |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | Projektübersicht, Technologie-Stack, Schnellstart |
+| [Glossary](../en/guides/glossary.md) | Chinesisch-englische Fachbegriffe |
+| [Architecture](../en/guides/architecture.md) | Schichtung der vier Pakete, Request-Fluss, `SafeEntityTrait`-Muster |
+| [Building](../en/guides/building.md) | Voraussetzungen, `just`-Befehle, `.env`, lokales docker-compose |
+| [API Reference](../en/guides/api-reference.md) | Vom Router bereitgestellte API-Domänen (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | gitmoji-Commit-Konvention |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Portierungsreihenfolge aus der Java-Referenz |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Fünf-Schichten-Vorlage zum Portieren einer Java-Domäne nach Rust |
+
+### Designs
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## Andere Sprachen
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+**Deutsch** · [Português](../pt/README.md)

--- a/docs/de/SUMMARY.md
+++ b/docs/de/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · **[Deutsch]**(../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,19 +1,44 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Backend Rust
 
-> **Español** 翻译正在进行中（Translation in progress）。
+> La reescritura en Rust del backend « 空荧酒馆 Genshin Map », sincronizada con
+> la implementación de referencia en Java
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+Esta es la sección de documentación en español. El backend es un workspace de
+Cargo con cuatro paquetes (`utils → database → functions → router`) construido
+sobre `axum`, `sea-orm` (PostgreSQL), `redis`, `minio`, con `jsonwebtoken` +
+`bcrypt` para la autenticación. Esta sección es solo una página de entrada; la
+documentación completa está en [English](../en/README.md) o
+[简体中文](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## Índice de documentación
+
+### Guías
+
+| Guía | Contenido |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | Resumen del proyecto, stack técnico, inicio rápido |
+| [Glossary](../en/guides/glossary.md) | Terminología de dominio chino-inglés |
+| [Architecture](../en/guides/architecture.md) | Capas de los cuatro paquetes, flujo de peticiones, patrón `SafeEntityTrait` |
+| [Building](../en/guides/building.md) | Requisitos previos, comandos `just`, archivo `.env`, docker-compose local |
+| [API Reference](../en/guides/api-reference.md) | Dominios de API expuestos por el router (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | Convención de commits gitmoji |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Prioridad del portado desde la implementación Java |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Plantilla de cinco capas para portar un dominio Java a Rust |
+
+### Diseños
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## Otros idiomas
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+**Español** · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/es/SUMMARY.md
+++ b/docs/es/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · **[Español]**(../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,19 +1,44 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Backend Rust
 
-> **Français** 翻译正在进行中（Translation in progress）。
+> La réécriture en Rust du backend « 空荧酒馆 Genshin Map », synchronisée avec
+> l'implémentation de référence Java
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+Ceci est la section documentaire en français. Le backend est un workspace Cargo
+de quatre paquets (`utils → database → functions → router`) construit sur
+`axum`, `sea-orm` (PostgreSQL), `redis`, `minio`, avec `jsonwebtoken` + `bcrypt`
+pour l'authentification. Cette section n'est pour l'instant qu'une page
+d'accueil ; la documentation complète est disponible en
+[English](../en/README.md) ou [简体中文](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## Index de la documentation
+
+### Guides
+
+| Guide | Contenu |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | Présentation, stack technique, démarrage rapide |
+| [Glossary](../en/guides/glossary.md) | Terminologie de domaine chinois-anglais |
+| [Architecture](../en/guides/architecture.md) | Couches des quatre paquets, flux de requête, patron `SafeEntityTrait` |
+| [Building](../en/guides/building.md) | Prérequis, commandes `just`, fichier `.env`, docker-compose local |
+| [API Reference](../en/guides/api-reference.md) | Domaines d'API exposés par le routeur (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | Convention de commits gitmoji |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Ordre de priorité du portage depuis l'implémentation Java |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Gabarit en cinq couches pour porter un domaine Java en Rust |
+
+### Designs
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## Autres langues
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · **Français** ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/fr/SUMMARY.md
+++ b/docs/fr/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · **[Français]**(../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,19 +1,43 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Rust バックエンド
 
-> **日本語** 翻译正在进行中（Translation in progress）。
+> 「空荧酒館・原神マップ」バックエンドの Rust による書き直し。Java の参照実装
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud))
+> と機能を同期しています。
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+これは日本語ドキュメントセクションです。バックエンドは `axum`・`sea-orm`
+（PostgreSQL）・`redis`・`minio`・`jsonwebtoken` + `bcrypt` で構成された
+4 パッケージの Cargo workspace（`utils → database → functions → router`）です。
+このセクションは現在エントリーページのみで、完全なドキュメントは
+[English](../en/README.md) または [简体中文](../zhs/README.md) を参照してください。
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## ドキュメント索引
+
+### ガイド
+
+| ガイド | 内容 |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | プロジェクト概要・技術スタック・クイックスタート |
+| [Glossary](../en/guides/glossary.md) | 中英ドメイン用語集 |
+| [Architecture](../en/guides/architecture.md) | 4 パッケージのレイヤリング・リクエストフロー・`SafeEntityTrait` パターン |
+| [Building](../en/guides/building.md) | 前提条件・`just` コマンド・`.env`・ローカル docker-compose |
+| [API Reference](../en/guides/api-reference.md) | ルーターが公開する API ドメイン（area/icon/item/marker/punctuate/score/system…） |
+| [Commit Convention](../en/guides/commit-message-convention.md) | gitmoji コミット規約 |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Java 参照実装からの移植優先順位 |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Java ドメインを Rust へ移植する 5 層テンプレート |
+
+### 設計
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## 他の言語
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+**日本語** · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/ja/SUMMARY.md
+++ b/docs/ja/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · **[日本語]**(../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,19 +1,43 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Rust 백엔드
 
-> **한국어** 翻译正在进行中（Translation in progress）。
+> 「공영주점·원신 지도」백엔드의 Rust 재구현으로, Java 참조 구현
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud))
+> 과 기능을 맞춥니다.
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+한국어 문서 섹션입니다. 백엔드는 `axum`·`sea-orm`(PostgreSQL)·`redis`·`minio`·
+`jsonwebtoken` + `bcrypt`로 구성된 4패키지 Cargo 워크스페이스
+(`utils → database → functions → router`)입니다. 이 섹션은 현재 진입
+페이지이며, 전체 문서는 [English](../en/README.md) 또는
+[简体中文](../zhs/README.md)을 참조하세요.
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## 문서 색인
+
+### 가이드
+
+| 가이드 | 내용 |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | 프로젝트 개요·기술 스택·빠른 시작 |
+| [Glossary](../en/guides/glossary.md) | 중영 도메인 용어집 |
+| [Architecture](../en/guides/architecture.md) | 4패키지 계층·요청 흐름·`SafeEntityTrait` 패턴 |
+| [Building](../en/guides/building.md) | 전제 조건·`just` 명령·`.env`·로컬 docker-compose |
+| [API Reference](../en/guides/api-reference.md) | 라우터가 노출하는 API 도메인 (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | gitmoji 커밋 규약 |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Java 참조 구현 이식 우선순위 |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Java 도메인을 Rust로 이식하는 5계층 템플릿 |
+
+### 설계
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## 다른 언어
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · **한국어** · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · **[한국어]**(../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -1,19 +1,44 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Backend Rust
 
-> **Português** 翻译正在进行中（Translation in progress）。
+> A reescrita em Rust do backend « 空荧酒馆 Genshin Map », sincronizada com a
+> implementação de referência em Java
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+Esta é a seção de documentação em português. O backend é um workspace Cargo de
+quatro pacotes (`utils → database → functions → router`) construído sobre
+`axum`, `sea-orm` (PostgreSQL), `redis`, `minio`, com `jsonwebtoken` + `bcrypt`
+para autenticação. Esta seção é apenas uma página de entrada; a documentação
+completa está em [English](../en/README.md) ou
+[简体中文](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## Índice da documentação
+
+### Guias
+
+| Guia | Conteúdo |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | Visão geral do projeto, stack, início rápido |
+| [Glossary](../en/guides/glossary.md) | Terminologia de domínio chinês-inglês |
+| [Architecture](../en/guides/architecture.md) | Camadas dos quatro pacotes, fluxo de requisições, padrão `SafeEntityTrait` |
+| [Building](../en/guides/building.md) | Pré-requisitos, comandos `just`, arquivo `.env`, docker-compose local |
+| [API Reference](../en/guides/api-reference.md) | Domínios de API expostos pelo roteador (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | Convenção de commits gitmoji |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Prioridade do port da implementação Java |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Modelo de cinco camadas para portar um domínio Java para Rust |
+
+### Designs
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## Outros idiomas
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · **Português**

--- a/docs/pt/SUMMARY.md
+++ b/docs/pt/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · **[Português]**(../pt/SUMMARY.md)

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,19 +1,44 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — бэкенд на Rust
 
-> **Русский** 翻译正在进行中（Translation in progress）。
+> Переписывание бэкенда «空荧酒馆 Genshin Map» на Rust с синхронизацией
+> функций с эталонной реализацией на Java
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud)).
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+Это раздел документации на русском языке. Бэкенд представляет собой Cargo
+workspace из четырёх пакетов (`utils → database → functions → router`) на
+`axum`, `sea-orm` (PostgreSQL), `redis`, `minio`, с `jsonwebtoken` + `bcrypt`
+для аутентификации. Этот раздел пока является только входной страницей;
+полная документация доступна на [English](../en/README.md) или
+[简体中文](../zhs/README.md).
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## Индекс документации
+
+### Руководства
+
+| Руководство | Содержание |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | Обзор проекта, стек, быстрый старт |
+| [Glossary](../en/guides/glossary.md) | Китайско-английская терминология |
+| [Architecture](../en/guides/architecture.md) | Слои четырёх пакетов, поток запросов, паттерн `SafeEntityTrait` |
+| [Building](../en/guides/building.md) | Требования, команды `just`, файл `.env`, локальный docker-compose |
+| [API Reference](../en/guides/api-reference.md) | Домены API роутера (area/icon/item/marker/punctuate/score/system…) |
+| [Commit Convention](../en/guides/commit-message-convention.md) | Соглашение о коммитах gitmoji |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | Приоритеты переноса из Java-реализации |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | Шаблон из пяти слоёв для переноса Java-домена в Rust |
+
+### Дизайн
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## Другие языки
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · [繁體中文](../zht/README.md) ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · **Русский** · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/ru/SUMMARY.md
+++ b/docs/ru/SUMMARY.md
@@ -29,4 +29,4 @@
 ---
 
 语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md) · [日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) · [Español](../es/SUMMARY.md) · **[Русский]**(../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) · [Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)

--- a/docs/zht/README.md
+++ b/docs/zht/README.md
@@ -1,19 +1,42 @@
-# 空荧酒馆·原神地图 Rust 后端 / Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Rust 後端
 
-> **繁體中文** 翻译正在进行中（Translation in progress）。
+> 「空熒酒館·原神地圖」後端的 Rust 重寫，與 Java 參考實作
+> ([`java-genshin-map-cloud`](https://github.com/kongying-tavern/java-genshin-map-cloud))
+> 功能對齊。
 
-完整文档请暂时参阅 / For the full documentation, please refer to:
-
-- **[简体中文 / Simplified Chinese](../zhs/README.md)**
-- **[English](../en/README.md)**
-
-本项目是「空荧酒馆·原神地图」后端的 Rust 实现，与 Java 侧参考实现
-（`java-genshin-map-cloud`）功能对齐。
-
-This project is the Rust rewrite of the "空荧酒馆 Genshin Map" backend,
-feature-synced with the Java reference implementation.
+這是繁體中文文件區。後端是以 `axum`、`sea-orm`（PostgreSQL）、`redis`、
+`minio`、`jsonwebtoken` + `bcrypt` 組成的四套件 Cargo workspace
+（`utils → database → functions → router`）。本區目前為入口頁，
+完整文件請見 [English](../en/README.md) 或 [简体中文](../zhs/README.md)。
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/README.md) · [简体中文](../zhs/README.md) · [繁體中文](../zht/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) · [Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) · [Deutsch](../de/README.md) · [Português](../pt/README.md)
+## 文件索引
+
+### 指南（Guides）
+
+| 指南 | 內容 |
+| --- | --- |
+| [Detailed README](../en/guides/README.md) | 專案總覽、技術棧、快速開始 |
+| [Glossary](../en/guides/glossary.md) | 中英領域術語對照 |
+| [Architecture](../en/guides/architecture.md) | 四套件分層、請求流、`SafeEntityTrait` 模式 |
+| [Building](../en/guides/building.md) | 前置條件、`just` 指令、`.env`、本機 docker-compose |
+| [API Reference](../en/guides/api-reference.md) | 路由暴露的 API 域（area/icon/item/marker/punctuate/score/system…） |
+| [Commit Convention](../en/guides/commit-message-convention.md) | gitmoji 提交規範 |
+| [Java Sync Roadmap](../en/guides/sync-with-java-roadmap.md) | 從 Java 參考實作移植的優先順序 |
+| [Domain Sync Template](../en/guides/domain-sync-template.md) | 單一 Java 域移植到 Rust 的五層模板 |
+
+### 設計（Designs）
+
+- [Punctuate Workflow](../en/designs/punctuate-workflow.md)
+- [BinaryMD5 Archive Export](../en/designs/binarymd5-archive-export.md)
+- [Hidden and Special Flags](../en/designs/hidden-and-special-flags.md)
+
+---
+
+## 其他語言
+
+[简体中文](../zhs/README.md) · [English](../en/README.md) · **繁體中文** ·
+[日本語](../ja/README.md) · [한국어](../ko/README.md) · [Français](../fr/README.md) ·
+[Español](../es/README.md) · [Русский](../ru/README.md) · [العربية](../ar/README.md) ·
+[Deutsch](../de/README.md) · [Português](../pt/README.md)

--- a/docs/zht/SUMMARY.md
+++ b/docs/zht/SUMMARY.md
@@ -1,12 +1,11 @@
-# Genshin Map Cloud — Rust Backend
+# Genshin Map Cloud — Rust 後端
 
-[Overview](./README.md)
+[概述](./README.md)
 
 ---
 
-> **繁體中文** translation is in progress. The complete table of contents is
-> available in [English](../en/SUMMARY.md) and
-> [Simplified Chinese](../zhs/SUMMARY.md).
+> **繁體中文** 翻譯進行中。完整目錄請見
+> [English](../en/SUMMARY.md) 與 [简体中文](../zhs/SUMMARY.md)。
 
 # Guides
 
@@ -28,5 +27,8 @@
 
 ---
 
-语言切换 / Language switcher:
-[English](../en/SUMMARY.md) · [简体中文](../zhs/SUMMARY.md) · [繁體中文](../zht/SUMMARY.md)
+其他語言 / Language switcher:
+[简体中文](../zhs/SUMMARY.md) · [English](../en/SUMMARY.md) · **繁體中文** ·
+[日本語](../ja/SUMMARY.md) · [한국어](../ko/SUMMARY.md) · [Français](../fr/SUMMARY.md) ·
+[Español](../es/SUMMARY.md) · [Русский](../ru/SUMMARY.md) · [العربية](../ar/SUMMARY.md) ·
+[Deutsch](../de/SUMMARY.md) · [Português](../pt/SUMMARY.md)


### PR DESCRIPTION
## Summary

Translate the nine scaffolded documentation entry pages (ar/de/es/fr/ja/ko/pt/ru/zht).

## Motivation

The 9 non-default language directories each had only a Chinese placeholder README ("翻译进行中 / Translation in progress" written in Chinese, not the target language) and a SUMMARY whose language switcher listed just 3 languages.

## Changes

- **`docs/{ar,de,es,fr,ja,ko,pt,ru,zht}/README.md`**: real translated landing pages — project intro + full document index (Guides table + Designs list) in each target language, linking to the English content (the source of truth for the un-translated guides/designs). The language switcher lists all 11 languages with the current one highlighted.
- **`docs/{ar,de,es,fr,ja,ko,pt,ru}/SUMMARY.md`**: the language switcher now lists all 11 languages with the current one highlighted (zht already updated in the same pass).
- **`CHANGELOG.md`**: Unreleased entry.

## Design note

Fully translating all 14 guides × 9 languages (126 documents) is not practical for a single pass and would create a huge maintenance burden. The chosen pattern — translated landing pages + full index linking to English — is the standard community approach and keeps English as the single source of truth. Native speakers can fill in individual guides over time.

## Test Plan

- [x] `celestia-devtools format-markdown . --check` passes (exit 0; only informational i18n warnings for the intentionally identical en-linked index lists)
- [x] Docs-only change; no Rust code touched

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes (no Rust code touched)
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None.
