### PR TITLE
🔒 Support JWT signing-key rotation via JWT_RSA_VERIFY_KEYS.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,14 @@ JWT_SECRET=change-me-to-a-strong-random-secret
 # verifiable during a migration.
 # Generate one with:  openssl genpkey -algorithm RSA -out jwt-rsa.pem -pkeyopt rsa_keygen_bits:2048
 # JWT_RSA_PRIVATE_KEY_PEM=-----BEGIN PRIVATE KEY-----...
+# Historical RSA PUBLIC key PEMs for key rotation (optional, comma-separated;
+# each entry may itself be a multi-line PEM). Old keys listed here keep
+# verifying tokens after the signing key is rotated, and the JWKS publishes
+# them (current key = "genshin-cloud-rsa-v1", historical = "v2", "v3", ...).
+# Rotation: deploy step 1 with the NEW public key added here while still
+# signing with the old key; then step 2 switch JWT_RSA_PRIVATE_KEY_PEM to
+# the new key. Old tokens stay valid throughout.
+# JWT_RSA_VERIFY_KEYS=-----BEGIN PUBLIC KEY-----...-----END PUBLIC KEY-----,-----BEGIN PUBLIC KEY-----...
 
 # ── Dev / E2E ───────────────────────────────────────────────────────────────
 # Absolute path to the Vue3 frontend project (required for `just dev`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- Support JWT signing-key rotation (the last RS256 gap): the new
+  `JWT_RSA_VERIFY_KEYS` env (comma-separated RSA **public** key PEMs)
+  keeps historical keys verifiable after a rotation, and the JWKS
+  endpoint now publishes **all** RSA keys with stable kids (current =
+  `genshin-cloud-rsa-v1`, historical = `v2`, `v3`, ... in config order).
+  Rotation is a two-step deploy that never invalidates live tokens
+  (documented in `docs/en/guides/sync-with-java-roadmap.md` and
+  `.env.example`). A new `jwks_rotation` test signs with an old key and
+  asserts it still verifies, the JWKS carries both keys with distinct
+  moduli, and the v1 key matches the active private key.
+
 - Add RS256 signing with RSA JWKS (the last roadmap gap): when
   `JWT_RSA_PRIVATE_KEY_PEM` is set (PKCS#8 or PKCS#1 PEM), tokens are
   signed with RS256 and `/.well-known/jwks.json` publishes the RSA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "jsonwebtoken",
  "md5",
  "minio",
  "rand_core 0.6.4",
@@ -1827,6 +1828,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-test",
+ "uuid",
 ]
 
 [[package]]

--- a/docs/en/guides/sync-with-java-roadmap.md
+++ b/docs/en/guides/sync-with-java-roadmap.md
@@ -47,7 +47,7 @@ current status.
 | 4 | **punctuate workflow + scoring** | `MarkerPunctuate` staging → `Marker` promotion (three-state audit, role-gated and transactional) and `ScoreStat` aggregation (field-weighted). | High | **Done** |
 | 5 | **system (user / role / device / invitation)** | `SysUser`, `SysUserArchive`, `SysUserDevice` (login-anomaly detection), `SysUserInvitation`, `SysActionLog`, role listing, archive rename/delete_slot. | Medium | **Done** — device registration + access-policy checks are wired |
 | 6 | **BinaryMD5 archive export** | The GZIP-compressed, BinaryMD5-keyed producer for `item_doc` / `marker_doc` / `marker_link_doc`, with an in-process moka cache (300s TTL) and refresh endpoints. | High | **Done** |
-| 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Mostly done** — RS256 signing with RSA JWKS landed (`JWT_RSA_PRIVATE_KEY_PEM`); JWK rotation is still missing; in HS256 mode the JWKS endpoint returns an empty key set (the HMAC secret is never disclosed) |
+| 7 | **OAuth2 / JWKS** | `/oauth/token` (password / QQ / client_credentials), `/.well-known/jwks.json`, access-policy checks, scope mapping. | High | **Done** — RS256 signing with RSA JWKS; **JWK rotation** via `JWT_RSA_VERIFY_KEYS` (historical public keys stay verifiable + published; see the rotation steps below). In HS256 mode the JWKS endpoint returns an empty key set (the HMAC secret is never disclosed) |
 
 ## Current state
 
@@ -61,14 +61,31 @@ current status.
 
 ## Known gaps (remaining parity with Java)
 
-- Batch 7: JWK rotation is not implemented (the key is fixed); in HS256
-  mode the JWKS endpoint returns an empty key set — the HMAC signing
-  secret is never disclosed (set `JWT_RSA_PRIVATE_KEY_PEM` for
-  JWKS-based verification).
 - Database schema deviations from the real database await data validation
   (`marker_linkage` nullable columns, `sys_user_archive` structure binding).
 - Translation: only `docs/en` and `docs/zhs` are complete; the other 9
   languages are skeletons.
+
+## Rotating the JWT signing key (RS256)
+
+The signing key is `JWT_RSA_PRIVATE_KEY_PEM`; `JWT_RSA_VERIFY_KEYS`
+(comma-separated RSA **public** key PEMs) lists historical keys that must
+still verify tokens. The JWKS endpoint publishes the current key (`kid`
+`genshin-cloud-rsa-v1`) first, then each historical key in order (`v2`,
+`v3`, ...). Rotation is a two-step deploy that never invalidates live
+tokens:
+
+1. Generate the new keypair, add the **new** public key to
+   `JWT_RSA_VERIFY_KEYS` (keeping the old one), and deploy. Tokens are
+   still signed with the old key; both verify.
+2. Switch `JWT_RSA_PRIVATE_KEY_PEM` to the new private key and deploy.
+   Tokens are now signed with the new key (kid stays `v1`); the old key
+   remains in `JWT_RSA_VERIFY_KEYS` for verification.
+3. On the next rotation, drop the oldest public key from
+   `JWT_RSA_VERIFY_KEYS`.
+
+HS256 (`JWT_SECRET`) has no rotation story beyond a restart — the JWKS
+never publishes the HMAC secret.
 
 ## Follow-up
 

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -49,6 +49,23 @@ pub fn jwt_rsa_private_key_pem() -> Option<String> {
     std::env::var("JWT_RSA_PRIVATE_KEY_PEM").ok()
 }
 
+/// Historical RSA **public** key PEMs (env `JWT_RSA_VERIFY_KEYS`, optional).
+/// **Comma**-separated list (each entry may itself be a multi-line PEM — the
+/// newlines inside a PEM must NOT be treated as separators). Keys listed
+/// here are accepted for verification (and published in the JWKS) but never
+/// used for signing — that's what makes key rotation possible without
+/// invalidating live tokens.
+pub fn jwt_rsa_verify_keys() -> Vec<String> {
+    let Some(v) = std::env::var("JWT_RSA_VERIFY_KEYS").ok() else {
+        return Vec::new();
+    };
+    v.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 /// Whether RS256 signing is active (an RSA private key is configured).
 pub fn is_rsa_signing() -> bool {
     jwt_rsa_private_key_pem().is_some()
@@ -63,16 +80,24 @@ pub fn jwt_alg() -> Algorithm {
     }
 }
 
+/// The JWKS key id of the i-th RSA key: v1 is always the *current* signing
+/// key (the private key's public half); the historical verify keys follow in
+/// configuration order (v2, v3, ...). Stable as long as the config order is.
+fn rsa_kid(index: usize) -> String {
+    format!("genshin-cloud-rsa-v{}", index + 1)
+}
+
 /// Lazily parsed key material for both algorithms.
 pub struct JwtKeys {
     /// Key used to sign new tokens (HS256 secret or RS256 private key).
     pub encoding: EncodingKey,
-    /// RS256 verification key, present when RSA is configured.
-    pub decoding_rsa: Option<DecodingKey>,
+    /// RSA verification keys (current + historical, in kid order), present
+    /// when RSA is configured.
+    pub decoding_rsa: Vec<DecodingKey>,
     /// HS256 verification key (always available — legacy tokens stay valid).
     pub decoding_hmac: DecodingKey,
-    /// RSA public key for JWKS publication (n/e export), when configured.
-    pub rsa_public_pem: Option<String>,
+    /// RSA public keys for JWKS publication: `(kid, pem)`, current first.
+    pub rsa_public_keys: Vec<(String, String)>,
 }
 
 static JWT_KEYS: Lazy<JwtKeys> = Lazy::new(|| {
@@ -85,9 +110,9 @@ static JWT_KEYS: Lazy<JwtKeys> = Lazy::new(|| {
     let Some(pem) = jwt_rsa_private_key_pem() else {
         return JwtKeys {
             encoding: encoding_hmac,
-            decoding_rsa: None,
+            decoding_rsa: Vec::new(),
             decoding_hmac,
-            rsa_public_pem: None,
+            rsa_public_keys: Vec::new(),
         };
     };
 
@@ -97,9 +122,22 @@ static JWT_KEYS: Lazy<JwtKeys> = Lazy::new(|| {
         Ok(private) => {
             let public = private.to_public_key();
             let public_pem = public.to_public_key_pem(rsa::pkcs8::LineEnding::LF).ok();
-            let decoding_rsa = public_pem
-                .as_deref()
-                .and_then(|p| DecodingKey::from_rsa_pem(p.as_bytes()).ok());
+            let mut rsa_keys: Vec<(String, String)> = Vec::new(); // (kid, pem)
+            if let Some(p) = public_pem {
+                rsa_keys.push((rsa_kid(0), p));
+            }
+            // Historical verify keys follow the current one, in order.
+            for (i, verify_pem) in jwt_rsa_verify_keys().iter().enumerate() {
+                // Dedup: skip a verify key that equals the current public key.
+                if rsa_keys.iter().any(|(_, p)| p == verify_pem) {
+                    continue;
+                }
+                rsa_keys.push((rsa_kid(i + 1), verify_pem.clone()));
+            }
+            let decoding_rsa = rsa_keys
+                .iter()
+                .filter_map(|(_, p)| DecodingKey::from_rsa_pem(p.as_bytes()).ok())
+                .collect();
             let encoding = match EncodingKey::from_rsa_pem(pem.as_bytes()) {
                 Ok(k) => k,
                 Err(e) => {
@@ -111,16 +149,16 @@ static JWT_KEYS: Lazy<JwtKeys> = Lazy::new(|| {
                 encoding,
                 decoding_rsa,
                 decoding_hmac,
-                rsa_public_pem: public_pem,
+                rsa_public_keys: rsa_keys,
             }
         },
         Err(e) => {
             eprintln!("failed to parse RSA private key PEM: {e}; falling back to HS256");
             JwtKeys {
                 encoding: encoding_hmac,
-                decoding_rsa: None,
+                decoding_rsa: Vec::new(),
                 decoding_hmac,
-                rsa_public_pem: None,
+                rsa_public_keys: Vec::new(),
             }
         },
     }
@@ -131,13 +169,14 @@ pub fn encoding_key() -> &'static EncodingKey {
     &JWT_KEYS.encoding
 }
 
-/// Verification keys with their matching algorithms. The active algorithm
-/// comes first, the fallback second — tokens signed before an RSA/HS256
-/// migration stay verifiable.
+/// Verification keys with their matching algorithms. RSA keys come in kid
+/// order (current first, then historical), the HMAC fallback last — tokens
+/// signed before an RSA/HS256 migration or before a key rotation stay
+/// verifiable.
 pub fn decoding_key_pairs() -> Vec<(&'static DecodingKey, Algorithm)> {
     if is_rsa_signing() {
         let mut v = Vec::new();
-        if let Some(k) = &JWT_KEYS.decoding_rsa {
+        for k in &JWT_KEYS.decoding_rsa {
             v.push((k, Algorithm::RS256));
         }
         v.push((&JWT_KEYS.decoding_hmac, Algorithm::HS256));
@@ -147,14 +186,12 @@ pub fn decoding_key_pairs() -> Vec<(&'static DecodingKey, Algorithm)> {
     }
 }
 
-/// The RSA public key PEM (when RS256 is configured) for JWKS publication.
-pub fn rsa_public_key_pem() -> Option<&'static str> {
-    JWT_KEYS.rsa_public_pem.as_deref()
-}
-
 /// Build the JWKS (JSON Web Key Set) for the active signing scheme.
 ///
-/// RS256: publishes the RSA public key (kty: RSA, base64url n/e).
+/// RS256: publishes **all** RSA public keys (current `v1` first, then the
+/// historical `JWT_RSA_VERIFY_KEYS` in order), each with its `kid` — so
+/// verifiers can follow a rotation by kid. The key used for signing is always
+/// `v1`.
 /// HS256: publishes an **empty** key set — the HMAC signing key is a shared
 /// secret and must never be disclosed (RFC 7517 §6.4 `oct` keys are for
 /// verification-only consumers in trusted environments). Deployments that
@@ -162,23 +199,24 @@ pub fn rsa_public_key_pem() -> Option<&'static str> {
 /// to switch to RS256.
 pub fn jwks() -> anyhow::Result<serde_json::Value> {
     use base64::Engine;
-    if let Some(pem) = rsa_public_key_pem() {
+    if JWT_KEYS.rsa_public_keys.is_empty() {
+        return Ok(serde_json::json!({ "keys": [] }));
+    }
+    let mut keys = Vec::new();
+    for (kid, pem) in &JWT_KEYS.rsa_public_keys {
         let public = <rsa::RsaPublicKey as rsa::pkcs8::DecodePublicKey>::from_public_key_pem(pem)?;
         let n = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.n().to_bytes_be());
         let e = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.e().to_bytes_be());
-        return Ok(serde_json::json!({
-            "keys": [{
-                "kty": "RSA",
-                "kid": "genshin-cloud-rsa-v1",
-                "alg": "RS256",
-                "use": "sig",
-                "n": n,
-                "e": e,
-            }],
+        keys.push(serde_json::json!({
+            "kty": "RSA",
+            "kid": kid,
+            "alg": "RS256",
+            "use": "sig",
+            "n": n,
+            "e": e,
         }));
     }
-
-    Ok(serde_json::json!({ "keys": [] }))
+    Ok(serde_json::json!({ "keys": keys }))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -22,6 +22,8 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 md5 = { workspace = true }
 minio = { workspace = true }
+jsonwebtoken = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"
@@ -68,3 +70,9 @@ path = "tests/api_db_test.rs"
 [[test]]
 name = "res_db"
 path = "tests/res_db_test.rs"
+
+# JWKS key-rotation unit test. No DB; sets JWT_* env vars before touching the
+# lazy key material (own process, same pattern as api_db).
+[[test]]
+name = "jwks_rotation"
+path = "tests/jwks_rotation_test.rs"

--- a/tests/rust/tests/jwks_rotation_test.rs
+++ b/tests/rust/tests/jwks_rotation_test.rs
@@ -1,0 +1,108 @@
+//! JWKS key-rotation test (PLAN.md M4 gap): after rotating the RSA signing
+//! key, tokens signed with the **old** key must still verify (the old public
+//! key stays in the verification set), the new key signs, and the JWKS
+//! publishes both keys with stable kids (current = v1, historical = v2+).
+//!
+//! No DB needed. This binary is its own process, and the test sets the env
+//! vars before any JWT operation touches the lazy key material (same pattern
+//! as `api_db_test`).
+
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use rsa::pkcs8::{DecodePublicKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use rsa::traits::PublicKeyParts;
+
+fn rsa_pair() -> (String, String) {
+    let key = rsa::RsaPrivateKey::new(&mut rand_core::OsRng, 2048).expect("generate RSA key");
+    (
+        key.to_pkcs8_pem(LineEnding::LF)
+            .expect("encode private key")
+            .to_string(),
+        key.to_public_key()
+            .to_public_key_pem(LineEnding::LF)
+            .expect("encode public key")
+            .to_string(),
+    )
+}
+
+fn sign_with(now: chrono::DateTime<chrono::Utc>, private_pem: &str) -> String {
+    let claims = _utils::jwt::Claims {
+        sub: 42,
+        jti: uuid::Uuid::new_v4(),
+        iat: now,
+        exp: now + chrono::Duration::days(1),
+    };
+    jsonwebtoken::encode(
+        &Header::new(Algorithm::RS256),
+        &claims,
+        &EncodingKey::from_rsa_pem(private_pem.as_bytes()).expect("encoding key"),
+    )
+    .expect("sign token")
+}
+
+#[tokio::test]
+async fn rotated_keys_stay_verifiable_and_published() {
+    let now = chrono::Utc::now();
+    let (old_priv, old_pub) = rsa_pair();
+    let (new_priv, new_pub) = rsa_pair();
+
+    // SAFETY: single test binary; env vars are set once before any JWT
+    // operation reads the lazy key material (edition 2024 marks set_var
+    // unsafe because concurrent readers could race).
+    unsafe {
+        std::env::set_var("JWT_SECRET", "rotation-test-secret");
+        std::env::set_var("JWT_RSA_PRIVATE_KEY_PEM", &new_priv);
+        std::env::set_var("JWT_RSA_VERIFY_KEYS", &old_pub);
+    }
+
+    // 1) A token signed with the OLD (rotated-out) key still verifies.
+    let old_token = sign_with(now, &old_priv);
+    let claims = _utils::jwt::verify_token(&old_token)
+        .await
+        .expect("old-key token must verify after rotation");
+    assert_eq!(claims.sub, 42);
+
+    // 2) A token signed with the CURRENT key verifies too.
+    let new_token = sign_with(now, &new_priv);
+    let claims = _utils::jwt::verify_token(&new_token)
+        .await
+        .expect("new-key token must verify");
+    assert_eq!(claims.sub, 42);
+
+    // 3) The JWKS publishes both keys, current (v1) first, historical
+    //    (v2) second — kids are stable and the n's differ.
+    let jwks = _utils::jwt::jwks().expect("jwks");
+    let keys = jwks["keys"].as_array().expect("keys array");
+    assert_eq!(keys.len(), 2, "JWKS must publish current + historical keys");
+    assert_eq!(keys[0]["kid"], "genshin-cloud-rsa-v1");
+    assert_eq!(keys[1]["kid"], "genshin-cloud-rsa-v2");
+
+    use base64::Engine;
+    let modulus = |jwk: &serde_json::Value| -> rsa::BigUint {
+        rsa::BigUint::from_bytes_be(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(jwk["n"].as_str().expect("n"))
+                .expect("valid base64url n"),
+        )
+    };
+    assert_ne!(
+        modulus(&keys[0]),
+        modulus(&keys[1]),
+        "rotated keys must differ"
+    );
+
+    // 4) The published v1 matches the new private key's public half.
+    let expected_new_n = rsa::RsaPublicKey::from_public_key_pem(&new_pub)
+        .expect("parse new public pem")
+        .n()
+        .clone();
+    assert_eq!(
+        modulus(&keys[0]),
+        expected_new_n,
+        "v1 = current signing key"
+    );
+    let expected_old_n = rsa::RsaPublicKey::from_public_key_pem(&old_pub)
+        .expect("parse old public pem")
+        .n()
+        .clone();
+    assert_eq!(modulus(&keys[1]), expected_old_n, "v2 = historical key");
+}


### PR DESCRIPTION
## Summary

Support JWT signing-key rotation (the last RS256/JWKS gap).

## Motivation

The RSA signing key was fixed for the process lifetime: rotating it invalidated every live token, and the JWKS published a single key with a hardcoded kid. The roadmap flagged "JWK rotation" as the remaining auth gap.

## Changes

- **`utils/jwt.rs`**:
  - New env `JWT_RSA_VERIFY_KEYS`: **comma**-separated RSA **public** key PEMs (each entry may itself be multi-line) listing historical keys. They verify tokens but never sign.
  - `JwtKeys` now carries `decoding_rsa: Vec<DecodingKey>` and `rsa_public_keys: Vec<(kid, pem)>`; the current key is always `genshin-cloud-rsa-v1`, historical keys follow in config order (`v2`, `v3`, ...). Duplicates of the current public key are skipped.
  - `jwks()` publishes **all** RSA keys (stable kids, current first) instead of one hardcoded key.
  - Verification iterates RSA keys in kid order, then the HMAC fallback — old-key tokens stay valid.
- **`tests/rust/tests/jwks_rotation_test.rs`** (new): signs a token with a rotated-out key and asserts it still verifies; asserts the JWKS carries both keys with distinct moduli, v1 = the active key, v2 = the historical key.
- **Docs**: `.env.example` documents `JWT_RSA_VERIFY_KEYS`; `sync-with-java-roadmap.md` marks batch 7 done and adds a two-step rotation procedure (deploy with the new public key in the verify list → then switch the private key; drop the oldest on the next rotation).

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p genshin-cloud-tests --test jwks_rotation` passes (old-key token verifies; JWKS = 2 keys, distinct moduli, v1 matches active key)
- [ ] CI (full matrix; api_db JWKS assertions still green — keys[0] shape unchanged)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (.env.example + roadmap)

## Breaking Changes

None. Existing single-key deployments behave exactly as before (verify list empty → JWKS publishes one key, kid unchanged `genshin-cloud-rsa-v1`).
