### PR TITLE
📝 Resync the docs with the audit findings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Documentation
 
+- Resync the audit findings (secondary audit D-items): the Java-sync
+  roadmap batch-7 status now reflects the landed RS256/JWKS work (only
+  JWK rotation remains; HS256 mode publishes an empty key set); the
+  API-reference route prefixes match the real `/icon_type` etc. paths;
+  the architecture doc drops the non-existent logging/rate-limit
+  middleware claims; the README tech-stack table lists the actual
+  logger (`env_logger`); PLAN.md milestone headers carry completion
+  status; and a stale `user_db` test comment is fixed.
+
+### Documentation
+
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):
   each language's `README.md` is now a real translated landing page (project
   intro + full document index linking to the English content, which remains

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,7 +149,7 @@ master  ── 唯一主线，永远可构建、CI 全绿；禁止直推、禁�
 
 > 每行 = 一个独立 PR（分支名 + 拟定 PR 标题 + 验收 DoD）。里程碑内可并行，跨里程碑有依赖。
 
-### M1 — 基建修复与测试底座（先行，后续迭代的门槛）
+### M1 — 基建修复与测试底座（先行，后续迭代的门槛） — ✅ 已完成（PR #22–24）
 
 | 分支 | PR 标题 | 内容 | DoD |
 | --- | --- | --- | --- |
@@ -158,7 +158,7 @@ master  ── 唯一主线，永远可构建、CI 全绿；禁止直推、禁�
 | `test/db-integration-harness` | `✅ Wire the docker compose stack into DB-backed integration tests.` | compose(PG/Redis/MinIO) 接 CI service 或 job 容器；写第一个 user 域 DB 测试作为样板；T2 的注释与现实对齐 | CI 起服务并跑通 ≥1 个 `#[ignore]`→正式测试 |
 | `test/e2e-business-assertions` | `✅ Upgrade e2e from smoke checks to authenticated business assertions.` | e2e 带登录态；401/403 不再算通过；覆盖 area/marker/item_doc 至少 3 条业务断言 | `just dev mock` 绿且断言真实数据 |
 
-### M2 — 技术债清零（CHANGELOG 已登记的 5 条 + 占位实现）
+### M2 — 技术债清零（CHANGELOG 已登记的 5 条 + 占位实现） — ✅ 已完成（PR #25–29）
 
 | 分支 | PR 标题 | 内容 | DoD |
 | --- | --- | --- | --- |
@@ -168,7 +168,7 @@ master  ── 唯一主线，永远可构建、CI 全绿；禁止直推、禁�
 | `fix/user-domain-placeholders` | `🐛 Remove the user domain placeholder implementations.` | F8：注册默认密码、旧密码校验、sort 生效、kick_out 实现 | 四处行为对齐 Java + 测试 |
 | `fix/marker-tweak-item-list` | `🐛 Implement the ItemList branch of marker tweak.` | F9 | 行为对齐 Java + 测试 |
 
-### M3 — 权限与安全（生产部署前必须）
+### M3 — 权限与安全（生产部署前必须） — ✅ 已完成（PR #30–33）
 
 | 分支 | PR 标题 | 内容 | DoD |
 | --- | --- | --- | --- |
@@ -177,14 +177,14 @@ master  ── 唯一主线，永远可构建、CI 全绿；禁止直推、禁�
 | `feat/jwks-endpoint` | `✨ Add the JWKS public key distribution endpoint.` | F7 后半：JWKS 路由 + 密钥轮换策略 | `/.well-known/jwks.json` 可用 |
 | `feat/qq-login` | `✨ Implement QQ third-party login.` | F7/F8 交集：`do_register_qq` 真实现 | 全流程可登录（mock QQ 侧） |
 
-### M4 — 性能与缓存
+### M4 — 性能与缓存 — 🟡 部分完成（moka 进程内缓存 + 刷新接线 PR #35–36；Redis 二级缓存未做）
 
 | 分支 | PR 标题 | 内容 | DoD |
 | --- | --- | --- | --- |
 | `feat/binarymd5-cache` | `⚡ Add the two-tier cache for BinaryMD5 doc endpoints.` | F5：进程内缓存（moka）+ Redis 二级；MD5 `time` 改数据变更时间 | 重复请求不再重生成；失效正确 |
 | `feat/cache-refresh-wiring` | `✨ Wire the cache refresh endpoints to the Redis cache layer.` | F10：7 个 no-op DELETE 端点接线 | 刷新后缓存确实失效 + 测试 |
 
-### M5 — 文档同步与首个发布
+### M5 — 文档同步与首个发布 — ✅ 已完成（PR #37–39，v0.2.0）
 
 | 分支 | PR 标题 | 内容 | DoD |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ while improving performance, deployment ergonomics, and type safety.
 | 对象存储 / Object storage | `minio` |
 | 鉴权 / Auth | `jsonwebtoken` + `bcrypt` |
 | 运行时 / Runtime | `tokio` |
-| 日志 / Tracing | `tracing` + `tracing-subscriber` |
+| 日志 | `tracing` + `env_logger` |
 
 ## 快速开始 / Quick Start
 

--- a/docs/en/guides/sync-with-java-roadmap.md
+++ b/docs/en/guides/sync-with-java-roadmap.md
@@ -47,7 +47,7 @@ current status.
 | 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit, role-gated and transactional) and `ScoreStat` aggregation (field-weighted). | High | **Done** |
 | 5 | **system (user / role / device / invitation)** | `SysUser`, `SysUserArchive`, `SysUserDevice` (login-anomaly detection), `SysUserInvitation`, `SysActionLog`, role listing, archive rename/delete_slot. | Medium | **Done** — device registration + access-policy checks are wired |
 | 6 | **BinaryMD5 archive export** | The GZIP-compressed, BinaryMD5-keyed producer for `item_doc` / `marker_doc` / `marker_link_doc`, with an in-process moka cache (300s TTL) and refresh endpoints. | High | **Done** |
-| 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Mostly done** — still HMAC (HS256) signing; the RSA keypair + JWK rotation are not implemented |
+| 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Mostly done** — RS256 signing with RSA JWKS landed (`JWT_RSA_PRIVATE_KEY_PEM`); JWK rotation is still missing; in HS256 mode the JWKS endpoint returns an empty key set (the HMAC secret is never disclosed) |
 
 ## Current state
 
@@ -61,9 +61,10 @@ current status.
 
 ## Known gaps (remaining parity with Java)
 
-- Batch 7: tokens are HMAC-SHA256; the Java side uses an RSA keypair with JWK
-  rotation. The JWKS endpoint currently publishes the HMAC key in `oct` form;
-  switching to RSA requires key management and rotation.
+- Batch 7: JWK rotation is not implemented (the key is fixed); in HS256
+  mode the JWKS endpoint returns an empty key set — the HMAC signing
+  secret is never disclosed (set `JWT_RSA_PRIVATE_KEY_PEM` for
+  JWKS-based verification).
 - Database schema deviations from the real database await data validation
   (`marker_linkage` nullable columns, `sys_user_archive` structure binding).
 - Translation: only `docs/en` and `docs/zhs` are complete; the other 9

--- a/docs/zhs/guides/api-reference.md
+++ b/docs/zhs/guides/api-reference.md
@@ -13,12 +13,12 @@ Java 侧控制器的 Rust 移植：路径、请求/响应结构与 Java 参考�
 | --- | --- | --- |
 | area | `/area` | 地区树（含父子关系、末端标记、权限屏蔽） |
 | icon | `/icon` | 地图图标资源及其元数据 |
-| icon_type | `/iconType` | 图标分类 |
+| icon_type | `/icon_type` | 图标分类 |
 | item | `/item` | 地图条目（item），含 copy/join 等聚合操作 |
-| item_type | `/itemType` | 条目分类，含 move_type 排序 |
+| item_type | `/item_type` | 条目分类，含 move_type 排序 |
 | item_common | `/itemCommon` | 条目公共属性 |
 | marker | `/marker` | 打点（marker）的增删改查、single、tweak |
-| marker_link | `/markerLink` | 打点之间的关联关系 |
+| marker_link | `/marker_link` | 打点之间的关联关系 |
 | notice | `/notice` | 公告管理 |
 | route | `/route` | 路线（route）管理 |
 | history | `/history` | 历史版本列表 |
@@ -30,7 +30,7 @@ Java 侧控制器的 Rust 移植：路径、请求/响应结构与 Java 参考�
 | --- | --- | --- |
 | item_doc | `/itemDoc` | 条目分页导出（bin 二进制 / md5 校验） |
 | marker_doc | `/markerDoc` | 打点分页导出（bin / md5） |
-| marker_link_doc | `/markerLinkDoc` | 打点关联导出 |
+| marker_link_doc | `/marker_link_doc` | 打点关联导出 |
 | res | `/res` | 资源上传（MinIO） |
 
 > `*_doc` 系列对应 Java 侧 BinaryMD5 压缩归档导出能力。
@@ -40,7 +40,7 @@ Java 侧控制器的 Rust 移植：路径、请求/响应结构与 Java 参考�
 | 域 | 路径前缀 | 说明 |
 | --- | --- | --- |
 | punctuate | `/punctuate` | 用户提交打点（actions / get / manage） |
-| punctuate_audit | `/punctuateAudit` | 打点审批流（audit / delete / get） |
+| punctuate_audit | `/punctuate_audit` | 打点审批流（audit / delete / get） |
 | score | `/score` | 评分数据与生成 |
 
 ## 系统域

--- a/docs/zhs/guides/architecture.md
+++ b/docs/zhs/guides/architecture.md
@@ -13,7 +13,7 @@
 | `utils` | 通用基础 | DTO/VO 类型（`src/types/`、`src/models/`）、`SafeEntityTrait` 宏、JWT、`CommonResponse` 包装 |
 | `database` | 数据访问 | sea-orm 实体，按域组织于 `src/models/<domain>/`，全局 `DB_CONN` 连接池 |
 | `functions` | 业务逻辑 | `src/functions/api/<domain>.rs` 提供 `do_*` 异步函数，编排实体读写与缓存 |
-| `router` | 接入层 | axum 路由 `src/routes/api/<domain>/`、中间件（鉴权、日志、限流）、二进制 `_router` |
+| `router` | 接入层 | axum 路由 `src/routes/api/<domain>/`、中间件（鉴权、IP 提取、User-Agent 提取）、二进制 `_router` |
 
 ## 请求流
 

--- a/docs/zhs/guides/sync-with-java-roadmap.md
+++ b/docs/zhs/guides/sync-with-java-roadmap.md
@@ -20,7 +20,7 @@ Rust 后端的目标是与 Java 参考实现 `java-genshin-map-cloud` 功能对�
 | 4 | **打点审批流 + 评分** | `punctuate`、`punctuate_audit`（pass/reject/delete，含角色校验与事务化晋升）、`score`（data/generate，字段级加权） | 高 — 状态机 + 生成逻辑 | **已完成** |
 | 5 | **系统域** | `user`、`role`、`device`、`invitation`、`action_log`、`archive`（rename/delete_slot 已补齐） | 中 — 鉴权与权限耦合 | **已完成** — 登录设备登记 + access_policy 校验已接线 |
 | 6 | **BinaryMD5 归档导出** | `item_doc`、`marker_doc`、`marker_link_doc` 的 bin/md5 端点；GZIP 压缩 + 进程内缓存（moka，300s TTL） | 高 — 二进制协议还原 | **已完成** |
-| 7 | **OAuth2 / JWKS** | `oauth` 路由（password / QQ / client_credentials）、`/.well-known/jwks.json`、access_policy 检查、scope 映射 | 高 — 安全敏感 | **大部分完成** — 仍为 HMAC(HS256) 签名；RSA 密钥对与 JWK 轮换尚未实现 |
+| 7 | **OAuth2 / JWKS** | `oauth` 路由（password / QQ / client_credentials）、`/.well-known/jwks.json`、access_policy 检查、scope 映射 | 高 — 安全敏感 | **大部分完成** — RS256 签名与 RSA JWKS 已实现（`JWT_RSA_PRIVATE_KEY_PEM`）；JWK 轮换仍未实现；HS256 模式下 JWKS 返回空 key set（不泄露 HMAC 密钥） |
 
 ## 当前状态
 
@@ -32,8 +32,7 @@ Rust 后端的目标是与 Java 参考实现 `java-genshin-map-cloud` 功能对�
 
 ## 已知差距（与 Java 的剩余差异）
 
-- 批次 7：token 签名为 HMAC-SHA256；Java 侧为 RSA 密钥对 + JWK 轮换。
-  当前 JWKS 以 `oct` 形式公布 HMAC 密钥；切换 RSA 时需引入密钥管理与轮换。
+- 批次 7：JWK 轮换未实现（密钥固定，无轮换机制）；HS256 模式下 JWKS 为空 key set（签名密钥不对外公布）。
 - 数据库 schema 与真实库的偏差待数据验证（`marker_linkage` 空值列、
   `sys_user_archive` 结构绑定等）。
 - 文档翻译：`docs/` 下仅 en/zhs 完整，其余 9 种语言为骨架。

--- a/tests/rust/tests/user_db_test.rs
+++ b/tests/rust/tests/user_db_test.rs
@@ -61,9 +61,8 @@ async fn recreate_table(db: &sea_orm::DatabaseConnection) -> anyhow::Result<()> 
     Ok(())
 }
 
-/// Insert a user row directly via the entity (bypassing `do_register`, which
-/// hard-codes id=0 and would collide on the second insert — see PLAN.md F8).
-/// Lets the IDENTITY column assign the id and returns it.
+/// Insert a user row directly via the entity (avoids the bcrypt round-trip of
+/// `do_register`). Lets the IDENTITY column assign the id and returns it.
 async fn seed_user(db: &sea_orm::DatabaseConnection) -> anyhow::Result<i64> {
     use chrono::Utc;
     use sea_orm::ActiveValue::Set;


### PR DESCRIPTION
## Summary

Resync the docs with the audit findings (secondary audit D-items).

## Motivation

The secondary audit flagged stale/misleading docs: the roadmap still claimed HMAC-only signing (RS256 landed in #42 and the key-disclosure fix in #51 changed HS256 JWKS behavior), the API-reference listed Java-style route prefixes, the architecture doc claimed non-existent logging/rate-limit middleware, the README advertised `tracing-subscriber` (never initialized), PLAN.md milestones had no status, and a stale test comment referenced a fixed bug.

## Changes

- **roadmaps (zhs/en)**: batch-7 status updated — RS256 signing + RSA JWKS done; remaining gap is JWK rotation; HS256 mode publishes an empty key set.
- **`api-reference.md`**: `/iconType` → `/icon_type`, `/itemType` → `/item_type`, `/markerLink` → `/marker_link`, `/markerLinkDoc` → `/marker_link_doc`, `/punctuateAudit` → `/punctuate_audit`.
- **`architecture.md`**: middleware list corrected (auth / IP / user-agent only).
- **`README.md`**: tech-stack table lists `env_logger` (the actual logger).
- **`PLAN.md`**: milestone headers carry completion status (M1–M3, M5 done; M4 partial — Redis tier not done).
- **`user_db_test.rs`**: stale "hard-codes id=0" comment fixed.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] Docs-only change; no Rust code touched (test comment edit is comment-only)

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (this PR is the documentation)

## Breaking Changes

None.
