### PR TITLE
🐛 Align the text column types with the legacy schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   have (`hidden_flag` / `sort_index`): the entities, VOs, and business
   code are aligned so the schema now matches the old DDL exactly.
 
+- Align the text-column types with the legacy database: 11 long-text
+  fields across history / item / marker / marker_punctuate / notice /
+  route / sys_user / sys_user_invitation now use `Text` instead of
+  the default `varchar`, so the generated DDL matches the old schema
+  exactly (verified column-for-column, type-for-type against the
+  461 MB legacy dump).
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/database/src/models/common/history.rs
+++ b/packages/database/src/models/common/history.rs
@@ -26,6 +26,7 @@ pub struct Model {
     pub del_flag: bool,
 
     /// 内容
+    #[sea_orm(column_type = "Text")]
     pub content: String,
     /// MD5
     pub md5: Option<String>,

--- a/packages/database/src/models/common/notice.rs
+++ b/packages/database/src/models/common/notice.rs
@@ -27,6 +27,7 @@ pub struct Model {
     /// 标题
     pub title: String,
     /// 内容
+    #[sea_orm(column_type = "Text")]
     pub content: Option<String>,
     /// 有效期开始时间
     pub valid_time_start: Option<DateTime>,

--- a/packages/database/src/models/common/route.rs
+++ b/packages/database/src/models/common/route.rs
@@ -33,6 +33,7 @@ pub struct Model {
     #[sea_orm(indexed)]
     pub hidden_flag: HiddenFlag,
     /// 视频地址
+    #[sea_orm(column_type = "Text")]
     pub video: Option<String>,
     /// 额外信息
     pub extra: serde_json::Value,

--- a/packages/database/src/models/item/item.rs
+++ b/packages/database/src/models/item/item.rs
@@ -37,6 +37,7 @@ pub struct Model {
     pub default_refresh_time: i64,
     /// 默认描述模板
     /// 用于提交新物品点位时的描述模板
+    #[sea_orm(column_type = "Text")]
     pub default_content: Option<String>,
     /// 默认数量
     #[sea_orm(default_value = 1)]

--- a/packages/database/src/models/marker/marker.rs
+++ b/packages/database/src/models/marker/marker.rs
@@ -31,8 +31,10 @@ pub struct Model {
     /// 形如 "{x},{y}" 的格式，其中 x 与 y 均为浮点数文本
     pub position: String,
     /// 点位说明
+    #[sea_orm(column_type = "Text")]
     pub content: String,
     /// 点位图片
+    #[sea_orm(column_type = "Text")]
     pub picture: Option<String>,
     /// 点位初始标记者
     pub marker_creator_id: i64,

--- a/packages/database/src/models/marker/marker_punctuate.rs
+++ b/packages/database/src/models/marker/marker_punctuate.rs
@@ -38,8 +38,10 @@ pub struct Model {
     /// 点位坐标
     pub position: String,
     /// 点位说明
+    #[sea_orm(column_type = "Text")]
     pub content: String,
     /// 点位图片
+    #[sea_orm(column_type = "Text")]
     pub picture: Option<String>,
     /// 点位初始标记者
     pub marker_creator_id: i64,

--- a/packages/database/src/models/system/sys_user.rs
+++ b/packages/database/src/models/system/sys_user.rs
@@ -41,6 +41,7 @@ pub struct Model {
     #[sea_orm(indexed)]
     pub phone: Option<String>,
     /// 头像链接
+    #[sea_orm(column_type = "Text")]
     pub logo: Option<String>,
 
     /// 角色
@@ -49,6 +50,7 @@ pub struct Model {
     #[sea_orm(column_type = "Json")]
     pub access_policy: AccessPolicyList,
     /// 备注
+    #[sea_orm(column_type = "Text")]
     pub remark: Option<String>,
 }
 

--- a/packages/database/src/models/system/sys_user_invitation.rs
+++ b/packages/database/src/models/system/sys_user_invitation.rs
@@ -29,6 +29,7 @@ pub struct Model {
     /// 角色 ID
     pub role_id: Option<SystemUserRole>,
     /// 备注
+    #[sea_orm(column_type = "Text")]
     pub remark: Option<String>,
     /// 权限策略
     pub access_policy: Option<serde_json::Value>,


### PR DESCRIPTION
## Summary

Align the text-column types with the legacy schema — the DDL-level completion of the legacy database alignment.

## Motivation

The final offline diff (23 entities vs the 461 MB legacy dump) showed one remaining DDL difference: 11 long-text fields used `varchar` where the legacy schema uses `text`. Runtime-compatible, but the generated DDL did not match the old schema exactly.

## Changes

- `#[sea_orm(column_type = "Text")]` on: `history.content`, `item.default_content`, `marker.content`, `marker.picture`, `marker_punctuate.content`, `marker_punctuate.picture`, `notice.content`, `route.video`, `sys_user.logo`, `sys_user.remark`, `sys_user_invitation.remark`.
- **CHANGELOG**: Unreleased entry.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Offline diff: column sets **and** types now match the legacy dump exactly (0 column-set issues, 0 type issues)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — same Rust types, only the generated DDL type name changes.
