### PR TITLE
📝 Document the marker_linkage nullability decision.

### DIFF
--- a/packages/database/src/models/marker/marker_linkage.rs
+++ b/packages/database/src/models/marker/marker_linkage.rs
@@ -5,6 +5,9 @@ use _utils::{impl_safe_operation, types::MarkerLinkageLinkAction};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "marker_linkage", schema_name = "genshin_map")]
+/// 可空性说明：旧库中 group_id / from_id / to_id / link_action / link_reverse
+/// 均为「可空 + DEFAULT 兜底」（'' / 0 / false）且无任何 NULL 数据实例（461 MB
+/// 备份扫描验证），因此实体保持非 Option（我们写入必填、读取安全）。
 pub struct Model {
     /// 乐观锁
     pub version: i64,


### PR DESCRIPTION
## Summary

Document the `marker_linkage` nullability decision.

## Motivation

The final nullability audit (against the 461 MB legacy dump) found five columns where the legacy schema is nullable-with-DEFAULT but our entities are non-optional: `group_id` / `from_id` / `to_id` / `link_action` / `link_reverse`. The decision to keep them non-Option is data-driven — the dump contains **zero NULL rows** in `marker_linkage` (and every column has a DEFAULT fallback) — so reading the legacy database is safe.

## Changes

- **`marker_linkage.rs`**: module-level note documenting the nullability decision and its data evidence, so future maintainers don't "fix" it back to `Option` (or worry about the mismatch).
- **CHANGELOG**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean (comment-only)
- [x] `cargo fmt --check` clean

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (comment-only)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None.
