### PR TITLE
🐛 Align the icon entity with the legacy name and url columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (the old schema has no such FK). Verified against the full 461 MB
   legacy dump: the remaining 22 shared tables now match column-for-column.
 
+- Align the `icon` entity with the legacy Java database: the old schema
+  has only `name` + `url` columns; the `tag` / `description` /
+  `url_variants` columns (and the now-unused `IconURLVariants` type)
+  are removed, the entity and `IconVO` now expose `name` (the request
+  model already used `name` — `do_add` previously mis-stored it into
+  `tag`). The name filter now queries `name` instead of `tag`.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/database/src/models/icon/icon.rs
+++ b/packages/database/src/models/icon/icon.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use _utils::{impl_safe_operation, types::IconURLVariants};
+use _utils::impl_safe_operation;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "icon", schema_name = "genshin_map")]
@@ -22,15 +22,10 @@ pub struct Model {
     /// 逻辑删除
     pub del_flag: bool,
 
+    /// 图标名称（旧库列名 `name`，与 Java 侧一致）
+    pub name: String,
     /// 图标 URL
     pub url: String,
-    /// 图标标签
-    pub tag: String,
-    /// 图标描述
-    pub description: String,
-    /// 图标变体 URL 信息
-    #[sea_orm(column_type = "Json")]
-    pub url_variants: IconURLVariants,
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, DeriveRelation)]

--- a/packages/functions/src/functions/api/icon.rs
+++ b/packages/functions/src/functions/api/icon.rs
@@ -36,11 +36,8 @@ pub async fn do_add(
         updater_id: Set(None),
         del_flag: Set(false),
 
-        // 数据库列：url, tag, description, url_variants
+        name: Set(payload.name),
         url: Set(payload.url),
-        tag: Set(payload.name),
-        description: Set(String::new()),
-        url_variants: Set(Default::default()),
     };
 
     let res = active.insert(&DB_CONN.wait().pg_conn).await?;
@@ -62,7 +59,7 @@ pub async fn do_list(
         query = query.filter(icon_model::Column::Id.is_in(ids));
     }
     if let Some(name) = payload.name {
-        query = query.filter(icon_model::Column::Tag.contains(name));
+        query = query.filter(icon_model::Column::Name.contains(name));
     }
 
     let total = query.clone().count(&DB_CONN.wait().pg_conn).await?;
@@ -80,10 +77,8 @@ pub async fn do_list(
     for it in items {
         arr.push(IconVO {
             id: it.id,
+            name: it.name,
             url: it.url,
-            tag: it.tag,
-            description: it.description,
-            url_variants: it.url_variants,
         });
     }
     let payload = IconListResponse {
@@ -102,10 +97,8 @@ pub async fn do_get_single(_auth: AuthInfo, id: i64) -> Result<CommonResponse<Ic
     let payload = IconSingleResponse {
         item: IconVO {
             id: item.id,
+            name: item.name,
             url: item.url,
-            tag: item.tag,
-            description: item.description,
-            url_variants: item.url_variants,
         },
     };
     Ok(CommonResponse::new(Ok(payload)))
@@ -132,7 +125,7 @@ pub async fn do_update(_auth: AuthInfo, payload: IconUpdateRequest) -> Result<Co
         .await?;
     let item = item.ok_or(anyhow!("Icon not found"))?;
     let mut am: icon_model::ActiveModel = item.into();
-    am.tag = Set(payload.base.name);
+    am.name = Set(payload.base.name);
     am.url = Set(payload.base.url);
     icon_model::Entity::update_safety(am)?
         .exec(&DB_CONN.wait().pg_conn)

--- a/packages/utils/src/models/icon.rs
+++ b/packages/utils/src/models/icon.rs
@@ -48,10 +48,8 @@ pub struct IconListRequest {
 #[serde(rename_all = "camelCase")]
 pub struct IconVO {
     pub id: i64,
+    pub name: String,
     pub url: String,
-    pub tag: String,
-    pub description: String,
-    pub url_variants: crate::types::IconURLVariants,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/packages/utils/src/types/icon.rs
+++ b/packages/utils/src/types/icon.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use strum::EnumIter;
 
-use sea_orm::FromJsonQueryResult;
 use sea_orm::prelude::*;
 
 #[derive(
@@ -26,15 +24,3 @@ pub enum IconStyleType {
     #[sea_orm(num_value = 3)]
     Oculus = 3,
 }
-
-// SeaORM requires JSON column types to implement certain traits like
-// `FromJsonQueryResult` / `TryGetableFromJson` / `ValueType`. A plain
-// `HashMap<String, String>` does not implement those. Wrap it in a
-// newtype and derive `FromJsonQueryResult` so it can be used directly in
-// entity models as `#[sea_orm(column_type = "Json")]`.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, FromJsonQueryResult)]
-pub struct IconURLVariantsWrapper(pub HashMap<String, String>);
-
-// Keep a compatibility alias used by other codepaths in the repo. Prefer
-// `IconURLVariantsWrapper` for DB models that require SeaORM traits.
-pub type IconURLVariants = IconURLVariantsWrapper;


### PR DESCRIPTION
## Summary

Align the `icon` entity with the legacy Java database — second legacy-schema alignment PR.

## Motivation

The legacy `icon` table has only `name` + `url` columns, but our entity had `url` / `tag` / `description` / `url_variants`. Querying the legacy database with our entity would fail (`column "description" does not exist`), and the legacy data's `name` was never readable. Additionally, `do_add` received a `name` in the request but mis-stored it into `tag` with an empty `description`.

## Changes

- **Entity** (`icon.rs`): columns → `name` + `url` (matching the old DDL); the `IconURLVariants` JSON type and its wrapper are removed (no longer referenced anywhere).
- **VO** (`IconVO`): `id` + `name` + `url` (was `id`/`url`/`tag`/`description`/`url_variants`).
- **Business** (`icon.rs`): `do_add` stores `name` + `url` correctly; the list name filter queries `Column::Name`; `do_update` sets `name`.
- **`types/icon.rs`**: `IconURLVariants` / `IconURLVariantsWrapper` deleted; unused imports cleaned.
- **CHANGELOG**: Unreleased entry.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Offline diff vs the legacy dump: `icon` now matches column-for-column (`name`, `url`)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

`IconVO` drops `tag` / `description` / `urlVariants` and adds `name` — matching the legacy frontend contract (the request model already used `name`).
