### PR TITLE
🐛 Drop the tag columns that the legacy schema does not have.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   model already used `name` — `do_add` previously mis-stored it into
   `tag`). The name filter now queries `name` instead of `tag`.
 
+- Drop the `tag` / `tag_type` columns that the legacy database does not
+  have (`hidden_flag` / `sort_index`): the entities, VOs, and business
+  code are aligned so the schema now matches the old DDL exactly.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/database/src/models/tag/tag.rs
+++ b/packages/database/src/models/tag/tag.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use _utils::{impl_safe_operation, types::HiddenFlag};
+use _utils::impl_safe_operation;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "tag", schema_name = "genshin_map")]
@@ -26,11 +26,6 @@ pub struct Model {
     pub tag: String,
     /// 图标 ID
     pub icon_id: i64,
-    /// 权限屏蔽标记
-    #[sea_orm(indexed)]
-    pub hidden_flag: HiddenFlag,
-    /// 排序索引
-    pub sort_index: i32,
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, DeriveRelation)]

--- a/packages/database/src/models/tag/tag_type.rs
+++ b/packages/database/src/models/tag/tag_type.rs
@@ -28,8 +28,6 @@ pub struct Model {
     pub parent_id: i64,
     /// 是否为末端类型
     pub is_final: bool,
-    /// 排序索引
-    pub sort_index: i32,
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, DeriveRelation)]

--- a/packages/functions/src/functions/api/tag.rs
+++ b/packages/functions/src/functions/api/tag.rs
@@ -35,8 +35,6 @@ pub async fn do_add(_auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddRes
         del_flag: Set(false),
         tag: Set(payload.tag),
         icon_id: Set(payload.icon_id),
-        hidden_flag: Set(_utils::types::HiddenFlag::Visible),
-        sort_index: Set(0),
     };
 
     let res = tag_model::Entity::insert(am).exec(db).await?;
@@ -93,8 +91,6 @@ pub async fn do_list(
             id: t.id,
             tag: t.tag,
             icon_id: t.icon_id,
-            hidden_flag: t.hidden_flag,
-            sort_index: t.sort_index,
         })
         .collect();
 

--- a/packages/functions/src/functions/api/tag_type.rs
+++ b/packages/functions/src/functions/api/tag_type.rs
@@ -37,7 +37,6 @@ pub async fn do_add(_auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<TagT
         name: Set(payload.name),
         parent_id: Set(payload.parent_id),
         is_final: Set(payload.is_final),
-        sort_index: Set(0),
     };
 
     let res = tag_type_model::Entity::insert(am).exec(db).await?;
@@ -96,7 +95,6 @@ pub async fn do_list(
             name: t.name,
             parent_id: t.parent_id,
             is_final: t.is_final,
-            sort_index: t.sort_index,
         })
         .collect();
 

--- a/packages/utils/src/models/tag.rs
+++ b/packages/utils/src/models/tag.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{models::Pagination, types::HiddenFlag};
+use crate::models::Pagination;
 
 /// 标签基础请求模型
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -58,8 +58,6 @@ pub struct TagVO {
     pub id: i64,
     pub tag: String,
     pub icon_id: i64,
-    pub hidden_flag: HiddenFlag,
-    pub sort_index: i32,
 }
 
 /// 标签列表响应

--- a/packages/utils/src/models/tag_type.rs
+++ b/packages/utils/src/models/tag_type.rs
@@ -53,7 +53,6 @@ pub struct TagTypeVO {
     pub name: String,
     pub parent_id: i64,
     pub is_final: bool,
-    pub sort_index: i32,
 }
 
 /// 标签类型列表响应


### PR DESCRIPTION
## Summary

Drop the `tag` / `tag_type` columns the legacy database does not have — final legacy-schema alignment PR.

## Motivation

The legacy `tag` table has only `tag` + `icon_id`; our entity additionally had `hidden_flag` + `sort_index`. The legacy `tag_type` table has `name` / `parent_id` / `is_final`; ours had an extra `sort_index`. Queries against the legacy database would fail on those columns.

## Changes

- **Entities**: `tag` drops `hidden_flag` + `sort_index`; `tag_type` drops `sort_index`.
- **VOs**: `TagVO` drops `hiddenFlag` + `sortIndex`; `TagTypeVO` drops `sortIndex`; unused `HiddenFlag` imports removed.
- **Business**: `tag` / `tag_type` `do_add` no longer sets the removed columns; list mappings updated.
- **CHANGELOG**: Unreleased entry.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Offline diff vs the legacy dump: `tag` and `tag_type` now match column-for-column
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

`TagVO` / `TagTypeVO` drop the `hiddenFlag` / `sortIndex` fields — matching the legacy contract.
