### PR TITLE
🐛 Make the oauth refresh grant return the new token pair.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   set explicit test secrets; `.env.example` documents the required
   variable.
 
+- Fix `oauth_refresh` (secondary audit P0-2): it generated fresh
+  access/refresh tokens but discarded them and returned 204 with no
+  body — the refresh flow was unusable. It now returns the new token
+  pair (`OauthLoginResponse`) via `POST /oauth/token` with
+  `grant_type=refresh_token`, rotating the jti (old tokens invalidated
+  in Redis) as before.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -389,7 +389,7 @@ pub async fn do_jwks() -> Result<serde_json::Value> {
     _utils::jwt::jwks()
 }
 
-pub async fn oauth_refresh(refresh_token: String) -> Result<()> {
+pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> {
     // 验证传入的 refresh token 并获取 claims
     let claims = verify_token(&refresh_token).await?;
 
@@ -408,11 +408,11 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<()> {
         return Err(anyhow!("Refresh token not found"));
     }
 
-    // 生成新的 jti 和 token
+    // 生成新的 jti 和 token（旧 token 一次性使用：旋转后立即作废）
     let new_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let _new_access = generate_token(now, claims.sub, new_jti).await?;
-    let _new_refresh = generate_token(now, claims.sub, new_jti).await?;
+    let access_token = generate_token(now, claims.sub, new_jti).await?;
+    let refresh_token_new = generate_token(now, claims.sub, new_jti).await?;
 
     // 保持原来的访问负载（如果有），尝试读取旧的 access payload
     let old_access_key = format!("jwt:access:{}:{}", claims.sub, claims.jti);
@@ -452,5 +452,12 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<()> {
     let _deleted_old_access: usize = redis_conn.del(old_access_key).await?;
     let _deleted_old_refresh: usize = redis_conn.del(refresh_key).await?;
 
-    Ok(())
+    Ok(OauthLoginResponse {
+        access_token,
+        refresh_token: refresh_token_new,
+        token_type: OauthTokenType::Bearer,
+        expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
+        scope: OauthScopeType::All,
+        jti: new_jti,
+    })
 }

--- a/packages/router/src/routes/system/oauth.rs
+++ b/packages/router/src/routes/system/oauth.rs
@@ -132,10 +132,10 @@ pub async fn oauth(
                     "Refresh token is required for refresh token grant type".into(),
                 )
             })?;
-            oauth_refresh(refresh_token)
+            let ret = oauth_refresh(refresh_token)
                 .await
                 .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
-            return Ok(StatusCode::NO_CONTENT.into_response());
+            return Ok(Json(ret).into_response());
         },
     }
 }


### PR DESCRIPTION
## Summary

Make the oauth refresh grant return the new token pair (secondary audit P0-2).

## Motivation

`oauth_refresh` generated fresh access/refresh tokens but **discarded them** (`let _new_access` / `let _new_refresh`) and the route returned 204 with no body — the refresh flow rotated Redis entries but never handed the client its new tokens, making it unusable.

## Changes

- **`packages/functions/.../system/oauth.rs`**: `oauth_refresh` now returns `OauthLoginResponse` with the new access token, refresh token, and jti (token rotation preserved: old Redis entries are deleted, new ones stored).
- **`packages/router/.../system/oauth.rs`**: the `grant_type=refresh_token` branch returns `Json(response)` instead of 204.
- **`CHANGELOG.md`**: Unreleased Security entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Runtime verification requires Redis (refresh is Redis-gated); not covered by the DB integration job.

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

`POST /oauth/token?grant_type=refresh_token` now returns the token pair (200 + JSON) instead of an empty 204 — the intended behavior.
