### PR TITLE
🔒 Harden the image upload endpoint against arbitrary files and leaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `update_password_by_admin`) skip the payload in their tracing spans
   so credentials never land in logs.
 
+- Harden the image upload endpoint (secondary-audit minor): a
+  content-type whitelist (png/jpeg/gif/webp) rejects arbitrary file
+  uploads, single-field size is capped at 16 MiB, and the response no
+  longer leaks the server filesystem path.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/router/src/routes/api/res/upload.rs
+++ b/packages/router/src/routes/api/res/upload.rs
@@ -7,6 +7,11 @@ use std::path::PathBuf;
 
 use crate::middlewares::ExtractAuthInfo;
 
+/// 允许上传的内容类型白名单。
+const ALLOWED_IMAGE_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif", "image/webp"];
+/// 单个上传字段的大小上限（16 MiB，与全局 DefaultBodyLimit 一致）。
+const MAX_FIELD_BYTES: usize = 16 * 1024 * 1024;
+
 /// 上传图片
 #[tracing::instrument(skip(auth))]
 pub async fn upload_image(
@@ -29,14 +34,32 @@ pub async fn upload_image(
             .content_type()
             .map(|ct| ct.to_string())
             .unwrap_or_default();
+
+        // 内容类型白名单：拒绝非图片（防任意文件上传）。
+        if !ALLOWED_IMAGE_TYPES.contains(&content_type.as_str()) {
+            return Err((
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                format!(
+                    "unsupported content type '{content_type}' — allowed: {ALLOWED_IMAGE_TYPES:?}"
+                ),
+            ));
+        }
+
         let data = field.bytes().await.map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("multipart read bytes error: {}", e),
             )
         })?;
+        // 单字段大小上限（防磁盘耗尽）。
+        if data.len() > MAX_FIELD_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!("file exceeds the {MAX_FIELD_BYTES}-byte limit"),
+            ));
+        }
 
-        // generate a unique filename
+        // generate a unique filename（不信任用户文件名——仅取其扩展名）
         let uuid = uuid::Uuid::new_v4().to_string();
         let ext = PathBuf::from(&file_name)
             .extension()
@@ -65,11 +88,11 @@ pub async fn upload_image(
         let digest = md5::compute(&data);
         let md5_hex = format!("{:x}", digest);
 
+        // 不返回 filesystem_path：避免向客户端泄露服务器绝对路径。
         files_meta.push(serde_json::json!({
             "field_name": name,
             "original_file_name": file_name,
             "content_type": content_type,
-            "filesystem_path": file_path.to_string_lossy().to_string(),
             "size": size,
             "md5": md5_hex,
         }));


### PR DESCRIPTION
## Summary

Harden the image upload endpoint against arbitrary files and leaks (secondary-audit minor).

## Motivation

The `POST /res/upload_image` handler accepted **any** file (no content-type check), had no per-field size cap, and returned `filesystem_path` (the server's absolute temp path) to the client.

## Changes

- **`packages/router/.../api/res/upload.rs`**:
  - Content-type whitelist (`image/png` / `image/jpeg` / `image/gif` / `image/webp`) — anything else → 415.
  - Per-field size cap of 16 MiB → 413.
  - The response no longer includes `filesystem_path` (original filename, content type, size, md5 remain).
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] CI on this PR

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

Non-image uploads and files > 16 MiB are now rejected (intended); `filesystemPath` removed from the response (intended).
