### PR TITLE
🔧 Replace blocking redis KEYS with SCAN and time out the CDN proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   response shape; without credentials they report an explicit SKIP
   (never a pass). `.env.example` documents the new variables.
 
+- Harden the remaining secondary-audit minors: `do_kick_out` now uses
+  SCAN + pipeline instead of blocking `KEYS` (with a batched cursor
+  walk); the CDN proxy client has connect (5s) and overall (15s)
+  timeouts instead of hanging indefinitely on a stuck upstream.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -271,7 +271,6 @@ pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
         // Redis 不可用时退化为无操作（与 oauth 的降级策略一致）
         return Ok(());
     };
-    use redis::AsyncCommands;
     let Ok(mut redis_conn) = redis_client.get_multiplexed_async_connection().await else {
         // Redis 连接失败同样降级（与 oauth 的降级策略一致）
         return Ok(());
@@ -279,11 +278,43 @@ pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
 
     let access_prefix = format!("jwt:access:{user_id}:*");
     let refresh_prefix = format!("jwt:refresh:{user_id}:*");
-    for key in redis_conn.keys::<_, Vec<String>>(access_prefix).await? {
-        let _: usize = redis_conn.del(&key).await?;
-    }
-    for key in redis_conn.keys::<_, Vec<String>>(refresh_prefix).await? {
-        let _: usize = redis_conn.del(&key).await?;
+    // 用 SCAN + pipeline 而非 KEYS：KEYS 会阻塞 Redis 主线程（大 key 空间下
+    // 长时间阻塞），SCAN 按游标分批遍历；收集后一次 pipeline 删除。
+    for prefix in [access_prefix, refresh_prefix] {
+        let keys = scan_keys(&mut redis_conn, &prefix).await?;
+        if keys.is_empty() {
+            continue;
+        }
+        let mut pipe = redis::pipe();
+        for k in &keys {
+            pipe.cmd("DEL").arg(k);
+        }
+        pipe.query_async::<()>(&mut redis_conn).await?;
     }
     Ok(())
+}
+
+/// 用 SCAN 游标分批收集匹配 pattern 的 key（不阻塞 Redis 主线程）。
+async fn scan_keys(
+    redis_conn: &mut redis::aio::MultiplexedConnection,
+    pattern: &str,
+) -> Result<Vec<String>> {
+    let mut keys = Vec::new();
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg(pattern)
+            .arg("COUNT")
+            .arg(500)
+            .query_async(redis_conn)
+            .await?;
+        keys.extend(batch);
+        cursor = next;
+        if cursor == 0 {
+            break;
+        }
+    }
+    Ok(keys)
 }

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -63,8 +63,16 @@ fn cdn_proxy() -> axum::Router {
     use axum::extract::State;
     use axum::http::Request;
     use axum::response::{IntoResponse, Response};
+    use std::time::Duration;
 
-    let client = std::sync::Arc::new(reqwest::Client::new());
+    // 上游挂起时不能无限等待：连接 5s、整体 15s 超时。
+    let client = std::sync::Arc::new(
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("build cdn client"),
+    );
     let upstream = cdn_upstream();
     let dadian_override = dadian_config_file();
 


### PR DESCRIPTION
## Summary

Replace blocking redis KEYS with SCAN and time out the CDN proxy (secondary-audit minors).

## Motivation

- `do_kick_out` used Redis `KEYS jwt:access:{uid}:*` + per-key `DEL` — `KEYS` blocks the Redis main thread on large key spaces, and the deletes were N round-trips.
- The CDN proxy used `reqwest::Client::new()` with **no timeouts** — a stuck upstream hangs the handler forever.

## Changes

- **`packages/functions/.../system/user.rs`**: `do_kick_out` now walks the keyspace with `SCAN` (cursor batches of 500, `MATCH` pattern) via a new `scan_keys` helper, then deletes all matches in one `redis::pipe()`. The `KEYS` command and per-key `DEL` loop are gone.
- **`packages/router/.../routes/mod.rs`**: the CDN client is built with `connect_timeout(5s)` + `timeout(15s)`.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Runtime SCAN behavior requires Redis; the existing kick_out degradation path (no Redis → no-op) is covered by `user_db` tests.

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None.
