### PR TITLE
🐛 Stop treating 401 and 403 responses as e2e passes.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,8 @@ JWT_SECRET=change-me-to-a-strong-random-secret
 # Absolute path to the Vue3 frontend project (required for `just dev`).
 # Clone from: https://github.com/kongying-tavern/vue_map_register_v3
 E2E_VUE_FRONTEND=/absolute/path/to/vue_map_register_v3
+# Optional: a real backend account used by the e2e API assertions
+# (scripts/e2e/run_tests.py). Without these, the authenticated API tests
+# SKIP explicitly — a 401/403 is never treated as a pass.
+# E2E_USERNAME=
+# E2E_PASSWORD=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   logger (`env_logger`); PLAN.md milestone headers carry completion
   status; and a stale `user_db` test comment is fixed.
 
+- Fix the e2e script honesty (secondary audit T-item): `run_tests.py`
+  no longer treats 401/403 as "route exists ✓". API tests now log in
+  via `E2E_USERNAME` / `E2E_PASSWORD` (password grant) and assert the
+  response shape; without credentials they report an explicit SKIP
+  (never a pass). `.env.example` documents the new variables.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/scripts/e2e/run_tests.py
+++ b/scripts/e2e/run_tests.py
@@ -63,20 +63,65 @@ def _wait_for_shirabe(timeout: float = 30) -> bool:
 
 TESTS_PASSED = 0
 TESTS_FAILED = 0
+TESTS_SKIPPED = 0
+
+
+class SkipTest(Exception):
+    """Raised when a test cannot run in the current environment (e.g. no
+    credentials configured). Reported as SKIP — never as PASS or FAIL."""
 
 
 def test(name: str, fn):
-    """Run a test function, reporting pass/fail."""
-    global TESTS_PASSED, TESTS_FAILED
+    """Run a test function, reporting pass/fail/skip."""
+    global TESTS_PASSED, TESTS_FAILED, TESTS_SKIPPED
     print(f"\n{'─' * 60}")
     print(f"TEST: {name}")
     try:
         fn()
         TESTS_PASSED += 1
         print(f"  ✅ PASS")
+    except SkipTest as e:
+        TESTS_SKIPPED += 1
+        print(f"  ⏭️  SKIP: {e}")
     except Exception as e:
         TESTS_FAILED += 1
         print(f"  ❌ FAIL: {e}")
+
+
+def _api_headers() -> dict:
+    """Authenticated headers for API calls.
+
+    When E2E_USERNAME / E2E_PASSWORD are set, logs in via the password grant
+    and returns an Authorization bearer header. Otherwise returns an empty
+    header set — the API tests then SKIP instead of treating 401/403 as a
+    pass.
+    """
+    import os
+    import urllib.parse
+
+    username = os.environ.get("E2E_USERNAME")
+    password = os.environ.get("E2E_PASSWORD")
+    if not username or not password:
+        raise SkipTest(
+            "no E2E_USERNAME / E2E_PASSWORD configured — set them to run "
+            "authenticated API assertions"
+        )
+    body = urllib.parse.urlencode({
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{RUST_URL}/oauth/token",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    token = data.get("access_token")
+    if not token:
+        raise SkipTest(f"login succeeded but no access_token in response: {data}")
+    return {"Authorization": f"Bearer {token}"}
 
 
 def test_page_loads():
@@ -120,59 +165,76 @@ def test_page_loads():
 
 
 def test_api_area_list():
-    """Verify the Rust backend serves area data through the Vite proxy."""
+    """Verify the Rust backend serves area data through the Vite proxy.
+
+    Requires configured credentials (E2E_USERNAME / E2E_PASSWORD): without
+    them the test SKIPs — a 401/403 is no longer treated as a pass.
+    """
     import urllib.error
     import urllib.request as ur
 
+    headers = _api_headers()
+    headers["Content-Type"] = "application/json"
     url = f"{VUE_URL}/api/area/get/list"
-    req = ur.Request(url, method="POST", data=b"{}",
-                     headers={"Content-Type": "application/json"})
+    req = ur.Request(url, method="POST", data=b"{}", headers=headers)
     try:
         with ur.urlopen(req, timeout=10) as resp:
             body = resp.read().decode("utf-8")
             print(f"  Response: {body[:200]}...")
+            payload = json.loads(body)
+            if "data" not in payload and "items" not in payload:
+                raise Exception(f"unexpected response shape: {body[:200]}")
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
-            print(f"  (Auth required — route exists ✓, HTTP {e.code})")
-        else:
-            raise Exception(f"HTTP {e.code}: {e.read().decode('utf-8', errors='replace')[:200]}")
+            raise SkipTest(f"endpoint requires auth (HTTP {e.code}) — "
+                           "check E2E_USERNAME / E2E_PASSWORD")
+        raise Exception(f"HTTP {e.code}: {e.read().decode('utf-8', errors='replace')[:200]}")
     except Exception as e:
         raise Exception(f"API call failed: {e}")
 
 
 def test_api_marker_doc_md5():
-    """Verify the BinaryMD5 marker doc endpoint returns MD5 list."""
+    """Verify the BinaryMD5 marker doc endpoint returns the MD5 list."""
     import urllib.request as ur
 
+    headers = _api_headers()
     url = f"{VUE_URL}/api/marker_doc/list_page_bin_md5"
-    req = ur.Request(url, method="GET")
+    req = ur.Request(url, method="GET", headers=headers)
     try:
         with ur.urlopen(req, timeout=15) as resp:
             body = resp.read().decode("utf-8")
             print(f"  Response: {body[:200]}...")
-    except Exception as e:
-        # This endpoint requires auth — a 401/403 is acceptable (proves the route exists)
-        if "401" in str(e) or "403" in str(e):
-            print(f"  (Auth required — route exists ✓)")
-        else:
-            raise Exception(f"API call failed: {e}")
+            payload = json.loads(body)
+            data = payload.get("data") if isinstance(payload, dict) else None
+            if not isinstance(data, list):
+                raise Exception(f"expected a data list, got: {body[:200]}")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            raise SkipTest(f"endpoint requires auth (HTTP {e.code}) — "
+                           "check E2E_USERNAME / E2E_PASSWORD")
+        raise Exception(f"HTTP {e.code}: {e.read().decode('utf-8', errors='replace')[:200]}")
 
 
 def test_api_item_doc_md5():
-    """Verify the BinaryMD5 item doc endpoint returns MD5 list."""
+    """Verify the BinaryMD5 item doc endpoint returns the MD5 list."""
     import urllib.request as ur
 
+    headers = _api_headers()
     url = f"{VUE_URL}/api/item_doc/list_page_bin_md5"
-    req = ur.Request(url, method="GET")
+    req = ur.Request(url, method="GET", headers=headers)
     try:
         with ur.urlopen(req, timeout=15) as resp:
             body = resp.read().decode("utf-8")
             print(f"  Response: {body[:200]}...")
-    except Exception as e:
-        if "401" in str(e) or "403" in str(e):
-            print(f"  (Auth required — route exists ✓)")
-        else:
-            raise Exception(f"API call failed: {e}")
+            payload = json.loads(body)
+            data = payload.get("data") if isinstance(payload, dict) else None
+            if not isinstance(data, list):
+                raise Exception(f"expected a data list, got: {body[:200]}")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            raise SkipTest(f"endpoint requires auth (HTTP {e.code}) — "
+                           "check E2E_USERNAME / E2E_PASSWORD")
+        raise Exception(f"HTTP {e.code}: {e.read().decode('utf-8', errors='replace')[:200]}")
 
 
 def test_rust_health():
@@ -233,7 +295,7 @@ def main() -> int:
 
         # Summary
         print(f"\n{'═' * 60}")
-        print(f"RESULTS: {TESTS_PASSED} passed, {TESTS_FAILED} failed")
+        print(f"RESULTS: {TESTS_PASSED} passed, {TESTS_FAILED} failed, {TESTS_SKIPPED} skipped")
         print(f"Screenshots: {SCREENSHOTS_DIR}")
         return 0 if TESTS_FAILED == 0 else 1
     finally:


### PR DESCRIPTION
## Summary

Stop treating 401 and 403 responses as e2e passes (secondary audit T-item).

## Motivation

`run_tests.py` treated 401/403 as "route exists ✓" — three API tests could "pass" without ever exercising any data. The audit flagged this as dishonest test reporting (the earlier "e2e business assertions" PR only upgraded the Rust `api_db` tests, not the Python script).

## Changes

- **`scripts/e2e/run_tests.py`**:
  - New `SkipTest` exception + skip reporting in the runner (SKIP is never a pass).
  - `_api_headers()` logs in via the OAuth password grant using `E2E_USERNAME` / `E2E_PASSWORD` and returns a bearer header.
  - The three API tests now assert the response **shape** (JSON `data` list for the md5 endpoints) with credentials; without credentials (or on 401/403) they raise an explicit SKIP.
- **`.env.example`**: documents `E2E_USERNAME` / `E2E_PASSWORD`.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `python -c "import ast; ast.parse(...)"` — syntax OK
- [x] No Rust code touched

## Checklist

- [x] `cargo fmt --check` passes (no Rust code touched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (no Rust code touched)
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example)

## Breaking Changes

The e2e suite no longer reports 401/403 as passes — without credentials those tests are explicitly skipped (or fail on real auth errors).
