### PR TITLE
⚡ Serve the BinaryMD5 doc endpoints from a result-level cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   uploads, single-field size is capped at 16 MiB, and the response no
   longer leaks the server filesystem path.
 
+### Performance
+
+- Eliminate the per-request full-table scan in the BinaryMD5 doc
+  endpoints (secondary-audit P2): `item_doc` / `marker_doc` /
+  `marker_link_doc` now serve both the md5 list and the compressed
+  pages from a **result-level cache** (same 300s TTL as the page
+  cache). A warm `list_page_bin_md5` / `list_page_bin` request
+  performs zero database queries — previously every request re-ran
+  `find_safety().all()` over the whole dataset (100k+ markers) before
+  consulting the per-page cache. The refresh endpoints flush both
+  caches.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -92,4 +92,44 @@ pub async fn invalidate(key: &str) {
 /// cheaply, so a full flush is the simple correct invalidation.
 pub fn invalidate_all() {
     BIN_CACHE.invalidate_all();
+    RESULT_CACHE.invalidate_all();
+}
+
+/// Result-level cache entry: one page's md5 metadata plus its compressed
+/// bytes, so both the md5-list and the bin-fetch endpoints can be served
+/// without any database scan on a warm hit.
+#[derive(Debug, Clone)]
+pub struct ResultEntry {
+    /// Domain page key (e.g. `item:0`, `marker:0:123`, `link:list`).
+    pub key: String,
+    pub vo: BinaryMd5Vo,
+    pub bytes: Vec<u8>,
+}
+
+/// Result-level cache: the fully computed page set for a domain (e.g.
+/// `item:result`, `marker:result`, `link:list-result`).
+///
+/// Without it, every `list_page_bin_md5` / `list_page_bin` request re-ran the
+/// full `find_safety().all()` scan (100k+ markers) before the per-page cache
+/// could be consulted. With it, a warm hit performs **zero** database
+/// queries.
+static RESULT_CACHE: Lazy<moka::future::Cache<String, Vec<ResultEntry>>> = Lazy::new(|| {
+    moka::future::Cache::builder()
+        .max_capacity(64)
+        .time_to_live(Duration::from_secs(300))
+        .build()
+});
+
+/// Fetch the full page set for a domain from the cache, or compute it via
+/// `compute` and store it.
+pub async fn get_result_cached(
+    key: String,
+    compute: impl std::future::Future<Output = anyhow::Result<Vec<ResultEntry>>>,
+) -> anyhow::Result<Vec<ResultEntry>> {
+    if let Some(cached) = RESULT_CACHE.get(&key).await {
+        return Ok(cached);
+    }
+    let result = compute.await?;
+    RESULT_CACHE.insert(key, result.clone()).await;
+    Ok(result)
 }

--- a/packages/functions/src/functions/api/item_doc.rs
+++ b/packages/functions/src/functions/api/item_doc.rs
@@ -4,6 +4,9 @@
 //! Items are grouped by `hidden_flag`, each group becomes one page (index 0),
 //! serialized to JSON, GZIP-compressed, and keyed by the MD5 of the compressed
 //! bytes.
+//!
+//! A result-level cache avoids re-scanning the whole table on every request:
+//! a warm `get_result_cached("item:result", ...)` performs zero DB queries.
 
 use anyhow::{Result, anyhow};
 use std::collections::BTreeMap;
@@ -11,87 +14,79 @@ use std::collections::BTreeMap;
 use _database::{DB_CONN, models::item::item as item_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
+use super::binary_doc::{
+    BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
+};
 
 /// `GET /item_doc/list_page_bin_md5`
 ///
 /// Returns the MD5 list for all item pages. Each `hidden_flag` group is a
-/// single page (index 0). Pages are served from the in-process cache; the
-/// `time` field is the page's generation timestamp (stable within the cache
-/// TTL), not the request time.
+/// single page (index 0). Served from the result cache — no DB scan on a
+/// warm hit.
 pub async fn do_list_page_bin_md5(
     _auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<Vec<BinaryMd5Vo>>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    // Query all non-deleted items
-    let items = item_model::Entity::find_safety().all(db).await?;
-
-    // Group by hidden_flag (BTreeMap → sorted by flag value ascending)
-    let mut groups: BTreeMap<i32, Vec<&item_model::Model>> = BTreeMap::new();
-    for item in &items {
-        groups
-            .entry(item.hidden_flag as i32)
-            .or_default()
-            .push(item);
-    }
-
-    // Each group → one page → cached (serialize + compress + MD5)
-    let mut result = Vec::with_capacity(groups.len());
-    for (flag, group_items) in &groups {
-        let page = get_or_compute(format!("item:{flag}"), async {
-            let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
-            Ok(CachedPage {
-                md5: md5_hex,
-                time: chrono::Utc::now().timestamp_millis(),
-                bytes: compressed,
-            })
-        })
-        .await?;
-        result.push(BinaryMd5Vo {
-            md5: page.md5,
-            time: page.time,
-        });
-    }
-
-    Ok(CommonResponse::new(Ok(result)))
+    let entries = item_result().await?;
+    Ok(CommonResponse::new(Ok(entries
+        .iter()
+        .map(|e| e.vo.clone())
+        .collect())))
 }
 
 /// `GET /item_doc/list_page_bin/{md5}`
 ///
 /// Returns the GZIP-compressed JSON bytes for the page whose MD5 matches.
-/// Pages are (re)generated on miss and cached, so a second fetch of the same
-/// md5 hits the cache instead of re-serializing the whole dataset.
+/// Served from the result cache — no DB scan on a warm hit.
 pub async fn do_list_page_bin(_auth: AuthInfo, md5: String) -> Result<Vec<u8>> {
+    let entries = item_result().await?;
+    entries
+        .iter()
+        .find(|e| e.vo.md5 == md5)
+        .map(|e| e.bytes.clone())
+        .ok_or_else(|| anyhow!("分页数据未生成或超出获取范围"))
+}
+
+/// Compute (and cache) the full item page set.
+async fn item_result() -> Result<Vec<ResultEntry>> {
     let db = &DB_CONN.wait().pg_conn;
 
-    let items = item_model::Entity::find_safety().all(db).await?;
+    get_result_cached("item:result".into(), async {
+        // Query all non-deleted items (once per TTL window)
+        let items = item_model::Entity::find_safety().all(db).await?;
 
-    // Group by hidden_flag
-    let mut groups: BTreeMap<i32, Vec<&item_model::Model>> = BTreeMap::new();
-    for item in &items {
-        groups
-            .entry(item.hidden_flag as i32)
-            .or_default()
-            .push(item);
-    }
-
-    // Find the page whose compressed MD5 matches
-    for (flag, group_items) in &groups {
-        let page = get_or_compute(format!("item:{flag}"), async {
-            let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
-            Ok(CachedPage {
-                md5: md5_hex,
-                time: chrono::Utc::now().timestamp_millis(),
-                bytes: compressed,
-            })
-        })
-        .await?;
-        if page.md5 == md5 {
-            return Ok(page.bytes);
+        // Group by hidden_flag (BTreeMap → sorted by flag value ascending)
+        let mut groups: BTreeMap<i32, Vec<&item_model::Model>> = BTreeMap::new();
+        for item in &items {
+            groups
+                .entry(item.hidden_flag as i32)
+                .or_default()
+                .push(item);
         }
-    }
 
-    Err(anyhow!("分页数据未生成或超出获取范围"))
+        // Each group → one page → cached (serialize + compress + MD5)
+        let mut entries = Vec::with_capacity(groups.len());
+        for (flag, group_items) in &groups {
+            let key = format!("item:{flag}");
+            let page = get_or_compute(key.clone(), async {
+                let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
+                Ok(CachedPage {
+                    md5: md5_hex,
+                    time: chrono::Utc::now().timestamp_millis(),
+                    bytes: compressed,
+                })
+            })
+            .await?;
+            entries.push(ResultEntry {
+                key,
+                vo: BinaryMd5Vo {
+                    md5: page.md5,
+                    time: page.time,
+                },
+                bytes: page.bytes,
+            });
+        }
+        Ok(entries)
+    })
+    .await
 }

--- a/packages/functions/src/functions/api/marker_doc.rs
+++ b/packages/functions/src/functions/api/marker_doc.rs
@@ -4,6 +4,8 @@
 //! Markers are grouped by `hidden_flag`; the **normal** group (flag 0) is
 //! further split into pages of 3000 by `marker.id / 3000`. All other flag
 //! groups are a single page (index 0).
+//!
+//! A result-level cache avoids re-scanning the whole table on every request.
 
 use anyhow::{Result, anyhow};
 use std::collections::BTreeMap;
@@ -11,7 +13,11 @@ use std::collections::BTreeMap;
 use _database::{DB_CONN, models::marker::marker as marker_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
+use super::binary_doc::{
+    BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
+};
+
+use _utils::types::HiddenFlag;
 
 /// Page size for the normal (flag 0) marker group.
 const MARKER_PAGE_SIZE: i64 = 3000;
@@ -21,100 +27,93 @@ fn marker_page_key(flag: i32, page_index: i64) -> String {
     format!("marker:{flag}:{page_index}")
 }
 
-/// Compute (and cache) one marker page. Returns the cached page entry.
-async fn marker_page(
-    flag: i32,
-    page_index: i64,
-    page_markers: &[&marker_model::Model],
-) -> Result<CachedPage> {
-    get_or_compute(marker_page_key(flag, page_index), async {
-        let (compressed, md5_hex) = serialize_compress_md5(&page_markers)?;
-        Ok(CachedPage {
-            md5: md5_hex,
-            time: chrono::Utc::now().timestamp_millis(),
-            bytes: compressed,
-        })
-    })
-    .await
-}
-
 /// `GET /marker_doc/list_page_bin_md5`
 pub async fn do_list_page_bin_md5(
     _auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<Vec<BinaryMd5Vo>>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    let markers = marker_model::Entity::find_safety().all(db).await?;
-
-    // Group by hidden_flag (BTreeMap → sorted ascending)
-    let mut groups: BTreeMap<i32, Vec<&marker_model::Model>> = BTreeMap::new();
-    for m in &markers {
-        groups.entry(m.hidden_flag as i32).or_default().push(m);
-    }
-
-    let mut result = Vec::new();
-    for (flag, group_markers) in &groups {
-        if *flag == HiddenFlag::Visible as i32 {
-            // Normal group: split into pages of MARKER_PAGE_SIZE by id
-            let mut pages: BTreeMap<i64, Vec<&marker_model::Model>> = BTreeMap::new();
-            for m in group_markers {
-                let page_index = m.id / MARKER_PAGE_SIZE;
-                pages.entry(page_index).or_default().push(m);
-            }
-            for (page_index, page_markers) in &pages {
-                let page = marker_page(*flag, *page_index, page_markers).await?;
-                result.push(BinaryMd5Vo {
-                    md5: page.md5,
-                    time: page.time,
-                });
-            }
-        } else {
-            // Other flags: single page (index 0)
-            let page = marker_page(*flag, 0, group_markers).await?;
-            result.push(BinaryMd5Vo {
-                md5: page.md5,
-                time: page.time,
-            });
-        }
-    }
-
-    Ok(CommonResponse::new(Ok(result)))
+    let entries = marker_result().await?;
+    Ok(CommonResponse::new(Ok(entries
+        .iter()
+        .map(|e| e.vo.clone())
+        .collect())))
 }
 
 /// `GET /marker_doc/list_page_bin/{md5}`
 pub async fn do_list_page_bin(_auth: AuthInfo, md5: String) -> Result<Vec<u8>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    let markers = marker_model::Entity::find_safety().all(db).await?;
-
-    let mut groups: BTreeMap<i32, Vec<&marker_model::Model>> = BTreeMap::new();
-    for m in &markers {
-        groups.entry(m.hidden_flag as i32).or_default().push(m);
-    }
-
-    for (flag, group_markers) in &groups {
-        if *flag == HiddenFlag::Visible as i32 {
-            let mut pages: BTreeMap<i64, Vec<&marker_model::Model>> = BTreeMap::new();
-            for m in group_markers {
-                let page_index = m.id / MARKER_PAGE_SIZE;
-                pages.entry(page_index).or_default().push(m);
-            }
-            for (page_index, page_markers) in &pages {
-                let page = marker_page(*flag, *page_index, page_markers).await?;
-                if page.md5 == md5 {
-                    return Ok(page.bytes);
-                }
-            }
-        } else {
-            let page = marker_page(*flag, 0, group_markers).await?;
-            if page.md5 == md5 {
-                return Ok(page.bytes);
-            }
-        }
-    }
-
-    Err(anyhow!("分页数据未生成或超出获取范围"))
+    let entries = marker_result().await?;
+    entries
+        .iter()
+        .find(|e| e.vo.md5 == md5)
+        .map(|e| e.bytes.clone())
+        .ok_or_else(|| anyhow!("分页数据未生成或超出获取范围"))
 }
 
-use _utils::types::HiddenFlag;
+/// Compute (and cache) the full marker page set.
+async fn marker_result() -> Result<Vec<ResultEntry>> {
+    let db = &DB_CONN.wait().pg_conn;
+
+    get_result_cached("marker:result".into(), async {
+        let markers = marker_model::Entity::find_safety().all(db).await?;
+
+        // Group by hidden_flag (BTreeMap → sorted ascending)
+        let mut groups: BTreeMap<i32, Vec<&marker_model::Model>> = BTreeMap::new();
+        for m in &markers {
+            groups.entry(m.hidden_flag as i32).or_default().push(m);
+        }
+
+        let mut entries = Vec::new();
+        for (flag, group_markers) in &groups {
+            if *flag == HiddenFlag::Visible as i32 {
+                // Normal group: split into pages of MARKER_PAGE_SIZE by id
+                let mut pages: BTreeMap<i64, Vec<&marker_model::Model>> = BTreeMap::new();
+                for m in group_markers {
+                    let page_index = m.id / MARKER_PAGE_SIZE;
+                    pages.entry(page_index).or_default().push(m);
+                }
+                for (page_index, page_markers) in &pages {
+                    let key = marker_page_key(*flag, *page_index);
+                    let page = get_or_compute(key.clone(), async {
+                        let (compressed, md5_hex) = serialize_compress_md5(&page_markers)?;
+                        Ok(CachedPage {
+                            md5: md5_hex,
+                            time: chrono::Utc::now().timestamp_millis(),
+                            bytes: compressed,
+                        })
+                    })
+                    .await?;
+                    entries.push(ResultEntry {
+                        key,
+                        vo: BinaryMd5Vo {
+                            md5: page.md5,
+                            time: page.time,
+                        },
+                        bytes: page.bytes,
+                    });
+                }
+            } else {
+                // Other flags: single page (index 0)
+                let key = marker_page_key(*flag, 0);
+                let page = get_or_compute(key.clone(), async {
+                    let (compressed, md5_hex) = serialize_compress_md5(&group_markers)?;
+                    Ok(CachedPage {
+                        md5: md5_hex,
+                        time: chrono::Utc::now().timestamp_millis(),
+                        bytes: compressed,
+                    })
+                })
+                .await?;
+                entries.push(ResultEntry {
+                    key,
+                    vo: BinaryMd5Vo {
+                        md5: page.md5,
+                        time: page.time,
+                    },
+                    bytes: page.bytes,
+                });
+            }
+        }
+        Ok(entries)
+    })
+    .await
+}

--- a/packages/functions/src/functions/api/marker_link_doc.rs
+++ b/packages/functions/src/functions/api/marker_link_doc.rs
@@ -3,54 +3,30 @@
 //! Mirrors Java `MarkerLinkageDocController`. Single-blob shape (no per-flag
 //! paging): the entire dataset is one GZIP-compressed JSON blob.
 //! Two views: `list` (flat array) and `graph` (adjacency map). Both are cached
-//! in-process via `binary_doc::get_or_compute`.
+//! at the result level, so warm requests perform no database scan.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
 use _database::{DB_CONN, models::marker::marker_linkage as ml_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
-use super::binary_doc::{BinaryMd5Vo, CachedPage, get_or_compute, serialize_compress_md5};
+use super::binary_doc::{
+    BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
+};
 
 /// `GET /marker_link_doc/all_list_bin_md5` — MD5 of the flat linkage list blob.
 pub async fn do_all_list_bin_md5(
     _auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<BinaryMd5Vo>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    let page = get_or_compute("link:list".into(), async {
-        let linkages = ml_model::Entity::find_safety().all(db).await?;
-        let (compressed, md5_hex) = serialize_compress_md5(&linkages)?;
-        Ok(CachedPage {
-            md5: md5_hex,
-            time: chrono::Utc::now().timestamp_millis(),
-            bytes: compressed,
-        })
-    })
-    .await?;
-
-    Ok(CommonResponse::new(Ok(BinaryMd5Vo {
-        md5: page.md5,
-        time: page.time,
-    })))
+    let entry = linkage_result("link:list-result", false).await?;
+    Ok(CommonResponse::new(Ok(entry.vo)))
 }
 
 /// `GET /marker_link_doc/all_list_bin` — the flat linkage list blob (compressed bytes).
 pub async fn do_all_list_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    let page = get_or_compute("link:list".into(), async {
-        let linkages = ml_model::Entity::find_safety().all(db).await?;
-        let (compressed, md5_hex) = serialize_compress_md5(&linkages)?;
-        Ok(CachedPage {
-            md5: md5_hex,
-            time: chrono::Utc::now().timestamp_millis(),
-            bytes: compressed,
-        })
-    })
-    .await?;
-    Ok(page.bytes)
+    let entry = linkage_result("link:list-result", false).await?;
+    Ok(entry.bytes)
 }
 
 /// `GET /marker_link_doc/all_graph_bin_md5` — MD5 of the graph adjacency blob.
@@ -58,42 +34,51 @@ pub async fn do_all_graph_bin_md5(
     _auth: AuthInfo,
     _payload: serde_json::Value,
 ) -> Result<CommonResponse<BinaryMd5Vo>> {
-    let db = &DB_CONN.wait().pg_conn;
-
-    let page = get_or_compute("link:graph".into(), async {
-        let linkages = ml_model::Entity::find_safety().all(db).await?;
-        let graph = build_graph(&linkages);
-        let (compressed, md5_hex) = serialize_compress_md5(&graph)?;
-        Ok(CachedPage {
-            md5: md5_hex,
-            time: chrono::Utc::now().timestamp_millis(),
-            bytes: compressed,
-        })
-    })
-    .await?;
-
-    Ok(CommonResponse::new(Ok(BinaryMd5Vo {
-        md5: page.md5,
-        time: page.time,
-    })))
+    let entry = linkage_result("link:graph-result", true).await?;
+    Ok(CommonResponse::new(Ok(entry.vo)))
 }
 
 /// `GET /marker_link_doc/all_graph_bin` — the graph adjacency blob (compressed bytes).
 pub async fn do_all_graph_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
+    let entry = linkage_result("link:graph-result", true).await?;
+    Ok(entry.bytes)
+}
+
+/// Compute (and cache) one linkage blob view.
+async fn linkage_result(key: &'static str, graph: bool) -> Result<ResultEntry> {
     let db = &DB_CONN.wait().pg_conn;
 
-    let page = get_or_compute("link:graph".into(), async {
+    let entries = get_result_cached(key.to_string(), async {
         let linkages = ml_model::Entity::find_safety().all(db).await?;
-        let graph = build_graph(&linkages);
-        let (compressed, md5_hex) = serialize_compress_md5(&graph)?;
-        Ok(CachedPage {
-            md5: md5_hex,
-            time: chrono::Utc::now().timestamp_millis(),
-            bytes: compressed,
+        let data: serde_json::Value = if graph {
+            serde_json::to_value(build_graph(&linkages))?
+        } else {
+            serde_json::to_value(&linkages)?
+        };
+        let (compressed, md5_hex) = serialize_compress_md5(&data)?;
+        let page = get_or_compute(key.to_string(), async {
+            Ok(CachedPage {
+                md5: md5_hex,
+                time: chrono::Utc::now().timestamp_millis(),
+                bytes: compressed,
+            })
         })
+        .await?;
+        Ok(vec![ResultEntry {
+            key: key.to_string(),
+            vo: BinaryMd5Vo {
+                md5: page.md5,
+                time: page.time,
+            },
+            bytes: page.bytes,
+        }])
     })
     .await?;
-    Ok(page.bytes)
+
+    entries
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("empty linkage result"))
 }
 
 /// Build the adjacency map: marker_id → list of linked marker_ids.


### PR DESCRIPTION
## Summary

Serve the BinaryMD5 doc endpoints from a result-level cache (secondary-audit P2).

## Motivation

`item_doc` / `marker_doc` / `marker_link_doc` re-ran `find_safety().all()` over the **entire dataset on every request** (100k+ markers) — the per-page cache only skipped the compression/MD5 step, never the database scan.

## Changes

- **`binary_doc.rs`**: new result-level cache (`RESULT_CACHE`, 300s TTL) storing `ResultEntry { key, vo, bytes }` per domain; `get_result_cached` + `invalidate_all` now flushes both caches.
- **`item_doc.rs` / `marker_doc.rs` / `marker_link_doc.rs`**: both the md5-list and the bin-fetch handlers go through `get_result_cached("...:result", ...)`. A warm hit serves the response with **zero DB queries**; the bin handlers find the matching entry and return its cached bytes (no dependence on the per-page cache for correctness, since bytes live in the result entries).
- **`CHANGELOG.md`**: Unreleased Performance entry.

## Verification

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB) — the existing cache-stability / refresh assertions cover the new path in CI
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — same responses, now served without a DB scan on warm hits.
