### PR TITLE
🔒 Stop disclosing the HMAC signing key and require an explicit JWT secret.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,16 @@ PORT=8101
 # When unset, the endpoint falls back to an empty dev config.
 # CDN_DADIAN_CONFIG=/absolute/path/to/dadian-preview.json.bz2
 
-# ── JWT signing (optional) ───────────────────────────────────────────────────
+# ── JWT signing (required) ───────────────────────────────────────────────────
+# REQUIRED: HMAC signing secret. There is no default — the process refuses to
+# start without it (a predictable default would let anyone forge tokens).
+# Generate one with:  openssl rand -base64 48
+JWT_SECRET=change-me-to-a-strong-random-secret
 # RSA private key PEM (PKCS#8 or PKCS#1). When set, tokens are signed with
 # RS256 and /.well-known/jwks.json publishes the RSA public key. When unset,
-# HS256 is used (JWKS publishes the HMAC key in oct form). Tokens signed with
-# either algorithm remain verifiable during a migration.
+# HS256 is used and the JWKS endpoint publishes an EMPTY key set (the HMAC
+# secret is never disclosed). Tokens signed with either algorithm remain
+# verifiable during a migration.
 # Generate one with:  openssl genpkey -algorithm RSA -out jwt-rsa.pem -pkeyopt rsa_keygen_bits:2048
 # JWT_RSA_PRIVATE_KEY_PEM=-----BEGIN PRIVATE KEY-----...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (the `rsa` crate now performs signing/key export, never RSA
   decryption).
 
+- Fix the JWKS key-disclosure hole: `JWT_SECRET` no longer has a
+  predictable dev default (the process now refuses to start without it —
+  generate with `openssl rand -base64 48`), and the JWKS endpoint
+  publishes an **empty** key set in HS256 mode instead of disclosing the
+  HMAC signing key in `oct` form. Deployments needing JWKS-based
+  verification must configure `JWT_RSA_PRIVATE_KEY_PEM` (RS256). Tests
+  set explicit test secrets; `.env.example` documents the required
+  variable.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -28,11 +28,18 @@ pub static JWT_SECRET: Lazy<(EncodingKey, DecodingKey)> = Lazy::new(|| {
     )
 });
 
-/// The raw JWT secret (env `JWT_SECRET`, with the dev default). Exposed for
-/// the JWKS endpoint, which publishes the HMAC key in oct form.
+/// The raw JWT secret (env `JWT_SECRET`, **required**). There is deliberately
+/// no dev default: a predictable secret would let anyone forge tokens, and the
+/// JWKS endpoint must never publish an HMAC signing key.
+///
+/// Generates a strong secret with, e.g.:
+///   openssl rand -base64 48
 pub fn jwt_secret_raw() -> String {
-    std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "下定决心，不怕牺牲，排除万难，去争取胜利".into())
+    std::env::var("JWT_SECRET").unwrap_or_else(|_| {
+        panic!(
+            "JWT_SECRET must be set (see .env.example); generate one with: openssl rand -base64 48"
+        )
+    })
 }
 
 /// The RSA private key PEM (env `JWT_RSA_PRIVATE_KEY_PEM`, optional).
@@ -148,7 +155,11 @@ pub fn rsa_public_key_pem() -> Option<&'static str> {
 /// Build the JWKS (JSON Web Key Set) for the active signing scheme.
 ///
 /// RS256: publishes the RSA public key (kty: RSA, base64url n/e).
-/// HS256: publishes the HMAC key in RFC 7517 §6.4 `oct` form.
+/// HS256: publishes an **empty** key set — the HMAC signing key is a shared
+/// secret and must never be disclosed (RFC 7517 §6.4 `oct` keys are for
+/// verification-only consumers in trusted environments). Deployments that
+/// need JWKS-based verification should configure `JWT_RSA_PRIVATE_KEY_PEM`
+/// to switch to RS256.
 pub fn jwks() -> anyhow::Result<serde_json::Value> {
     use base64::Engine;
     if let Some(pem) = rsa_public_key_pem() {
@@ -167,16 +178,7 @@ pub fn jwks() -> anyhow::Result<serde_json::Value> {
         }));
     }
 
-    let k = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(jwt_secret_raw().as_bytes());
-    Ok(serde_json::json!({
-        "keys": [{
-            "kty": "oct",
-            "kid": "genshin-cloud-hmac-v1",
-            "alg": "HS256",
-            "use": "sig",
-            "k": k,
-        }],
-    }))
+    Ok(serde_json::json!({ "keys": [] }))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -214,6 +214,7 @@ async fn area_and_item_doc_business_assertions() {
     // unsafe because concurrent readers could race).
     unsafe {
         std::env::set_var("JWT_RSA_PRIVATE_KEY_PEM", rsa_pem);
+        std::env::set_var("JWT_SECRET", "integration-test-secret");
     }
 
     let Some(db) = db().await else {

--- a/tests/rust/tests/user_db_test.rs
+++ b/tests/rust/tests/user_db_test.rs
@@ -116,6 +116,13 @@ fn stub_auth() -> AuthInfo {
 
 #[tokio::test]
 async fn user_db_round_trip() {
+    // JWT_SECRET is required (no default); set a test secret before any JWT
+    // operation touches the lazy key material.
+    // SAFETY: single-threaded test process; set once at the start.
+    unsafe {
+        std::env::set_var("JWT_SECRET", "integration-test-secret");
+    }
+
     let Some(db) = db().await else {
         return;
     };


### PR DESCRIPTION
## Summary

Fix the JWKS key-disclosure hole (secondary audit P0-1).

## Motivation

Two compounding issues allowed token forgery:
1. `JWT_SECRET` had a predictable hard-coded dev default (`"下定决心..."`) — anyone who knows the codebase knows the signing key.
2. In HS256 mode, `/.well-known/jwks.json` published the HMAC signing key itself (`kty: oct`, base64url `k`) — combined with (1), an attacker could mint arbitrary admin tokens.

## Changes

- **`packages/utils/src/jwt.rs`**:
  - `jwt_secret_raw()` now **requires** `JWT_SECRET` (panics at first use with a clear message + `openssl rand -base64 48` hint). No default.
  - `jwks()` in HS256 mode returns `{ "keys": [] }` — the HMAC secret is never disclosed. The RS256 branch is unchanged (RSA public key).
- **Tests**: `api_db_test` / `user_db_test` set explicit test secrets before any JWT operation.
- **`.env.example`**: `JWT_SECRET` documented as required (with generation hint); the JWKS behavior note updated (empty key set in HS256 mode).
- **`CHANGELOG.md`**: Unreleased Security entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test user_db --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the (RS256) JWKS assertions against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example)

## Breaking Changes

**Operational**: `JWT_SECRET` is now required — deployments without it will panic on first token operation (previously a silent predictable key). This is the intended security fix.
