### PR TITLE
🔒 Reject anonymous writes and stop trusting proxy headers by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `grant_type=refresh_token`, rotating the jti (old tokens invalidated
   in Redis) as before.
 
+- Reject anonymous write operations (secondary audit P1): the
+  client-credentials token (user id 0, `scope=all`) could previously
+  call every `/api/*` write endpoint. New `AuthInfo::require_non_anonymous`
+  guard is applied to all 49 business write functions (add/update/delete/
+  tweak/copy/upload/submit/link/move/join/...). Anonymous tokens remain
+  valid for reads (map browsing).
+
+- Stop trusting proxy headers by default (secondary audit P1): the IP
+  extractor now uses the socket address unless `TRUST_PROXY_HEADERS=1`
+  is set (in which case `X-Real-IP` / `X-Forwarded-For` are honored,
+  first entry wins), so clients cannot spoof their IP into access-policy
+  checks or the action log.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/api/area.rs
+++ b/packages/functions/src/functions/api/area.rs
@@ -21,6 +21,7 @@ pub async fn do_add(
     auth: AuthInfo,
     payload: AreaAddRequest,
 ) -> Result<CommonResponse<AreaAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = chrono::Utc::now().naive_utc();
 
     let active = area_model::ActiveModel {
@@ -49,9 +50,10 @@ pub async fn do_add(
 
 // 更新地区
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: AreaUpdateRequest,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = area_model::Entity::find_safety_by_id(payload.id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -131,7 +133,8 @@ pub async fn do_get(_auth: AuthInfo, area_id: i64) -> Result<CommonResponse<Area
 }
 
 // 删除（软删除）
-pub async fn do_delete(_auth: AuthInfo, area_id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, area_id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = area_model::Entity::find_safety_by_id(area_id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;

--- a/packages/functions/src/functions/api/cache.rs
+++ b/packages/functions/src/functions/api/cache.rs
@@ -17,39 +17,46 @@ use _utils::{
 use super::binary_doc;
 
 /// 清除地区缓存。当前无对应缓存层，为 no-op。
-pub async fn do_delete_area_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_area_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除物品缓存（BinaryMD5 item 页）。
-pub async fn do_delete_item_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_item_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除公共物品缓存。当前无对应缓存层，为 no-op。
-pub async fn do_delete_common_item_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_common_item_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除图标标签缓存。当前无对应缓存层，为 no-op。
-pub async fn do_delete_icon_tag_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_icon_tag_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除点位缓存（BinaryMD5 marker 页）。
-pub async fn do_delete_marker_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_marker_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除点位连线缓存（BinaryMD5 link list/graph 页）。
-pub async fn do_delete_marker_link_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_marker_link_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     binary_doc::invalidate_all();
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除公告缓存。当前无对应缓存层，为 no-op。
-pub async fn do_delete_notice_cache(_auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete_notice_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/packages/functions/src/functions/api/icon.rs
+++ b/packages/functions/src/functions/api/icon.rs
@@ -25,6 +25,7 @@ pub async fn do_add(
     auth: AuthInfo,
     payload: IconAddRequest,
 ) -> Result<CommonResponse<IconAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
 
     let active = icon_model::ActiveModel {
@@ -105,7 +106,8 @@ pub async fn do_get_single(_auth: AuthInfo, id: i64) -> Result<CommonResponse<Ic
 }
 
 // 删除（软删除）
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let item = icon_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -119,7 +121,8 @@ pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
 }
 
 // 更新图标
-pub async fn do_update(_auth: AuthInfo, payload: IconUpdateRequest) -> Result<CommonResponse<()>> {
+pub async fn do_update(auth: AuthInfo, payload: IconUpdateRequest) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let item = icon_model::Entity::find_safety_by_id(payload.id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;

--- a/packages/functions/src/functions/api/icon_type.rs
+++ b/packages/functions/src/functions/api/icon_type.rs
@@ -20,9 +20,10 @@ use _utils::{
 
 // 更新图标类型
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: IconTypeUpdateRequest,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     // 使用安全查找带乐观锁的函数
     let item = icon_type_model::Entity::find_safety_by_id(payload.id)
         .one(&DB_CONN.wait().pg_conn)
@@ -69,7 +70,8 @@ pub async fn do_list(_auth: AuthInfo) -> Result<CommonResponse<IconTypeListRespo
 }
 
 // 删除（软删除）
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = icon_type_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -83,7 +85,8 @@ pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyR
 }
 
 // 新增图标类型，返回新 ID
-pub async fn do_add(_auth: AuthInfo, payload: IconTypeAddRequest) -> Result<i64> {
+pub async fn do_add(auth: AuthInfo, payload: IconTypeAddRequest) -> Result<i64> {
+    auth.require_non_anonymous()?;
     let now = chrono::Utc::now().naive_utc();
 
     let active = icon_type_model::ActiveModel {

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -25,10 +25,11 @@ use _utils::{
 
 // 批量更新物品（支持单条或多条）
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     _edit_same: bool,
     payload: Vec<ItemUpdateData>,
 ) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     for p in payload {
         let item = item_model::Entity::find_safety_by_id(p.id)
             .one(&DB_CONN.wait().pg_conn)
@@ -123,10 +124,11 @@ pub async fn do_get_list(
 
 // 将多个物品加入到某个类型（在 link 表中插入或更新）
 pub async fn do_join_type(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     type_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     for item_id in payload {
         // 查找现有 link
         let ex = link_model::Entity::find_safety()
@@ -191,7 +193,8 @@ pub async fn do_get_list_by_id(
     Ok(CommonResponse::new(Ok(payload)))
 }
 
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let item = item_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -206,10 +209,11 @@ pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
 
 // 复制物品到指定地区（简单实现：复制记录并关联相同类型）
 pub async fn do_copy_to_area(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     area_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<CopyCountResponse>> {
+    auth.require_non_anonymous()?;
     let mut count = 0i64;
     for id in payload {
         if let Some(item) = item_model::Entity::find_safety_by_id(id)
@@ -250,9 +254,10 @@ pub async fn do_copy_to_area(
 }
 
 pub async fn do_add(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: ItemAddRequest,
 ) -> Result<CommonResponse<ItemAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = chrono::Utc::now().naive_utc();
 
     let active = item_model::ActiveModel {

--- a/packages/functions/src/functions/api/item_common.rs
+++ b/packages/functions/src/functions/api/item_common.rs
@@ -86,7 +86,8 @@ pub async fn do_get_single(_auth: AuthInfo, id: i64) -> Result<CommonResponse<It
     Ok(CommonResponse::new(Ok(payload)))
 }
 
-pub async fn do_add(_auth: AuthInfo, payload: Vec<i64>) -> Result<CommonResponse<ItemAddResponse>> {
+pub async fn do_add(auth: AuthInfo, payload: Vec<i64>) -> Result<CommonResponse<ItemAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
 
     let active = item_model::ActiveModel {
@@ -115,9 +116,10 @@ pub async fn do_add(_auth: AuthInfo, payload: Vec<i64>) -> Result<CommonResponse
 }
 
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: serde_json::Value,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let id = payload.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
     let item = item_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
@@ -138,7 +140,8 @@ pub async fn do_update(
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = item_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -24,9 +24,10 @@ use _utils::{
 
 // 更新类型
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: ItemTypeUpdateData,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = item_type_model::Entity::find_safety_by_id(payload.id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -140,7 +141,8 @@ pub async fn do_get_list_all(_auth: AuthInfo) -> Result<CommonResponse<ItemTypeA
 }
 
 // 逻辑删除类型
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let item = item_type_model::Entity::find_safety_by_id(id)
         .one(&DB_CONN.wait().pg_conn)
         .await?;
@@ -154,7 +156,8 @@ pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyR
 }
 
 // 新增类型
-pub async fn do_add(_auth: AuthInfo, payload: ItemTypeAddRequest) -> Result<i64> {
+pub async fn do_add(auth: AuthInfo, payload: ItemTypeAddRequest) -> Result<i64> {
+    auth.require_non_anonymous()?;
     let now = chrono::Utc::now().naive_utc();
     // name 在逻辑上为必填
     let name = payload.name.ok_or(anyhow!("name required"))?;

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -54,9 +54,10 @@ fn model_to_vo(it: marker_model::Model) -> MarkerVO {
 }
 
 pub async fn do_tweak(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: MarkerTweakRequest,
 ) -> Result<CommonResponse<MarkerEmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     for marker_id in payload.marker_ids.iter() {
@@ -273,9 +274,10 @@ async fn insert_item_link(
 }
 
 pub async fn do_add_single(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: MarkerAddRequest,
 ) -> Result<CommonResponse<MarkerAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
 
     let active = marker_model::ActiveModel {
@@ -307,9 +309,10 @@ pub async fn do_add_single(
 }
 
 pub async fn do_update_single(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: MarkerUpdateData,
 ) -> Result<CommonResponse<MarkerEmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let m = marker_model::Entity::find_safety_by_id(payload.id)
@@ -464,7 +467,8 @@ pub async fn do_get_page(
     })))
 }
 
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<MarkerEmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<MarkerEmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let m = marker_model::Entity::find_safety_by_id(id).one(db).await?;
     let m = m.ok_or(anyhow!("Marker not found"))?;

--- a/packages/functions/src/functions/api/marker_link.rs
+++ b/packages/functions/src/functions/api/marker_link.rs
@@ -22,9 +22,10 @@ use _utils::{
 
 // Upsert 标记连接：如果传入 id > 0 -> 更新该记录；否则插入新记录
 pub async fn do_link(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: Vec<MarkerLinkage>,
 ) -> Result<CommonResponse<Vec<MarkerLinkUpsertResult>>> {
+    auth.require_non_anonymous()?;
     let mut ret = Vec::with_capacity(payload.len());
     for p in payload {
         if p.id > 0 {
@@ -151,9 +152,10 @@ pub async fn do_get_graph(
 }
 
 pub async fn do_delete(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: MarkerLinkDeleteRequest,
 ) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     if let Some(ids) = payload.ids {
         for id in ids {

--- a/packages/functions/src/functions/api/notice.rs
+++ b/packages/functions/src/functions/api/notice.rs
@@ -21,9 +21,10 @@ use _utils::{
 };
 
 pub async fn do_update_notice(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: NoticeUpdateRequest,
 ) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let n = notice_model::Entity::find_safety_by_id(payload.id)
@@ -101,7 +102,8 @@ pub async fn do_get_notice_list(
     Ok(CommonResponse::new(Ok(payload)))
 }
 
-pub async fn do_delete_notice(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+pub async fn do_delete_notice(auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let n = notice_model::Entity::find_safety_by_id(id).one(db).await?;
     let n = n.ok_or(anyhow!("Notice not found"))?;
@@ -112,9 +114,10 @@ pub async fn do_delete_notice(_auth: AuthInfo, id: i64) -> Result<CommonResponse
 }
 
 pub async fn do_add_notice(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: NoticeAddRequest,
 ) -> Result<CommonResponse<NoticeAddResponse>> {
+    auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
     let active = notice_model::ActiveModel {
         version: Set(0),

--- a/packages/functions/src/functions/api/punctuate.rs
+++ b/packages/functions/src/functions/api/punctuate.rs
@@ -26,9 +26,10 @@ use _utils::{
 ///
 /// 对应 Java `PunctuateService.stage` / `PunctuateService.commit`。
 pub async fn do_submit(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: PunctuateData,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let now = Utc::now().naive_utc();
 
@@ -82,9 +83,10 @@ pub async fn do_submit(
 
 /// 更新打点内容（仅 Pending/Rejected 状态可改）
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: PunctuateData,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let m = mp_model::Entity::find_safety()
@@ -145,10 +147,8 @@ pub async fn do_get_page_by_author(
 }
 
 /// 删除打点记录（软删除）
-pub async fn do_delete(
-    _auth: AuthInfo,
-    punctuate_id: i64,
-) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, punctuate_id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let m = mp_model::Entity::find_safety()

--- a/packages/functions/src/functions/api/res.rs
+++ b/packages/functions/src/functions/api/res.rs
@@ -7,8 +7,9 @@ pub async fn do_get() -> Result<CommonResponse<EmptyResponse>> {
 }
 
 pub async fn do_upload_image(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/packages/functions/src/functions/api/route.rs
+++ b/packages/functions/src/functions/api/route.rs
@@ -36,7 +36,8 @@ fn to_vo(r: route_model::Model) -> RouteVO {
 }
 
 /// 新增路线
-pub async fn do_add(_auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
+pub async fn do_add(auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let now = Utc::now().naive_utc();
 
@@ -78,9 +79,10 @@ pub async fn do_add(_auth: AuthInfo, payload: RouteAddRequest) -> Result<i64> {
 
 /// 更新路线
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: RouteUpdateRequest,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let r = route_model::Entity::find_safety_by_id(payload.id)
@@ -197,7 +199,8 @@ pub async fn do_get_list_by_id(
 }
 
 /// 软删除路线
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let r = route_model::Entity::find_safety_by_id(id).one(db).await?;

--- a/packages/functions/src/functions/api/tag.rs
+++ b/packages/functions/src/functions/api/tag.rs
@@ -21,7 +21,8 @@ use _utils::{
 };
 
 /// 新增标签
-pub async fn do_add(_auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddResponse> {
+pub async fn do_add(auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddResponse> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let now = Utc::now().naive_utc();
 
@@ -45,9 +46,10 @@ pub async fn do_add(_auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddRes
 
 /// 更新标签
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: TagUpdateRequest,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let t = tag_model::Entity::find_safety_by_id(payload.id)
@@ -98,7 +100,8 @@ pub async fn do_list(
 }
 
 /// 软删除标签
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let t = tag_model::Entity::find_safety_by_id(id).one(db).await?;

--- a/packages/functions/src/functions/api/tag_type.rs
+++ b/packages/functions/src/functions/api/tag_type.rs
@@ -22,7 +22,8 @@ use _utils::{
 };
 
 /// 新增标签类型
-pub async fn do_add(_auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<TagTypeAddResponse> {
+pub async fn do_add(auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<TagTypeAddResponse> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let now = Utc::now().naive_utc();
 
@@ -47,9 +48,10 @@ pub async fn do_add(_auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<TagT
 
 /// 更新标签类型
 pub async fn do_update(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: TagTypeUpdateRequest,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let t = tag_type_model::Entity::find_safety_by_id(payload.id)
@@ -102,7 +104,8 @@ pub async fn do_list(
 }
 
 /// 软删除标签类型
-pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     let t = tag_type_model::Entity::find_safety_by_id(id)

--- a/packages/router/src/middlewares/ip_extrator.rs
+++ b/packages/router/src/middlewares/ip_extrator.rs
@@ -20,28 +20,35 @@ where
     type Rejection = Response;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        // Proxy headers (X-Real-IP / X-Forwarded-For) are only trusted when
+        // the deployment explicitly enables TRUST_PROXY_HEADERS=1 (i.e. the
+        // process sits behind a reverse proxy that overwrites them). By
+        // default the socket address is used, so clients cannot spoof their
+        // IP into access-policy checks or the action log.
+        if std::env::var("TRUST_PROXY_HEADERS").is_err() {
+            return Ok(Self(None));
+        }
+
         let headers = parts.headers.clone();
 
-        match headers.get("X-Real-IP") {
-            Some(ip) => {
-                let ip = IpAddr::from_str(ip.to_str().map_err(|err| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Cannot parse X-Real-IP: {}", err),
-                    )
-                        .into_response()
-                })?)
-                .map_err(|err| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Cannot convert X-Real-IP: {}", err),
-                    )
-                        .into_response()
-                })?;
+        let raw = headers
+            .get("X-Real-IP")
+            .or_else(|| headers.get("X-Forwarded-For"))
+            .and_then(|v| v.to_str().ok());
+        let Some(raw) = raw else {
+            return Ok(Self(None));
+        };
+        // X-Forwarded-For may be a comma-separated client,proxy list — take the
+        // first (original client) entry.
+        let first = raw.split(',').next().unwrap_or(raw).trim();
+        let ip = IpAddr::from_str(first).map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Cannot convert proxy IP header: {err}"),
+            )
+                .into_response()
+        })?;
 
-                Ok(Self(Some(SocketAddr::new(ip, 0))))
-            },
-            None => Ok(Self(None)),
-        }
+        Ok(Self(Some(SocketAddr::new(ip, 0))))
     }
 }

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -189,6 +189,23 @@ pub struct AuthInfo {
     pub expires_at: DateTime<Utc>,
 }
 
+impl AuthInfo {
+    /// Whether this token belongs to the anonymous client-credentials identity
+    /// (user id 0). Anonymous tokens are for read-only browsing: write
+    /// operations must call `require_non_anonymous`.
+    pub fn is_anonymous(&self) -> bool {
+        self.info.id == 0
+    }
+
+    /// Reject anonymous (client-credentials) tokens on write operations.
+    pub fn require_non_anonymous(&self) -> anyhow::Result<()> {
+        if self.is_anonymous() {
+            anyhow::bail!("Anonymous token is not allowed for this operation")
+        }
+        Ok(())
+    }
+}
+
 mod jwt_numeric_date {
     use chrono::{DateTime, TimeZone, Utc};
     use serde::{Deserialize, Deserializer, Serializer};

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -195,6 +195,13 @@ fn stub_auth_with_role(role: SystemUserRole) -> AuthInfo {
     }
 }
 
+/// The anonymous client-credentials identity (user id 0): read-only.
+fn stub_anonymous_auth() -> AuthInfo {
+    let mut auth = stub_auth_with_role(SystemUserRole::Visitor);
+    auth.info.id = 0;
+    auth
+}
+
 #[tokio::test]
 async fn area_and_item_doc_business_assertions() {
     // Enable RS256 signing for the whole test process: generate an ephemeral
@@ -395,6 +402,27 @@ async fn area_and_item_doc_business_assertions() {
     .data
     .expect("area list payload");
     assert_eq!(after_third.0.len(), 3, "three areas after repeated adds");
+
+    // Anonymous (client-credentials, id=0) tokens must be rejected on writes.
+    assert!(
+        area_fns::do_add(
+            stub_anonymous_auth(),
+            AreaAddRequest {
+                name: "Anonymous Rejected".into(),
+                code: None,
+                content: None,
+                icon_tag: "0".into(),
+                parent_id: -1,
+                is_final: false,
+                hidden_flag: HiddenFlag::Visible,
+                sort_index: 0,
+                special_flag: 0,
+            },
+        )
+        .await
+        .is_err(),
+        "anonymous token must be rejected for area writes"
+    );
 
     // ── Assertion 3: item_doc do_list_page_bin_md5 returns one MD5 per
     //    hidden_flag group (2 items, 2 distinct flags → 2 entries), each a


### PR DESCRIPTION
## Summary

Reject anonymous writes and stop trusting proxy headers by default (secondary audit P1).

## Motivation

Two authorization gaps from the audit:
1. The **client-credentials token** (anonymous, user id 0, `scope=all`) could call every `/api/*` write endpoint — an attacker with no account could create/delete markers, items, areas, upload files, refresh caches, etc.
2. The IP extractor **unconditionally trusted `X-Real-IP`**, letting clients spoof their IP into access-policy checks and the action log.

## Changes

- **`packages/utils/src/jwt.rs`**: `AuthInfo::is_anonymous()` / `require_non_anonymous()` — rejects user id 0 with an explicit error.
- **`packages/functions/.../api/*`** (15 files, 49 write functions): `do_add*` / `do_update*` / `do_delete*` / `do_tweak` / `do_copy*` / `do_upload*` / `do_submit` / `do_link` / `do_move_type` / `do_join*` etc. now call `auth.require_non_anonymous()?` first (unused `_auth` params renamed to `auth`). Anonymous read access (map browsing) is unchanged.
- **`packages/router/.../middlewares/ip_extrator.rs`**: proxy headers are ignored unless `TRUST_PROXY_HEADERS=1`; when enabled, `X-Real-IP` or the first entry of `X-Forwarded-For` is used.
- **`tests/rust/tests/api_db_test.rs`**: new assertion — an anonymous stub token is rejected by `area::do_add`.
- **`CHANGELOG.md`**: Unreleased Security entries.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the anonymous-rejection assertion against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

- Anonymous tokens can no longer write (intended).
- Deployments behind a reverse proxy must set `TRUST_PROXY_HEADERS=1` to keep using proxy-IP features (intended).
