### PR TITLE
🐛 Apply the dropped list filters and skip credentials in tracing spans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   walk); the CDN proxy client has connect (5s) and overall (15s)
   timeouts instead of hanging indefinitely on a stuck upstream.
 
+- Apply the dropped filters and tighten tracing (secondary-audit
+  minors): the action-log list now filters by `action` (the parameter
+  was parsed but ignored), the device list now honors the requested
+  `user_id` (it was hard-coded to `None`), and the four user handlers
+  taking passwords (`register`, `register_qq`, `update_password`,
+  `update_password_by_admin`) skip the payload in their tracing spans
+  so credentials never land in logs.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/system/action_log.rs
+++ b/packages/functions/src/functions/system/action_log.rs
@@ -4,13 +4,16 @@ use anyhow::Result;
 use sea_orm::{QueryFilter, QuerySelect, prelude::*};
 
 use _database::{DB_CONN, models::system::sys_action_log as log_model};
-use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
+use _utils::{
+    db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse,
+    types::SystemActionLogAction,
+};
 
 /// List action logs with optional filtering by user_id / action.
 pub async fn do_list(
     _auth: AuthInfo,
     user_id: Option<i64>,
-    _action: Option<i64>,
+    action: Option<i64>,
     size: u64,
     current: u64,
 ) -> Result<CommonResponse<serde_json::Value>> {
@@ -19,6 +22,20 @@ pub async fn do_list(
 
     if let Some(uid) = user_id {
         query = query.filter(log_model::Column::UserId.eq(uid));
+    }
+    if let Some(action) = action {
+        // ActionLogAction is a fieldless enum: Login = 0 (see types/action_log.rs).
+        let enum_val = match action {
+            0 => SystemActionLogAction::Login,
+            other => {
+                return Ok(CommonResponse::new(Ok(serde_json::json!({
+                    "total": 0,
+                    "list": [],
+                    "note": format!("unknown action filter: {other}"),
+                }))));
+            },
+        };
+        query = query.filter(log_model::Column::Action.eq(enum_val));
     }
 
     let total = query.clone().count(db).await?;

--- a/packages/router/src/routes/system/device.rs
+++ b/packages/router/src/routes/system/device.rs
@@ -76,7 +76,7 @@ pub async fn list(
 
     match _functions::functions::system::device::do_list(
         auth,
-        None,
+        payload.user_id,
         payload.device_id,
         payload.status.map(|s| s as i32),
         size,

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -139,7 +139,7 @@ pub struct UserKickOutParams {
 
 /// 注册用户
 /// POST /user/register
-#[tracing::instrument(skip(auth))]
+#[tracing::instrument(skip(auth, payload))]
 pub async fn register(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserRegisterParams>,
@@ -164,7 +164,7 @@ pub async fn register(
 
 /// 用QQ注册用户
 /// POST /user/register/qq
-#[tracing::instrument(skip(auth))]
+#[tracing::instrument(skip(auth, payload))]
 pub async fn register_qq(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserRegisterQQParams>,
@@ -236,7 +236,7 @@ pub async fn update(
 
 /// 更新用户密码
 /// POST /user/update_password
-#[tracing::instrument(skip(auth))]
+#[tracing::instrument(skip(auth, payload))]
 pub async fn update_password(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserUpdatePasswordParams>,
@@ -262,7 +262,7 @@ pub async fn update_password(
 
 /// 更新用户密码（管理员）
 /// POST /user/update_password_by_admin
-#[tracing::instrument(skip(auth))]
+#[tracing::instrument(skip(auth, payload))]
 pub async fn update_password_by_admin(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserUpdatePasswordByAdminParams>,


### PR DESCRIPTION
## Summary

Apply the dropped list filters and skip credentials in tracing spans (secondary-audit minors).

## Motivation

- `action_log::do_list` received the `action` filter but **ignored it** (`_action`).
- The device list route parsed `payload.user_id` but passed hard-coded `None` to `do_list`.
- The four user handlers taking passwords logged the whole payload into tracing spans (latent credential leak once a subscriber is initialized).

## Changes

- **`packages/functions/.../system/action_log.rs`**: the `action` filter is applied — `ActionLogAction` is a fieldless enum (`Login = 0`), mapped back to `SystemActionLogAction` and filtered via the entity column; unknown values return an explicit empty result.
- **`packages/router/.../system/device.rs`**: `payload.user_id` is passed through.
- **`packages/router/.../system/user.rs`**: `register` / `register_qq` / `update_password` / `update_password_by_admin` spans become `skip(auth, payload)`.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — the previously ignored filters now take effect (intended).
