### PR TITLE
🐛 Fix the item copy identity and the connection-pool lifetimes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   read endpoints require the Admin/MapManager role. Invitation
   `info`/`consume` also reject anonymous tokens.
 
+- Fix remaining identity/pool issues (secondary audit P1): `item` copy
+  now lets the identity column assign ids (the leftover `Set(0)` would
+  collide on a second copy), the Postgres pool `max_lifetime` is 30
+  minutes / `idle_timeout` 60s (was 8s, recycling every connection
+  constantly), and invalid `DB_PORT` / `REDIS_PORT` env values degrade
+  gracefully instead of panicking at startup.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/database/src/lib.rs
+++ b/packages/database/src/lib.rs
@@ -32,22 +32,28 @@ pub async fn init_db_conn() -> anyhow::Result<()> {
 async fn build_db_map() -> Result<DatabaseConnectionMap> {
     // ── Postgres (required — startup fails if unreachable) ─────────────────
     let pg_conn = {
+        let db_port = match std::env::var("DB_PORT") {
+            Ok(v) => v
+                .parse::<u16>()
+                .map_err(|e| anyhow!("Invalid DB_PORT '{v}': {e}"))?,
+            Err(_) => 5432,
+        };
         let mut opt = ConnectOptions::new(format!(
             "postgres://{}:{}@{}:{}/{}",
             std::env::var("DB_USERNAME").unwrap_or("genshin_map".into()),
             std::env::var("DB_PASSWORD").unwrap_or("".into()),
             std::env::var("DB_HOST").unwrap_or("localhost".into()),
-            std::env::var("DB_PORT")
-                .map(|str| str.parse::<u16>().unwrap())
-                .unwrap_or(5432),
+            db_port,
             std::env::var("DB_DATABASE").unwrap_or("genshin_map".into()),
         ));
         opt.max_connections(100)
             .min_connections(5)
             .connect_timeout(Duration::from_secs(8))
             .acquire_timeout(Duration::from_secs(8))
-            .idle_timeout(Duration::from_secs(8))
-            .max_lifetime(Duration::from_secs(8))
+            // idle/lifetime in minutes, not seconds — an 8s max_lifetime would
+            // recycle every connection constantly under any load.
+            .idle_timeout(Duration::from_secs(60))
+            .max_lifetime(Duration::from_secs(30 * 60))
             .sqlx_logging(true)
             .sqlx_logging_level(log::LevelFilter::Trace);
         Database::connect(opt).await?
@@ -63,7 +69,8 @@ async fn build_db_map() -> Result<DatabaseConnectionMap> {
             .unwrap_or_default(),
         std::env::var("REDIS_HOST").unwrap_or("localhost".into()),
         std::env::var("REDIS_PORT")
-            .map(|str| str.parse::<u16>().unwrap())
+            .ok()
+            .and_then(|v| v.parse::<u16>().ok())
             .unwrap_or(6379),
         1,
     )) {

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -221,7 +221,8 @@ pub async fn do_copy_to_area(
             .await?
         {
             let mut am: item_model::ActiveModel = item.into();
-            am.id = Set(0);
+            // 复制为新行：IDENTITY 列走自增（显式 Set(0) 会在第二次复制时撞主键）
+            am.id = NotSet;
             am.area_id = Set(area_id);
             am.create_time = Set(chrono::Utc::now().naive_utc());
             am.update_time = Set(None);


### PR DESCRIPTION
## Summary

Fix the item copy identity and the connection-pool lifetimes (secondary audit P1).

## Motivation

Three correctness issues from the audit:
1. `item::do_copy_to_area` set `am.id = Set(0)` before insert — the identity-column bug that the earlier sweep fixed everywhere except here; the second copy into the same table would collide on the primary key.
2. The Postgres pool had `max_lifetime` and `idle_timeout` of **8 seconds** — every connection was recycled almost immediately under any load, causing pool churn.
3. Invalid `DB_PORT` / `REDIS_PORT` env values panicked at startup via `.unwrap()`.

## Changes

- **`packages/functions/.../api/item.rs`**: `do_copy_to_area` uses `am.id = NotSet` (identity-assigned) with a comment explaining why.
- **`packages/database/src/lib.rs`**: pool `idle_timeout` 60s, `max_lifetime` 30 min; `DB_PORT` parsed with an explicit error message; `REDIS_PORT` falls back to 6379 on invalid values (Redis is optional anyway).
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None.
