### PR TITLE
🐛 Make four columns nullable to match the legacy data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   exactly (verified column-for-column, type-for-type against the
   461 MB legacy dump).
 
+- Make four columns nullable to match the legacy data: `score_stat.content`
+  (18 047 NULL rows in the dump), `sys_action_log.extra_data` (2 406),
+  `sys_user.access_policy` (197), and `route.extra` (1) were non-Option
+  in our entities but nullable in the legacy schema with actual NULL
+  data — reading the legacy database would have failed on those rows.
+  Entities and business code (score read-back, oauth policy checks,
+  route VO mapping, register/update writes, action-log writes) are
+  updated; `Option` accessors unwrap to defaults where the value is
+  always written by us.
+
 ## [0.2.0] - 2026-08-01
 
 ### Infrastructure (master-based iteration transition)

--- a/packages/database/src/models/common/route.rs
+++ b/packages/database/src/models/common/route.rs
@@ -36,7 +36,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text")]
     pub video: Option<String>,
     /// 额外信息
-    pub extra: serde_json::Value,
+    pub extra: Option<serde_json::Value>,
     /// 创建人昵称
     pub creator_nickname: String,
 }

--- a/packages/database/src/models/common/score_stat.rs
+++ b/packages/database/src/models/common/score_stat.rs
@@ -39,7 +39,7 @@ pub struct Model {
     pub user_id: Option<i64>,
     /// 统计内容 JSON（字段级 diff 数据）
     #[sea_orm(column_type = "Json")]
-    pub content: serde_json::Value,
+    pub content: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, DeriveRelation)]

--- a/packages/database/src/models/system/sys_action_log.rs
+++ b/packages/database/src/models/system/sys_action_log.rs
@@ -37,7 +37,7 @@ pub struct Model {
     pub is_error: bool,
     /// 附加信息
     #[sea_orm(column_type = "Json")]
-    pub extra_data: SysActionLogExtra,
+    pub extra_data: Option<SysActionLogExtra>,
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, DeriveRelation)]

--- a/packages/database/src/models/system/sys_user.rs
+++ b/packages/database/src/models/system/sys_user.rs
@@ -48,7 +48,7 @@ pub struct Model {
     pub role_id: SystemUserRole,
     /// 权限策略
     #[sea_orm(column_type = "Json")]
-    pub access_policy: AccessPolicyList,
+    pub access_policy: Option<AccessPolicyList>,
     /// 备注
     #[sea_orm(column_type = "Text")]
     pub remark: Option<String>,
@@ -87,7 +87,7 @@ impl From<Model> for SysUserVO {
             phone: val.phone,
             logo: val.logo,
             role_id: val.role_id,
-            access_policy: val.access_policy,
+            access_policy: val.access_policy.unwrap_or_default(),
             remark: val.remark,
         }
     }

--- a/packages/functions/src/functions/api/route.rs
+++ b/packages/functions/src/functions/api/route.rs
@@ -28,7 +28,7 @@ fn to_vo(r: route_model::Model) -> RouteVO {
         marker_list: r.marker_list.0,
         hidden_flag: r.hidden_flag,
         video: r.video,
-        extra: r.extra,
+        extra: r.extra.unwrap_or(serde_json::Value::Null),
         creator_nickname: r.creator_nickname,
         creator_id: r.creator_id,
         create_time: r.create_time,
@@ -59,7 +59,7 @@ pub async fn do_add(_auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
         marker_list: Set(route_model::MarkerListWrapper(marker_list)),
         hidden_flag: Set(payload.hidden_flag),
         video: Set(payload.video),
-        extra: Set(serde_json::Value::Object(
+        extra: Set(Some(serde_json::Value::Object(
             payload
                 .extra
                 .map(|m| {
@@ -68,7 +68,7 @@ pub async fn do_add(_auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
                         .collect()
                 })
                 .unwrap_or_default(),
-        )),
+        ))),
         creator_nickname: Set(payload.creator_nickname.unwrap_or_default()),
     };
 
@@ -100,7 +100,7 @@ pub async fn do_update(
     am.marker_list = Set(route_model::MarkerListWrapper(marker_list));
     am.hidden_flag = Set(payload.hidden_flag);
     am.video = Set(payload.video);
-    am.extra = Set(serde_json::Value::Object(
+    am.extra = Set(Some(serde_json::Value::Object(
         payload
             .extra
             .map(|m| {
@@ -109,7 +109,7 @@ pub async fn do_update(
                     .collect()
             })
             .unwrap_or_default(),
-    ));
+    )));
     am.creator_nickname = Set(payload.creator_nickname.unwrap_or_default());
 
     route_model::Entity::update_safety(am)?.exec(db).await?;

--- a/packages/functions/src/functions/api/score.rs
+++ b/packages/functions/src/functions/api/score.rs
@@ -103,11 +103,11 @@ pub async fn do_generate_score(
             span_start_time: Set(span_start),
             span_end_time: Set(span_end),
             user_id: Set(Some(user_id)),
-            content: Set(serde_json::json!({
+            content: Set(Some(serde_json::json!({
                 "type": "DAY",
                 "count": count,
                 "fieldWeight": score,
-            })),
+            }))),
         };
         score_stat_model::Entity::insert(am).exec(db).await?;
 
@@ -169,7 +169,7 @@ pub async fn do_get_score_data(
     let samples: Vec<ScoreSample> = stats
         .iter()
         .map(|s| {
-            let score = score_from_content(&s.content);
+            let score = score_from_content(s.content.as_ref());
             ScoreSample {
                 time: s.span_end_time.and_utc().timestamp_millis() as f64,
                 score,
@@ -188,11 +188,15 @@ pub async fn do_get_score_data(
 
 /// 从 score_stat.content JSON 提取分数：优先 `fieldWeight`（字段级加权），
 /// 旧数据回退到 `count`（编辑次数），都缺失时按 0。
-fn score_from_content(content: &serde_json::Value) -> f64 {
+fn score_from_content(content: Option<&serde_json::Value>) -> f64 {
     content
-        .get("fieldWeight")
+        .and_then(|c| c.get("fieldWeight"))
         .and_then(|v| v.as_f64())
-        .or_else(|| content.get("count").and_then(|v| v.as_f64()))
+        .or_else(|| {
+            content
+                .and_then(|c| c.get("count"))
+                .and_then(|v| v.as_f64())
+        })
         .unwrap_or(0.0)
 }
 

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -195,7 +195,8 @@ async fn oauth_password_login_inner(
     }
 
     // 身份验证通过后，按用户的 access_policy 校验登录环境
-    check_access_policy(item.id, &item.access_policy.0, ip, user_agent).await?;
+    let policy: Vec<_> = item.access_policy.clone().map(|a| a.0).unwrap_or_default();
+    check_access_policy(item.id, &policy, ip, user_agent).await?;
 
     issue_token(&item).await
 }
@@ -258,7 +259,7 @@ pub async fn oauth_password_login(
         device_id: Set(user_agent),
         action: Set(SystemActionLogAction::Login),
         is_error: Set(ret.is_err()),
-        extra_data: Set(Default::default()),
+        extra_data: Set(Some(Default::default())),
     }
     .insert(&DB_CONN.wait().pg_conn)
     .await?;
@@ -297,7 +298,8 @@ pub async fn oauth_qq_login(
     let user_id = item.id;
 
     // 身份由 openid 提供；同样校验登录环境
-    check_access_policy(item.id, &item.access_policy.0, ip, &user_agent).await?;
+    let policy: Vec<_> = item.access_policy.clone().map(|a| a.0).unwrap_or_default();
+    check_access_policy(item.id, &policy, ip, &user_agent).await?;
     let ret = issue_token(&item).await;
 
     if ret.is_ok() {
@@ -316,7 +318,7 @@ pub async fn oauth_qq_login(
         device_id: Set(user_agent),
         action: Set(SystemActionLogAction::Login),
         is_error: Set(ret.is_err()),
-        extra_data: Set(Default::default()),
+        extra_data: Set(Some(Default::default())),
     }
     .insert(&DB_CONN.wait().pg_conn)
     .await?;

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -46,7 +46,7 @@ pub async fn do_register(
         phone: Set(None),
         logo: Set(Some(logo)),
         role_id: Set(role_id),
-        access_policy: Set(_utils::types::AccessPolicyList(access_policy)),
+        access_policy: Set(Some(_utils::types::AccessPolicyList(access_policy))),
         remark: Set(Some(remark)),
     };
 
@@ -85,7 +85,7 @@ pub async fn do_register_qq(
         phone: Set(None),
         logo: Set(Some(logo)),
         role_id: Set(role_id),
-        access_policy: Set(_utils::types::AccessPolicyList(access_policy)),
+        access_policy: Set(Some(_utils::types::AccessPolicyList(access_policy))),
         remark: Set(Some(remark)),
     };
 
@@ -131,7 +131,7 @@ pub async fn do_update(
     let mut am: sys_user_model::ActiveModel = m.into();
 
     if let Some(ap) = access_policy {
-        am.access_policy = Set(_utils::types::AccessPolicyList(ap));
+        am.access_policy = Set(Some(_utils::types::AccessPolicyList(ap)));
     }
     if let Some(l) = logo {
         am.logo = Set(Some(l));

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -163,7 +163,7 @@ async fn seed_user(
         phone: Set(None),
         logo: Set(None),
         role_id: Set(SystemUserRole::MapUser),
-        access_policy: Set(AccessPolicyList(policy)),
+        access_policy: Set(Some(AccessPolicyList(policy))),
         remark: Set(None),
     };
     Ok(sys_user_model::Entity::insert(am)
@@ -886,7 +886,7 @@ async fn area_and_item_doc_business_assertions() {
         .await
         .expect("fetch score stats");
     assert_eq!(stats.len(), 1, "one score_stat row for the contributor");
-    let content = &stats[0].content;
+    let content = stats[0].content.as_ref().expect("score content set");
     assert_eq!(content["count"], 2, "two Position edits counted");
     assert_eq!(
         content["fieldWeight"], 4.0,

--- a/tests/rust/tests/user_db_test.rs
+++ b/tests/rust/tests/user_db_test.rs
@@ -83,7 +83,9 @@ async fn seed_user(db: &sea_orm::DatabaseConnection) -> anyhow::Result<i64> {
         phone: Set(None),
         logo: Set(None),
         role_id: Set(SystemUserRole::MapUser),
-        access_policy: Set(AccessPolicyList(vec![AccessPolicyItemEnum::IpSameLastIp])),
+        access_policy: Set(Some(AccessPolicyList(vec![
+            AccessPolicyItemEnum::IpSameLastIp,
+        ]))),
         remark: Set(None),
     };
     let res = sys_user::Entity::insert(am).exec(db).await?;


### PR DESCRIPTION
## Summary

Make four columns nullable to match the legacy data — final legacy-database alignment PR (data-level).

## Motivation

The column-set/type diff was already zero after the previous three alignment PRs. Scanning the actual legacy **data** (the 461 MB dump) revealed real NULL rows in four columns that our entities declared non-optional — reading the legacy database would have failed at runtime:

| column | NULL rows in dump |
| --- | --- |
| `score_stat.content` | 18 047 |
| `sys_action_log.extra_data` | 2 406 |
| `sys_user.access_policy` | 197 |
| `route.extra` | 1 |

## Changes

- **Entities**: `score_stat.content`, `sys_action_log.extra_data`, `sys_user.access_policy`, `route.extra` → `Option<...>`.
- **Business**:
  - `score.rs`: writes `Set(Some(...))`; `score_from_content` takes `Option<&Value>`.
  - `oauth.rs`: access-policy reads unwrap to an empty policy list; action-log writes `Set(Some(...))`.
  - `user.rs`: register / register_qq / update write `Set(Some(...))`.
  - `route.rs`: add/update write `Set(Some(...))`; VO maps `extra.unwrap_or(Null)`.
  - `sys_user` `From<Model> for SysUserVO` unwraps to default.
- **Tests**: `user_db` / `api_db` seeds use `Set(Some(...))`; the score assertion reads via `.as_ref()`.
- **CHANGELOG**: Unreleased entry.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Nullable direction audit: **0** remaining "legacy nullable but ours required" columns (scripted against the dump DDL + entity sources)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None externally — the four columns remain always-written by our code paths (the `Option` is for reading legacy NULL rows).
