### PR TITLE
🔒 Rate-limit logins, cap batch sizes, and drop sqlx trace logging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   consulting the per-page cache. The refresh endpoints flush both
   caches.
 
+- Harden the remaining security minors (secondary audit): the password
+  login now rate-limits per IP (fixed window, 5 failed attempts /
+  minute) to blunt brute force; all batch-ID endpoints (`item` join /
+  get-list / update / copy, `item_common` add, `item_type` move,
+  `marker` get-list, `route` get-list) reject payloads over 1000
+  entries so the sqlx 65535-parameter limit can't be hit; and the
+  sqlx SQL logging level drops from Trace to Info so bound values
+  (potentially sensitive) no longer land in logs.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/database/src/lib.rs
+++ b/packages/database/src/lib.rs
@@ -55,7 +55,8 @@ async fn build_db_map() -> Result<DatabaseConnectionMap> {
             .idle_timeout(Duration::from_secs(60))
             .max_lifetime(Duration::from_secs(30 * 60))
             .sqlx_logging(true)
-            .sqlx_logging_level(log::LevelFilter::Trace);
+            // Info 而非 Trace：Trace 会把绑定参数值（可能含敏感数据）打进日志。
+            .sqlx_logging_level(log::LevelFilter::Info);
         Database::connect(opt).await?
     };
     info!("Postgres is ready");

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -29,6 +29,16 @@ pub async fn do_update(
     _edit_same: bool,
     payload: Vec<ItemUpdateData>,
 ) -> Result<CommonResponse<()>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
     auth.require_non_anonymous()?;
     for p in payload {
         let item = item_model::Entity::find_safety_by_id(p.id)
@@ -128,6 +138,16 @@ pub async fn do_join_type(
     type_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<()>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
     auth.require_non_anonymous()?;
     for item_id in payload {
         // 查找现有 link
@@ -165,6 +185,16 @@ pub async fn do_get_list_by_id(
     _auth: AuthInfo,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<ItemListResponse>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
     let db = &DB_CONN.wait().pg_conn;
     let items = item_model::Entity::find_safety()
         .filter(item_model::Column::Id.is_in(payload))
@@ -213,6 +243,17 @@ pub async fn do_copy_to_area(
     area_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<CopyCountResponse>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
+
     auth.require_non_anonymous()?;
     let mut count = 0i64;
     for id in payload {

--- a/packages/functions/src/functions/api/item_common.rs
+++ b/packages/functions/src/functions/api/item_common.rs
@@ -87,6 +87,17 @@ pub async fn do_get_single(_auth: AuthInfo, id: i64) -> Result<CommonResponse<It
 }
 
 pub async fn do_add(auth: AuthInfo, payload: Vec<i64>) -> Result<CommonResponse<ItemAddResponse>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
+
     auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
 

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -61,6 +61,16 @@ pub async fn do_move_to_target(
     target_type_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
     for item_id in payload {
         // 查找 link 记录（末端类型）
         let links = link_model::Entity::find_safety()

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -426,6 +426,17 @@ pub async fn do_get_list_by_id(
     _auth: AuthInfo,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<MarkerItemsResponse>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
+
     let db = &DB_CONN.wait().pg_conn;
     if payload.is_empty() {
         return Ok(CommonResponse::new(Ok(MarkerItemsResponse {

--- a/packages/functions/src/functions/api/route.rs
+++ b/packages/functions/src/functions/api/route.rs
@@ -185,6 +185,17 @@ pub async fn do_get_list_by_id(
     _auth: AuthInfo,
     payload: Vec<f64>,
 ) -> Result<CommonResponse<Vec<RouteVO>>> {
+    const MAX_BATCH: usize = 1000;
+    if payload.len() > MAX_BATCH {
+        {
+            return Err(anyhow!(
+                "batch too large: {} > {}",
+                payload.len(),
+                MAX_BATCH
+            ));
+        }
+    }
+
     let db = &DB_CONN.wait().pg_conn;
     let ids: Vec<i64> = payload.iter().map(|f| *f as i64).collect();
 

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use once_cell::sync::Lazy;
 use std::net::SocketAddr;
 
 use redis::{AsyncTypedCommands, SetOptions};
@@ -225,12 +226,49 @@ pub async fn oauth_parse_token(token: String) -> Result<(SysUserVO, Claims)> {
     Ok((user.into(), claims))
 }
 
+/// 登录暴力破解限流：按 IP 固定窗口（每分钟最多 5 次失败的密码登录尝试）。
+/// 只计数失败尝试（成功登录不消耗额度），窗口过后自动重置。
+const LOGIN_RATE_LIMIT_PER_MINUTE: u32 = 5;
+
+static LOGIN_FAILURES: Lazy<std::sync::Mutex<std::collections::HashMap<String, (u32, i64)>>> =
+    Lazy::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn check_login_rate_limit(ip: SocketAddr) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let window = now / 60;
+    let mut map = LOGIN_FAILURES.lock().unwrap();
+    let entry = map.entry(ip.to_string()).or_insert((0, window));
+    if entry.1 != window {
+        *entry = (0, window);
+    }
+    if entry.0 >= LOGIN_RATE_LIMIT_PER_MINUTE {
+        return Err(anyhow!(
+            "Too many failed login attempts; try again in a minute"
+        ));
+    }
+    Ok(())
+}
+
+fn record_login_failure(ip: SocketAddr) {
+    let now = chrono::Utc::now().timestamp();
+    let window = now / 60;
+    let mut map = LOGIN_FAILURES.lock().unwrap();
+    let entry = map.entry(ip.to_string()).or_insert((0, window));
+    if entry.1 != window {
+        *entry = (0, window);
+    }
+    entry.0 += 1;
+}
+
 pub async fn oauth_password_login(
     username: String,
     password_raw: String,
     ip: SocketAddr,
     user_agent: String,
 ) -> Result<OauthLoginResponse> {
+    // 限流检查在用户名查询之前：避免攻击者用无效用户名做无代价探测。
+    check_login_rate_limit(ip)?;
+
     let item = models::system::sys_user::Entity::find()
         .filter(models::system::sys_user::Column::DelFlag.eq(false))
         .filter(models::system::sys_user::Column::Username.eq(username))
@@ -241,7 +279,9 @@ pub async fn oauth_password_login(
 
     let ret = oauth_password_login_inner(item, password_raw, ip, &user_agent).await;
 
-    if ret.is_ok() {
+    if ret.is_err() {
+        record_login_failure(ip);
+    } else {
         // 登录成功：登记设备（幂等 upsert）
         let _ = record_device(user_id, ip, &user_agent).await;
     }


### PR DESCRIPTION
## Summary

Rate-limit logins, cap batch sizes, and drop sqlx trace logging (secondary-audit minors).

## Motivation

- Password login had **no brute-force protection**.
- Batch-ID endpoints accepted unbounded `Vec<i64>` payloads — a client could hit sqlx's 65535-parameter limit (or trivially amplify work).
- sqlx SQL logging was at `Trace`, printing bound values (potentially sensitive) into the logs.

## Changes

- **`oauth.rs`**: per-IP fixed-window rate limit (5 failed attempts / minute, in-process `Mutex<HashMap>`), checked before the username query; only failures count, the window auto-resets.
- **Batch caps**: 7 endpoints reject `len > 1000` with an explicit error — `item` join-type / get-list-by-id / update / copy-to-area, `item_common` add, `item_type` move-to-target, `marker` get-list-by-id, `route` get-list-by-id.
- **`database/lib.rs`**: `sqlx_logging_level(Trace → Info)`.
- **`CHANGELOG.md`**: Unreleased entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB) — its oauth flow stays under the rate limit
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

- >5 failed logins per IP per minute are rejected (429-style error) — intended.
- Batch payloads > 1000 are rejected — intended.
