### PR TITLE
♻️ Replace the inline admin checks with an ExtractAdmin extractor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sqlx SQL logging level drops from Trace to Info so bound values
   (potentially sensitive) no longer land in logs.
 
+### Refactor
+
+- Replace the 24 inline Admin role checks across the system routes with
+  a dedicated `ExtractAdmin` axum extractor (one source of truth for
+  the Admin gate; non-Admin roles get the same 403). The invitation
+  `info` / `consume` handlers stay non-Admin (authenticated only, per
+  the registration flow) while the management endpoints become
+  uniformly Admin-gated.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/router/src/middlewares/admin_extrator.rs
+++ b/packages/router/src/middlewares/admin_extrator.rs
@@ -1,0 +1,30 @@
+use axum::{
+    extract::FromRequestParts,
+    http::{StatusCode, request::Parts},
+    response::{IntoResponse, Response},
+};
+
+use _utils::{jwt::AuthInfo, types::SystemUserRole};
+
+use super::auth_extrator::ExtractAuthInfo;
+
+/// Admin-only auth extractor: authenticates like `ExtractAuthInfo` and rejects
+/// any non-Admin role with 403. Replaces the repetitive
+/// `if auth.info.role_id != SystemUserRole::Admin { 403 }` boilerplate in the
+/// system routes.
+pub struct ExtractAdmin(pub AuthInfo);
+
+impl<S> FromRequestParts<S> for ExtractAdmin
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let ExtractAuthInfo(auth) = ExtractAuthInfo::from_request_parts(parts, state).await?;
+        if auth.info.role_id != SystemUserRole::Admin {
+            return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
+        }
+        Ok(Self(auth))
+    }
+}

--- a/packages/router/src/middlewares/mod.rs
+++ b/packages/router/src/middlewares/mod.rs
@@ -1,7 +1,9 @@
+mod admin_extrator;
 mod auth_extrator;
 mod ip_extrator;
 mod user_agent_extrator;
 
+pub use admin_extrator::*;
 pub use auth_extrator::*;
 pub use ip_extrator::*;
 pub use user_agent_extrator::*;

--- a/packages/router/src/routes/system/action_log.rs
+++ b/packages/router/src/routes/system/action_log.rs
@@ -7,11 +7,8 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAuthInfo;
-use _utils::{
-    models::Pagination,
-    types::{ActionLogAction, SystemUserRole},
-};
+use crate::middlewares::ExtractAdmin;
+use _utils::{models::Pagination, types::ActionLogAction};
 
 /// 格式：字段+ 字段-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -65,13 +62,9 @@ pub struct ActionLogParams {
 /// POST /action_log/list
 #[tracing::instrument(skip(auth))]
 pub async fn list(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Query(query): Query<ActionLogParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     let size = query.pagination.as_ref().and_then(|p| p.size).unwrap_or(10) as u64;
     let current = query
         .pagination

--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -8,19 +8,15 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAuthInfo;
-use _utils::types::SystemUserRole;
+use crate::middlewares::ExtractAdmin;
 
 /// 获取指定槽位的最新存档
 /// GET /archive/last/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn get_last(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_last(auth, user_id, slot_index as i32)
         .await
@@ -34,12 +30,9 @@ pub async fn get_last(
 /// GET /archive/history/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn get_history(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_history(auth, user_id, slot_index as i32)
         .await
@@ -53,11 +46,8 @@ pub async fn get_history(
 /// GET /archive/all_history
 #[tracing::instrument(skip(auth))]
 pub async fn get_all_history(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_all_history(auth, user_id).await {
         Ok(v) => Ok(Json(v).into_response()),
@@ -77,13 +67,10 @@ pub struct ArchiveSaveParams {
 /// PUT /archive/{slot_index}/{name}
 #[tracing::instrument(skip(auth))]
 pub async fn put(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path((slot_index, name)): Path<(i64, String)>,
     Json(payload): Json<ArchiveSaveParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_save(
         auth,
@@ -103,13 +90,10 @@ pub async fn put(
 /// POST /archive/save/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn save(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(slot_index): Path<i64>,
     Json(payload): Json<ArchiveSaveParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_save(
         auth,
@@ -129,12 +113,9 @@ pub async fn save(
 /// POST /archive/rename/{slot_index}/{new_name}
 #[tracing::instrument(skip(auth))]
 pub async fn rename(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path((slot_index, new_name)): Path<(i64, String)>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_rename_by_slot(
         user_id,
@@ -152,12 +133,9 @@ pub async fn rename(
 /// DELETE /archive/restore/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn restore(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_last(auth, user_id, slot_index as i32)
         .await
@@ -171,12 +149,9 @@ pub async fn restore(
 /// DELETE /archive/slot/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn delete_slot(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_delete_slot(user_id, slot_index as i32).await {
         Ok(v) => Ok(Json(v).into_response()),

--- a/packages/router/src/routes/system/device.rs
+++ b/packages/router/src/routes/system/device.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use axum::{extract::Json, http::StatusCode, response::IntoResponse};
 
-use crate::middlewares::ExtractAuthInfo;
-use _utils::{models::wrapper::Pagination, types::SystemUserRole};
+use crate::middlewares::ExtractAdmin;
+use _utils::models::wrapper::Pagination;
 
 /// 格式：字段+ 字段-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -56,13 +56,9 @@ pub struct DeviceListParams {
 /// POST /device/list
 #[tracing::instrument(skip(auth))]
 pub async fn list(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<DeviceListParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     let size = payload
         .pagination
         .as_ref()
@@ -101,13 +97,9 @@ pub struct DeviceUpdateParams {
 /// POST /device/update
 #[tracing::instrument(skip(auth))]
 pub async fn update(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<DeviceUpdateParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     let status = payload
         .status
         .ok_or_else(|| (StatusCode::BAD_REQUEST, "status required".to_string()))?;

--- a/packages/router/src/routes/system/invitation.rs
+++ b/packages/router/src/routes/system/invitation.rs
@@ -7,11 +7,8 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAuthInfo;
-use _utils::{
-    models::wrapper::Pagination,
-    types::{AccessPolicyItemEnum, SystemUserRole},
-};
+use crate::middlewares::{ExtractAdmin, ExtractAuthInfo};
+use _utils::{models::wrapper::Pagination, types::AccessPolicyItemEnum};
 
 /// 获取用户邀请列表的请求参数
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -86,13 +83,9 @@ pub struct InvitationInfoRequest {
 /// POST /invitation/list
 #[tracing::instrument(skip(auth))]
 pub async fn list(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<InvitationListRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     let size = payload
         .pagination
         .as_ref()
@@ -122,13 +115,9 @@ pub async fn list(
 /// POST /invitation/update
 #[tracing::instrument(skip(auth))]
 pub async fn update(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<InvitationUpdateRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     match _functions::functions::system::invitation::do_update(
         auth,
         payload.code,
@@ -172,13 +161,9 @@ pub async fn consume(
 /// DELETE /invitation/{invitation_id}
 #[tracing::instrument(skip(auth))]
 pub async fn delete(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(invitation_id): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     match _functions::functions::system::invitation::do_delete(auth, invitation_id).await {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),

--- a/packages/router/src/routes/system/role.rs
+++ b/packages/router/src/routes/system/role.rs
@@ -2,18 +2,13 @@ use anyhow::Result;
 
 use axum::{extract::Json, http::StatusCode, response::IntoResponse};
 
-use crate::middlewares::ExtractAuthInfo;
-use _utils::types::SystemUserRole;
+use crate::middlewares::ExtractAdmin;
 
 /// 返回可用角色列表
 /// GET /role/list
-#[tracing::instrument(skip(auth))]
+#[tracing::instrument(skip(_auth))]
 pub async fn list(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(_auth): ExtractAdmin,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((axum::http::StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(Json(()).into_response())
 }

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -7,12 +7,9 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAuthInfo;
+use crate::middlewares::ExtractAdmin;
 use _functions::functions::system::user::*;
-use _utils::{
-    models::Pagination,
-    types::{AccessPolicyItemEnum, SystemUserRole},
-};
+use _utils::{models::Pagination, types::AccessPolicyItemEnum, types::SystemUserRole};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UserSort {
@@ -141,13 +138,9 @@ pub struct UserKickOutParams {
 /// POST /user/register
 #[tracing::instrument(skip(auth, payload))]
 pub async fn register(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserRegisterParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_register(
         auth,
         payload.access_policy,
@@ -166,13 +159,9 @@ pub async fn register(
 /// POST /user/register/qq
 #[tracing::instrument(skip(auth, payload))]
 pub async fn register_qq(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserRegisterQQParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_register_qq(
         auth,
         payload.access_policy,
@@ -192,13 +181,9 @@ pub async fn register_qq(
 /// GET /user/info/{userId}
 #[tracing::instrument(skip(auth))]
 pub async fn get_info(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(user_id): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(Json(
         do_get_info(auth, user_id)
             .await
@@ -211,13 +196,9 @@ pub async fn get_info(
 /// POST /user/update
 #[tracing::instrument(skip(auth))]
 pub async fn update(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserUpdateParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_update(
         auth,
         payload.id,
@@ -238,13 +219,9 @@ pub async fn update(
 /// POST /user/update_password
 #[tracing::instrument(skip(auth, payload))]
 pub async fn update_password(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserUpdatePasswordParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_update_password(
         auth,
         payload.access_policy,
@@ -264,13 +241,9 @@ pub async fn update_password(
 /// POST /user/update_password_by_admin
 #[tracing::instrument(skip(auth, payload))]
 pub async fn update_password_by_admin(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserUpdatePasswordByAdminParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(
         do_update_password_by_admin(auth, payload.password, payload.user_id)
             .await
@@ -283,13 +256,9 @@ pub async fn update_password_by_admin(
 /// DELETE /user/{workId}
 #[tracing::instrument(skip(auth))]
 pub async fn delete(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(work_id): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_delete(auth, work_id)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?
@@ -300,13 +269,9 @@ pub async fn delete(
 /// POST /user/info/list
 #[tracing::instrument(skip(auth))]
 pub async fn list(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Json(payload): Json<UserListParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(Json(
         do_list(
             auth,
@@ -328,13 +293,9 @@ pub async fn list(
 /// DELETE /user/kick_out/{workId}
 #[tracing::instrument(skip(auth))]
 pub async fn kick_out(
-    ExtractAuthInfo(auth): ExtractAuthInfo,
+    ExtractAdmin(auth): ExtractAdmin,
     Path(work_id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    if auth.info.role_id != SystemUserRole::Admin {
-        return Ok((StatusCode::FORBIDDEN, "Forbidden".to_string()).into_response());
-    }
-
     Ok(do_kick_out(auth, work_id)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?


### PR DESCRIPTION
## Summary

Replace the inline admin checks with an `ExtractAdmin` extractor (secondary-audit refactor).

## Motivation

24 handlers across the system routes repeated the same inline gate (`if auth.info.role_id != SystemUserRole::Admin { 403 }`), drifting in formatting and easy to forget on new endpoints.

## Changes

- **`middlewares/admin_extrator.rs`** (new): `ExtractAdmin` authenticates via `ExtractAuthInfo` and rejects non-Admin roles with 403.
- **System routes** (`action_log` / `archive` / `device` / `invitation` / `role` / `user`): the Admin-gated handlers now use `ExtractAdmin(auth)` and the inline `if` blocks are removed (net −58 lines).
- **`invitation.rs`**: `info` / `consume` intentionally stay non-Admin (authenticated via `ExtractAuthInfo`; the business layer already rejects anonymous) — they serve the registration flow.
- **`CHANGELOG.md`**: Unreleased Refactor entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB)
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None — same authorization semantics (all previously Admin-gated endpoints stay Admin-gated; `invitation/info` + `consume` stay authenticated-only).
