### PR TITLE
⚡ Batch the remaining N+1 soft deletes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (cross-origin browser access blocked, same-origin / Vite proxy
   unaffected). `.env.example` documents the variable.
 
+### Performance
+
+- Batch the remaining N+1 deletes: score generation soft-deletes old
+  `score_stat` rows and the archive `delete_slot` operation now use a
+  single `update_many` statement instead of per-row find+update
+  round-trips.
+
 ### Documentation
 
 - Translate the nine scaffolded doc entry pages (ar/de/es/fr/ja/ko/pt/ru/zht):

--- a/packages/functions/src/functions/api/score.rs
+++ b/packages/functions/src/functions/api/score.rs
@@ -51,17 +51,17 @@ pub async fn do_generate_score(
         .map(|m| m.id)
         .collect();
 
-    for id in old_ids {
-        if let Some(m) = score_stat_model::Entity::find_safety_by_id(id)
-            .one(db)
-            .await?
-        {
-            let mut am: score_stat_model::ActiveModel = m.into();
-            am.del_flag = Set(true);
-            score_stat_model::Entity::update_safety(am)?
-                .exec(db)
-                .await?;
-        }
+    // 批量软删旧行（避免逐条 find+update 的 N+1 往返）
+    if !old_ids.is_empty() {
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+        score_stat_model::Entity::update_many()
+            .col_expr(
+                score_stat_model::Column::DelFlag,
+                sea_orm::sea_query::Expr::value(true),
+            )
+            .filter(score_stat_model::Column::Id.is_in(old_ids))
+            .exec(db)
+            .await?;
     }
 
     // 2. 扫描 history 表（type = 4 = 打点/点位，对齐 Java 侧）

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -139,16 +139,16 @@ pub async fn do_restore(_auth: AuthInfo, id: i64) -> Result<CommonResponse<serde
 /// Delete an archive slot (soft-delete every archive in the slot).
 pub async fn do_delete_slot(user_id: i64, slot_index: i32) -> Result<CommonResponse<()>> {
     let db = &DB_CONN.wait().pg_conn;
-    let items = archive_model::Entity::find_safety()
+    // 批量软删（避免逐条 find+delete 的 N+1 往返）
+    archive_model::Entity::update_many()
+        .col_expr(
+            archive_model::Column::DelFlag,
+            sea_orm::sea_query::Expr::value(true),
+        )
         .filter(archive_model::Column::UserId.eq(user_id))
         .filter(archive_model::Column::SlotIndex.eq(slot_index))
-        .all(db)
+        .exec(db)
         .await?;
-    for a in items {
-        archive_model::Entity::delete_safety(a.into())?
-            .exec(db)
-            .await?;
-    }
     Ok(CommonResponse::new(Ok(())))
 }
 


### PR DESCRIPTION
## Summary

Batch the remaining N+1 soft deletes (secondary-audit P2).

## Motivation

Two loops ran per-row find+update/delete round-trips: score generation soft-deleted old `score_stat` rows one by one, and the archive `delete_slot` soft-deleted each row individually.

## Changes

- **`score.rs`**: the old-row cleanup now uses one `update_many` (`del_flag = true WHERE id IN (...)`).
- **`archive.rs`**: `do_delete_slot` uses one `update_many` (`del_flag = true WHERE user_id = ? AND slot_index = ?`).
- **`CHANGELOG.md`**: Unreleased Performance entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test api_db` skips locally (no DB) — the score round-trip assertion exercises the new batch path in CI
- [ ] `integration` CI job runs against live Postgres

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

None.
