### PR TITLE
🔒 Fix punctuate ownership and audit-read authorization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   first entry wins), so clients cannot spoof their IP into access-policy
   checks or the action log.
 
+- Fix punctuate authorization (secondary audit P1): the author is now
+  taken from the authenticated identity (the request-body `author` is
+  ignored), STAGE/COMMIT refuse to touch another author's records,
+  `do_delete` is owner-or-admin only, and the four punctuate-audit
+  read endpoints require the Admin/MapManager role. Invitation
+  `info`/`consume` also reject anonymous tokens.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/api/punctuate.rs
+++ b/packages/functions/src/functions/api/punctuate.rs
@@ -16,7 +16,7 @@ use _utils::{
         punctuate::PunctuateData,
         wrapper::{CommonResponse, Pagination},
     },
-    types::MarkerPunctuateStatus,
+    types::{MarkerPunctuateStatus, SystemUserRole},
 };
 
 /// 暂存 / 提交打点
@@ -46,13 +46,17 @@ pub async fn do_submit(
                 .await?;
 
             if let Some(m) = existing {
+                // 仅允许覆盖自己的暂存记录（author 以登录身份为准，忽略请求体）
+                if m.author != auth.info.id {
+                    return Err(anyhow!("Cannot overwrite another author's punctuate"));
+                }
                 // 更新已有的暂存记录
                 let mut am: mp_model::ActiveModel = m.into();
                 apply_punctuate_fields(&mut am, &payload);
                 mp_model::Entity::update_safety(am)?.exec(db).await?;
             } else {
                 // 新建暂存记录
-                let am = new_punctuate_active_model(&payload, now);
+                let am = new_punctuate_active_model(&payload, now, auth.info.id);
                 mp_model::Entity::insert(am).exec(db).await?;
             }
         },
@@ -67,6 +71,10 @@ pub async fn do_submit(
                 .one(db)
                 .await?
                 .ok_or_else(|| anyhow!("无待提交的打点信息"))?;
+            // 仅允许提交自己的记录
+            if m.author != auth.info.id {
+                return Err(anyhow!("Cannot commit another author's punctuate"));
+            }
 
             let mut am: mp_model::ActiveModel = m.into();
             am.status = Set(MarkerPunctuateStatus::Reviewing);
@@ -146,7 +154,7 @@ pub async fn do_get_page_by_author(
     }))))
 }
 
-/// 删除打点记录（软删除）
+/// 删除打点记录（软删除；仅限作者本人或管理员）
 pub async fn do_delete(auth: AuthInfo, punctuate_id: i64) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
@@ -156,6 +164,11 @@ pub async fn do_delete(auth: AuthInfo, punctuate_id: i64) -> Result<CommonRespon
         .one(db)
         .await?
         .ok_or_else(|| anyhow!("打点信息不存在"))?;
+
+    // 仅作者可删除自己的打点；管理员可清理任意审核中记录
+    if m.author != auth.info.id && !matches!(auth.info.role_id, SystemUserRole::Admin) {
+        return Err(anyhow!("Cannot delete another author's punctuate"));
+    }
 
     mp_model::Entity::delete_safety(m.into())?.exec(db).await?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
@@ -182,17 +195,19 @@ fn apply_punctuate_fields(am: &mut mp_model::ActiveModel, p: &PunctuateData) {
         .map(|m| serde_json::to_value(m).unwrap_or(serde_json::Value::Null)));
 }
 
-/// 构造一条新的 marker_punctuate ActiveModel（状态 = payload.status）。
+/// 构造一条新的 marker_punctuate ActiveModel（状态 = payload.status；
+/// author 以登录身份为准，忽略请求体中的 author 字段）。
 fn new_punctuate_active_model(
     p: &PunctuateData,
     now: chrono::NaiveDateTime,
+    author_id: i64,
 ) -> mp_model::ActiveModel {
     mp_model::ActiveModel {
         version: Set(0),
         id: NotSet,
         create_time: Set(now),
         update_time: Set(None),
-        creator_id: Set(Some(p.author)),
+        creator_id: Set(Some(author_id)),
         updater_id: Set(None),
         del_flag: Set(false),
         punctuate_id: Set(p.punctuate_id as i64),
@@ -207,7 +222,7 @@ fn new_punctuate_active_model(
         marker_creator_id: Set(p.marker_creator_id),
         picture_creator_id: Set(p.picture_creator_id),
         video_path: Set(p.video_path.clone()),
-        author: Set(p.author),
+        author: Set(author_id),
         status: Set(p.status),
         audit_remark: Set(None),
         method_type: Set(p.method_type),

--- a/packages/functions/src/functions/api/punctuate_audit.rs
+++ b/packages/functions/src/functions/api/punctuate_audit.rs
@@ -33,9 +33,10 @@ fn require_auditor(auth: &AuthInfo) -> Result<()> {
 
 /// 按 punctuate_id 查询单条打点审核信息
 pub async fn do_get_id(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     punctuate_id: i64,
 ) -> Result<CommonResponse<serde_json::Value>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
     let m = mp_model::Entity::find_safety()
         .filter(mp_model::Column::PunctuateId.eq(punctuate_id))
@@ -47,9 +48,10 @@ pub async fn do_get_id(
 
 /// 分页查询所有待审核的打点（status = Reviewing）
 pub async fn do_get_page_all(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: _utils::models::Pagination,
 ) -> Result<CommonResponse<serde_json::Value>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
     let size = payload.size.unwrap_or(10) as u64;
     let current = payload.current.unwrap_or(1);
@@ -68,9 +70,10 @@ pub async fn do_get_page_all(
 
 /// 按提交者列表查询待审核打点
 pub async fn do_get_list_by_authors(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     authors: Vec<i64>,
 ) -> Result<CommonResponse<serde_json::Value>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
     let items = mp_model::Entity::find_safety()
         .filter(mp_model::Column::Status.eq(MarkerPunctuateStatus::Reviewing))
@@ -85,9 +88,10 @@ pub async fn do_get_list_by_authors(
 
 /// 按 punctuate_id 列表批量查询
 pub async fn do_get_list_by_id(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     punctuate_ids: Vec<i64>,
 ) -> Result<CommonResponse<serde_json::Value>> {
+    require_auditor(&auth)?;
     let db = &DB_CONN.wait().pg_conn;
     let items = mp_model::Entity::find_safety()
         .filter(mp_model::Column::PunctuateId.is_in(punctuate_ids))

--- a/packages/functions/src/functions/system/invitation.rs
+++ b/packages/functions/src/functions/system/invitation.rs
@@ -69,7 +69,8 @@ pub async fn do_update(
 }
 
 /// Check invitation info by code.
-pub async fn do_info(_auth: AuthInfo, code: String) -> Result<CommonResponse<serde_json::Value>> {
+pub async fn do_info(auth: AuthInfo, code: String) -> Result<CommonResponse<serde_json::Value>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let inv = inv_model::Entity::find_safety()
         .filter(inv_model::Column::Code.eq(code))
@@ -80,7 +81,8 @@ pub async fn do_info(_auth: AuthInfo, code: String) -> Result<CommonResponse<ser
 }
 
 /// Consume (use) an invitation code — marks it as used by deleting it.
-pub async fn do_consume(_auth: AuthInfo, code: String) -> Result<CommonResponse<()>> {
+pub async fn do_consume(auth: AuthInfo, code: String) -> Result<CommonResponse<()>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let inv = inv_model::Entity::find_safety()
         .filter(inv_model::Column::Code.eq(code))

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -21,7 +21,7 @@ use _database::models::{
 };
 use _functions::functions::api::{
     area as area_fns, cache as cache_fns, item_doc, marker as marker_fns,
-    punctuate_audit as audit_fns, score as score_fns,
+    punctuate as punctuate_fns, punctuate_audit as audit_fns, score as score_fns,
 };
 use _functions::functions::system::oauth as oauth_fns;
 use _utils::{
@@ -658,6 +658,14 @@ async fn area_and_item_doc_business_assertions() {
     assert!(
         audit_fns::do_pass(user_auth.clone(), 9001).await.is_err(),
         "MapUser must not be allowed to pass an audit"
+    );
+    // A non-owner (id=1, seeded author=2) must not delete another author's
+    // punctuate.
+    assert!(
+        punctuate_fns::do_delete(user_auth.clone(), 9001)
+            .await
+            .is_err(),
+        "a user must not delete another author's punctuate"
     );
     assert!(
         audit_fns::do_reject(user_auth, 9001, "nope".into())


### PR DESCRIPTION
## Summary

Fix punctuate ownership and audit-read authorization (secondary audit P1).

## Motivation

From the audit:
- The punctuate `author` came from the request body — any logged-in user could impersonate another author, overwrite their staged submissions, or delete their records (the delete route even discarded the path `author_id`).
- The four punctuate-audit **read** endpoints had no role check — any logged-in user could view the whole review queue.
- `invitation/info` and `invitation/consume` had no gate at all.

## Changes

- **`packages/functions/.../api/punctuate.rs`**:
  - `new_punctuate_active_model` takes the authenticated `author_id` (request-body `author` is ignored).
  - STAGE (overwrite) and COMMIT now refuse when the existing record belongs to another author.
  - `do_delete` is owner-or-Admin only.
- **`packages/functions/.../api/punctuate_audit.rs`**: `do_get_id` / `do_get_page_all` / `do_get_list_by_authors` / `do_get_list_by_id` now require the Admin/MapManager role (`require_auditor`).
- **`packages/functions/.../system/invitation.rs`**: `do_info` / `do_consume` reject anonymous tokens.
- **`tests/rust/tests/api_db_test.rs`**: a non-owner user cannot delete another author's punctuate.
- **`CHANGELOG.md`**: Unreleased Security entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs the ownership assertion against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

- Non-owners can no longer overwrite/commit/delete others' punctuate records (intended).
- Review-queue reads now require an auditor role (intended).
- Anonymous tokens can no longer query/consume invitations (intended).
