### PR TITLE
✨ Add a configurable CORS allowlist layer.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ PORT=8101
 # When unset, the endpoint falls back to an empty dev config.
 # CDN_DADIAN_CONFIG=/absolute/path/to/dadian-preview.json.bz2
 
+# ── CORS (optional) ──────────────────────────────────────────────────────────
+# Comma-separated allowlist of browser origins. When unset, no CORS headers
+# are sent (cross-origin browser access is blocked; same-origin/Vite proxy
+# still works).
+# CORS_ALLOW_ORIGIN=https://map.example.com,https://admin.example.com
+
 # ── JWT signing (required) ───────────────────────────────────────────────────
 # REQUIRED: HMAC signing secret. There is no default — the process refuses to
 # start without it (a predictable default would let anyone forge tokens).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the registration flow) while the management endpoints become
   uniformly Admin-gated.
 
+### Features
+
+- Add a configurable CORS layer: `CORS_ALLOW_ORIGIN` (comma-separated
+  allowlist) controls which browser origins may call the API with
+  `Authorization` headers. Unset → no CORS headers are sent
+  (cross-origin browser access blocked, same-origin / Vite proxy
+  unaffected). `.env.example` documents the variable.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ rustls = { version = "^0.23", default-features = false, features = [
   "tls12",
   "logging",
 ] }
-tower-http = { version = "^0.7", features = ["fs", "trace"] }
+tower-http = { version = "^0.7", features = ["fs", "trace", "cors"] }
 
 # sea-orm 2.0 release candidate. The SafeEntityTrait macro and all call sites
 # have been ported to the new UpdateOne/ValidatedUpdateOne API. Switch to "^2"

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -21,11 +21,53 @@ pub async fn router() -> Result<Router> {
         .merge(api::router().await?)
         .nest_service("/cdn", cdn_proxy())
         .fallback(|| async { (StatusCode::NOT_IMPLEMENTED, "Not Implemented").into_response() })
+        .layer(cors_layer())
         .layer(from_extractor::<crate::middlewares::ExtractUserAgent>())
         .layer(from_extractor::<crate::middlewares::ExtractIP>())
         .layer(DefaultBodyLimit::max(1024 * 1024 * 16)); // 16 MiB
 
     Ok(ret)
+}
+
+/// 可配置的 CORS 策略：
+/// - `CORS_ALLOW_ORIGIN` 设置允许的源（逗号分隔），未设置时**不允许**任何
+///   跨域请求（浏览器前端应走同源/Vite 代理）；
+/// - 允许的源会收到 `Authorization` 头放行与标准的 GET/POST/PUT/DELETE。
+fn cors_layer() -> tower_http::cors::CorsLayer {
+    use axum::http::header::HeaderValue;
+    use tower_http::cors::{AllowOrigin, CorsLayer};
+
+    let allowed = std::env::var("CORS_ALLOW_ORIGIN")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(|v| {
+            v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+        });
+
+    let base = CorsLayer::new()
+        .allow_methods([
+            axum::http::Method::GET,
+            axum::http::Method::POST,
+            axum::http::Method::PUT,
+            axum::http::Method::DELETE,
+            axum::http::Method::OPTIONS,
+        ])
+        .allow_headers([
+            axum::http::header::AUTHORIZATION,
+            axum::http::header::CONTENT_TYPE,
+        ]);
+
+    match allowed {
+        Some(origins) if !origins.is_empty() => {
+            let origins: Vec<HeaderValue> = origins.iter().filter_map(|o| o.parse().ok()).collect();
+            base.allow_origin(AllowOrigin::list(origins))
+        },
+        // 未配置白名单：不发送任何 CORS 头，浏览器默认阻止跨域读取。
+        _ => base,
+    }
 }
 
 /// JWKS 公钥分发端点（`GET /.well-known/jwks.json`），无鉴权。


### PR DESCRIPTION
## Summary

Add a configurable CORS allowlist layer (secondary-audit feature).

## Motivation

The API had **no CORS layer** — browsers calling the backend cross-origin (a deployed frontend on another domain) would be blocked with no preflight headers. The audit flagged this as a deployment foot-gun (only `/cdn` manually set `ACAO: *`).

## Changes

- **`routes/mod.rs`**: a `CorsLayer` is applied to the whole router —
  - `CORS_ALLOW_ORIGIN` (comma-separated) allowlists origins (parsed to `HeaderValue`);
  - methods GET/POST/PUT/DELETE/OPTIONS, headers `Authorization` + `Content-Type`;
  - unset → **no CORS headers sent** (cross-origin blocked by the browser by default; same-origin and the Vite proxy are unaffected).
- **`tower-http`** gains the `cors` feature.
- **`.env.example`** documents the variable.
- **`CHANGELOG.md`**: Unreleased Features entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Runtime behavior verified on deployment (preflight headers)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example)

## Breaking Changes

None for same-origin/proxy deployments. Cross-origin browser clients must now set `CORS_ALLOW_ORIGIN` explicitly (previously there was no CORS at all, so nothing regresses).
