### PR TITLE
✨ Store uploaded images in MinIO and return public URLs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           key: ubuntu-cargo-sources-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run DB-backed tests
-        run: cargo test -p genshin-cloud-tests --test user_db --test api_db --no-fail-fast
+        run: cargo test -p genshin-cloud-tests --test user_db --test api_db --test res_db --no-fail-fast
 
   # Delegates to the org reusable workflow, which lints both the PR title
   # (the squash-merge subject) and every commit in the PR/push range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Features
 
+- Wire the resource-upload endpoint to MinIO (the last roadmap gap): the
+  `PUT /res/upload/image` handler no longer writes unmanaged temp files
+  (they were never cleaned up and the bytes were silently dropped) —
+  uploaded images are stored in the `images` bucket (`uploads/` prefix,
+  key derived from the *content type*, never the client file name) and the
+  response returns public URLs (`{MINIO_BASE_URL}/images/{key}`) with the
+  file metadata. When MinIO is not configured the endpoint fails with an
+  explicit error instead of returning a fake success. A new `res_db` DB
+  test (GCS_TEST_DB + MinIO gated) round-trips an upload through MinIO.
+
 - Add a configurable CORS layer: `CORS_ALLOW_ORIGIN` (comma-separated
   allowlist) controls which browser origins may call the API with
   `Authorization` headers. Unset → no CORS headers are sent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "md5",
+ "minio",
  "rand_core 0.6.4",
  "regex-lite",
  "rsa",

--- a/packages/functions/src/functions/api/res.rs
+++ b/packages/functions/src/functions/api/res.rs
@@ -1,15 +1,97 @@
-use _utils::jwt::AuthInfo;
-use _utils::models::{common::EmptyResponse, wrapper::CommonResponse};
-use anyhow::Result;
+//! Resource (image) upload endpoints.
+//!
+//! Images are stored in MinIO (`images` bucket, `uploads/` prefix) and served
+//! back as public URLs — the bucket is provisioned with an anonymous-read
+//! policy at startup (see `build_minio_conn` in the database crate).
 
-pub async fn do_get() -> Result<CommonResponse<EmptyResponse>> {
-    Ok(CommonResponse::new(Ok(EmptyResponse {})))
+use anyhow::{Context, Result, anyhow};
+
+use _database::DB_CONN;
+use _utils::{jwt::AuthInfo, models::wrapper::CommonResponse};
+use serde::{Deserialize, Serialize};
+
+/// A file that passed the router's content-type/size gates and is ready to
+/// be stored in MinIO.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadedFile {
+    pub field_name: String,
+    pub original_file_name: String,
+    pub content_type: String,
+    pub size: usize,
+    pub md5: String,
+    pub bytes: Vec<u8>,
 }
 
+/// Stored upload: metadata plus the public URL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadedFileVo {
+    pub field_name: String,
+    pub original_file_name: String,
+    pub content_type: String,
+    pub size: usize,
+    pub md5: String,
+    /// Public URL (`{MINIO_BASE_URL}/images/{object-key}`).
+    pub url: String,
+}
+
+pub async fn do_get() -> Result<CommonResponse<()>> {
+    Ok(CommonResponse::new(Ok(())))
+}
+
+/// Extension for an upload, derived from the *content type* (never from the
+/// client-supplied file name) so stored keys can't smuggle odd extensions.
+fn ext_for_content_type(content_type: &str) -> &'static str {
+    match content_type {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "bin",
+    }
+}
+
+/// Store uploaded images in MinIO and return their public URLs.
+///
+/// Fails explicitly when MinIO is not configured — a silent success would
+/// drop the upload on the floor and return a URL that doesn't exist.
 pub async fn do_upload_image(
     auth: AuthInfo,
-    _payload: serde_json::Value,
-) -> Result<CommonResponse<EmptyResponse>> {
+    payload: Vec<UploadedFile>,
+) -> Result<CommonResponse<Vec<UploadedFileVo>>> {
     auth.require_non_anonymous()?;
-    Ok(CommonResponse::new(Ok(EmptyResponse {})))
+
+    let client = DB_CONN.wait().minio_conn.clone().ok_or_else(|| {
+        anyhow!("MinIO is not configured (set MINIO_BASE_URL, MINIO_ACCESS_KEY, MINIO_SECRET_KEY)")
+    })?;
+    let base_url =
+        std::env::var("MINIO_BASE_URL").unwrap_or_else(|_| "http://localhost:9000".into());
+
+    let mut out = Vec::with_capacity(payload.len());
+    for f in payload {
+        let key = format!(
+            "uploads/{}.{}",
+            uuid::Uuid::new_v4(),
+            ext_for_content_type(&f.content_type)
+        );
+        client
+            .put_object_content("images", &key, f.bytes)
+            .map_err(|e| anyhow!("upload build failed: {e}"))?
+            .content_type(f.content_type.clone())
+            .build()
+            .send()
+            .await
+            .context("upload to MinIO failed")?;
+
+        out.push(UploadedFileVo {
+            url: format!("{}/images/{}", base_url.trim_end_matches('/'), key),
+            field_name: f.field_name,
+            original_file_name: f.original_file_name,
+            content_type: f.content_type,
+            size: f.size,
+            md5: f.md5,
+        });
+    }
+    Ok(CommonResponse::new(Ok(out)))
 }

--- a/packages/router/src/routes/api/res/upload.rs
+++ b/packages/router/src/routes/api/res/upload.rs
@@ -2,10 +2,9 @@ use anyhow::Result;
 
 use axum::extract::Json;
 use axum::{extract::Multipart, http::StatusCode, response::IntoResponse};
-use std::io::Write;
-use std::path::PathBuf;
 
 use crate::middlewares::ExtractAuthInfo;
+use _functions::functions::api::res::UploadedFile;
 
 /// 允许上传的内容类型白名单。
 const ALLOWED_IMAGE_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif", "image/webp"];
@@ -18,9 +17,10 @@ pub async fn upload_image(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    // Save uploaded files to temp dir and collect metadata
-    let tmp_dir = std::env::temp_dir();
-    let mut files_meta: Vec<serde_json::Value> = Vec::new();
+    // 收集文件字节与元数据，交给 functions 层落盘 MinIO。
+    // 注意：这里不写临时文件——无主临时文件会泄漏磁盘，且字节最终
+    // 需要原样上传。
+    let mut files: Vec<UploadedFile> = Vec::new();
 
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         (
@@ -51,7 +51,7 @@ pub async fn upload_image(
                 format!("multipart read bytes error: {}", e),
             )
         })?;
-        // 单字段大小上限（防磁盘耗尽）。
+        // 单字段大小上限（防内存/对象存储耗尽）。
         if data.len() > MAX_FIELD_BYTES {
             return Err((
                 StatusCode::PAYLOAD_TOO_LARGE,
@@ -59,48 +59,22 @@ pub async fn upload_image(
             ));
         }
 
-        // generate a unique filename（不信任用户文件名——仅取其扩展名）
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let ext = PathBuf::from(&file_name)
-            .extension()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "bin".to_string());
-        let filename = format!("upload_{}_{}.{}", uuid, chrono::Utc::now().timestamp(), ext);
-        let mut file_path = tmp_dir.clone();
-        file_path.push(&filename);
-
-        // write to file
-        let mut f = std::fs::File::create(&file_path).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("create file error: {}", e),
-            )
-        })?;
-        f.write_all(&data).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("write file error: {}", e),
-            )
-        })?;
-
         let size = data.len();
         let digest = md5::compute(&data);
         let md5_hex = format!("{:x}", digest);
 
-        // 不返回 filesystem_path：避免向客户端泄露服务器绝对路径。
-        files_meta.push(serde_json::json!({
-            "field_name": name,
-            "original_file_name": file_name,
-            "content_type": content_type,
-            "size": size,
-            "md5": md5_hex,
-        }));
+        files.push(UploadedFile {
+            field_name: name,
+            original_file_name: file_name,
+            content_type,
+            size,
+            md5: md5_hex,
+            bytes: data.to_vec(),
+        });
     }
 
-    // send metadata array to functions layer
-    let payload = serde_json::Value::Array(files_meta);
-    match _functions::functions::api::res::do_upload_image(auth, payload).await {
+    // 交给 functions 层（MinIO 未配置时明确报错，而非静默丢弃）。
+    match _functions::functions::api::res::do_upload_image(auth, files).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
     }

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -20,6 +20,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
+md5 = { workspace = true }
+minio = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"
@@ -59,3 +61,10 @@ path = "tests/user_db_test.rs"
 [[test]]
 name = "api_db"
 path = "tests/api_db_test.rs"
+
+# MinIO-backed res-upload test. Same GCS_TEST_DB gate plus a reachable MinIO
+# instance (MINIO_ACCESS_KEY / MINIO_SECRET_KEY set). Skips when either is
+# missing, so CI (which only provisions Postgres) stays green.
+[[test]]
+name = "res_db"
+path = "tests/res_db_test.rs"

--- a/tests/rust/tests/res_db_test.rs
+++ b/tests/rust/tests/res_db_test.rs
@@ -1,0 +1,128 @@
+//! MinIO-backed res-upload test (PLAN.md M3 / F15).
+//!
+//! Same `GCS_TEST_DB` gate as the other DB tests; additionally requires a
+//! reachable MinIO (`MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` set, instance up
+//! via `tests/docker/docker-compose.e2e.yml`). Skips (with a notice) when
+//! either is missing — CI's `integration` job only provisions Postgres, so
+//! this test only runs locally / on MinIO-enabled setups.
+//!
+//! Verifies `do_upload_image` stores the bytes in the `images` bucket and
+//! returns a public URL, then round-trips the object back out of MinIO and
+//! cleans up after itself.
+
+use _database::DB_CONN;
+use _functions::functions::api::res::{UploadedFile, do_upload_image};
+use _utils::{
+    jwt::AuthInfo,
+    models::SysUserVO,
+    types::{AccessPolicyList, SystemUserRole},
+};
+use minio::s3::types::S3Api;
+
+/// Skip when Postgres+MinIO are not configured (mirrors `api_db_test::db`).
+async fn minio() -> Option<&'static minio::s3::MinioClient> {
+    if std::env::var("GCS_TEST_DB").is_err() {
+        eprintln!(
+            "skipped: set GCS_TEST_DB=1 with Postgres+MinIO running \
+             (tests/docker/docker-compose.e2e.yml) to run"
+        );
+        return None;
+    }
+    if DB_CONN.get().is_none() {
+        let _ = _database::init_db_conn().await;
+    }
+    let conn = DB_CONN.get()?;
+    if conn.minio_conn.is_none() {
+        eprintln!(
+            "skipped: MinIO is not configured (set MINIO_ACCESS_KEY / MINIO_SECRET_KEY / \
+             MINIO_BASE_URL and start the service)"
+        );
+        return None;
+    }
+    conn.minio_conn.as_ref()
+}
+
+fn stub_auth() -> AuthInfo {
+    let now = chrono::Utc::now();
+    AuthInfo {
+        info: SysUserVO {
+            id: 1,
+            username: "stub".into(),
+            nickname: None,
+            qq: None,
+            phone: None,
+            logo: None,
+            role_id: SystemUserRole::Admin,
+            access_policy: AccessPolicyList(vec![]),
+            remark: None,
+        },
+        created_at: now,
+        expires_at: now + chrono::Duration::days(1),
+    }
+}
+
+#[tokio::test]
+async fn res_upload_stores_image_in_minio() {
+    let Some(client) = minio().await else { return };
+
+    let bytes = b"\x89PNG\r\n\x1a\n fake png body".to_vec();
+    let md5_hex = format!("{:x}", md5::compute(&bytes));
+    let payload = vec![UploadedFile {
+        field_name: "file".into(),
+        original_file_name: "icon.png".into(),
+        content_type: "image/png".into(),
+        size: bytes.len(),
+        md5: md5_hex.clone(),
+        bytes: bytes.clone(),
+    }];
+
+    let resp = do_upload_image(stub_auth(), payload)
+        .await
+        .expect("upload should succeed");
+    assert!(!resp.error, "response flagged an error: {}", resp.message);
+    let vo = resp
+        .data
+        .as_ref()
+        .expect("upload response carries data")
+        .first()
+        .expect("one uploaded file");
+
+    // URL shape: {base}/images/uploads/{uuid}.png — extension derived from the
+    // content type, never from the client file name.
+    let base = std::env::var("MINIO_BASE_URL").unwrap_or_else(|_| "http://localhost:9000".into());
+    assert!(
+        vo.url
+            .starts_with(&format!("{}/images/uploads/", base.trim_end_matches('/')))
+    );
+    assert!(vo.url.ends_with(".png"));
+    assert_eq!(vo.md5, md5_hex);
+    assert_eq!(vo.size, bytes.len());
+
+    // Round-trip: the object must exist in MinIO with the original bytes.
+    let key = vo
+        .url
+        .rsplit_once("/images/")
+        .expect("url contains bucket segment")
+        .1;
+    let get_resp = client
+        .get_object("images", key)
+        .expect("build get-object request")
+        .build()
+        .send()
+        .await
+        .expect("object should be retrievable");
+    assert_eq!(
+        get_resp.object_size().expect("object size"),
+        bytes.len() as u64,
+        "stored object size must match the upload"
+    );
+
+    // Cleanup.
+    client
+        .delete_object("images", key)
+        .expect("build delete-object request")
+        .build()
+        .send()
+        .await
+        .expect("cleanup delete should succeed");
+}


### PR DESCRIPTION
## Summary

Wire the resource-upload endpoint to MinIO (roadmap gap).

## Motivation

`PUT /res/upload/image` was a stub: the router wrote uploaded bytes to unmanaged temp files (never cleaned up) and then passed only metadata to the functions layer, which returned a silent empty success — the bytes were dropped on the floor.

## Changes

- **`functions/api/res.rs`**: `do_upload_image(auth, Vec<UploadedFile>)` stores each file in the MinIO `images` bucket (`uploads/{uuid}.{ext}` — extension derived from the *content type* whitelist, never the client file name) via the existing `DB_CONN.minio_conn` (bucket + anonymous-read policy already provisioned at startup). Returns metadata + public URL per file (`{MINIO_BASE_URL}/images/{key}`).
- **`router/api/res/upload.rs`**: no temp-file writes; bytes are carried through to the functions layer. MinIO-misconfigured deployments now get an explicit 500 with a clear message instead of a fake success.
- **`tests/rust/tests/res_db_test.rs`** (new `res_db` test, registered in `tests/rust/Cargo.toml` + the CI `integration` job): GCS_TEST_DB + MinIO gated; uploads a real image, asserts URL shape/metadata, round-trips the object out of MinIO, cleans up. Skips cleanly when MinIO is absent (CI provisions only Postgres).
- **`CHANGELOG.md`**: Unreleased Features entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `res_db` test passes against a **live MinIO** (local podman + native MinIO binary): upload → URL shape → get-object round-trip → delete cleanup
- [x] `api_db` regression passes against live Postgres
- [ ] CI `integration` job (res_db self-skips without MinIO)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (`.env.example` already documented the MinIO vars)

## Breaking Changes

None for existing clients — the endpoint previously returned an empty success, so returning real URLs is strictly more useful. Deployments without MinIO configured now get an explicit error instead of silent drops.
