### PR TITLE
📝 Clarify the stale schema TODOs in the entity models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   all 11 languages with the current one highlighted. The previously
   Chinese-only placeholders and truncated switchers are gone.
 
+- Clarify the stale schema TODOs (PLAN.md F11, docs-only): the
+  `marker_linkage` "cannot be null" TODOs contradicted the already
+  non-null field types (removed); its `path` FIXME now states why the
+  type stays loose (no real data samples yet). `sys_user_archive.data`
+  documents the intentional opaque-JSON design, and `sys_user_device.status`
+  documents the `0 = normal / non-zero = disabled` convention used by the
+  OAuth access-policy checks.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/database/src/models/marker/marker_linkage.rs
+++ b/packages/database/src/models/marker/marker_linkage.rs
@@ -23,25 +23,21 @@ pub struct Model {
     pub del_flag: bool,
 
     /// 组 ID
-    /// TODO: 更正实际数据库中的表关系，这个列其实不能为空
     pub group_id: String,
     /// 起始点点位 ID
     /// 会根据是否反向与 to_id 交换
-    /// TODO: 更正实际数据库中的表关系，这个列其实不能为空
     pub from_id: i64,
     /// 终止点点位 ID
     /// 会根据是否反向与 from_id 交换
-    /// TODO: 更正实际数据库中的表关系，这个列其实不能为空
     pub to_id: i64,
     /// 关联操作类型
-    /// TODO: 更正实际数据库中的表关系，这个列其实不能为空
     pub link_action: MarkerLinkageLinkAction,
     /// 是否反向
-    /// TODO: 更正实际数据库中的表关系，这个列其实不能为空
     pub link_reverse: bool,
     /// 路线
-    /// 默认为空数组
-    /// FIXME: 数据库里没有任何数据案例，全是空数组，这里的进一步类型限制就暂时做不了
+    /// 默认为空数组。类型保持宽松（`Option<Json>`）：当前数据库样本中该列
+    /// 均为空数组，缺少真实数据案例，进一步的结构化（如固定字段的路线
+    /// 类型）待真实数据验证后再收紧。
     pub path: Option<serde_json::Value>,
     /// 额外数据
     pub extra: Option<serde_json::Value>,

--- a/packages/database/src/models/system/sys_user_archive.rs
+++ b/packages/database/src/models/system/sys_user_archive.rs
@@ -29,7 +29,8 @@ pub struct Model {
     #[sea_orm(indexed)]
     pub user_id: i64,
     /// 存档信息
-    /// TODO: 绑定一个完整的存档数据结构
+    /// 存档内容由前端定义（自由 JSON 结构），后端按不透明 blob 存取；
+    /// 刻意不做强类型绑定，避免在存档格式演进时破坏既有存档。
     pub data: serde_json::Value,
 }
 

--- a/packages/database/src/models/system/sys_user_device.rs
+++ b/packages/database/src/models/system/sys_user_device.rs
@@ -29,7 +29,9 @@ pub struct Model {
     /// IPv4
     pub ipv4: Option<String>,
     /// 设备状态
-    /// TODO: 测试数据库里，这个值似乎全是 0
+    /// 0 = 正常（登录时登记/刷新）；非 0 = 禁用。OAuth access_policy 的
+    /// `dev:block_disallow_device` / `ip:block_disallow_ip` 策略按
+    /// `status != 0` 判定命中并拒绝登录（见 oauth.rs 的 check_access_policy）。
     pub status: i32,
     /// 上次登录时间
     pub last_login_time: Option<DateTime>,


### PR DESCRIPTION
## Summary

Clarify the stale schema TODOs in the entity models — PLAN.md F11 (docs-only portion).

## Motivation

Three entity files carried misleading comments:
- `marker_linkage.rs` had 5× "TODO: 更正实际数据库中的表关系，这个列其实不能为空" — but the fields were **already non-null types** (`String`/`i64`/enum/`bool`), so the TODOs contradicted the code.
- `sys_user_archive.rs` said "TODO: 绑定一个完整的存档数据结构" — but archive content is intentionally frontend-defined free JSON.
- `sys_user_device.rs` said "测试数据库里，这个值似乎全是 0" — but `status` now has real semantics (the OAuth access-policy checks use `status != 0` as "disabled").

## Changes

- **`marker_linkage.rs`**: removed the 5 contradictory TODOs; the `path` FIXME now explains that the loose `Option<Json>` type is deliberate pending real data samples.
- **`sys_user_archive.rs`**: documents the intentional opaque-JSON design (no strong typing to avoid breaking existing archives on format evolution).
- **`sys_user_device.rs`**: documents `0 = normal / non-zero = disabled` and its use by `check_access_policy`.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean (comment-only change)
- [x] Docs-only change; no behavior touched

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (comment-only)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None — comment-only.
