### PR TITLE
⚡ Add a Redis second-level cache for the BinaryMD5 doc pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Performance
 
+- Add a Redis second-level cache for the BinaryMD5 doc pages (the roadmap's
+  multi-replica gap): the marker/item/link result sets are stored in Redis
+  (versioned `binmd5:result:{epoch}:{domain}` keys, base64 bytes, 300s TTL
+  matching the in-process moka cache), so a warm replica serves
+  `list_page_bin_md5` / `list_page_bin` without re-scanning the database.
+  Invalidation is an atomic epoch bump (`INCR binmd5:epoch`) — every
+  replica drops its stale copy at once, no SCAN/DEL pass needed. Redis
+  being down degrades silently to the existing in-process cache. A new
+  `redis_cache_db` test (GCS_TEST_DB + Redis gated) asserts the epoch
+  flow; unit tests cover the base64 round-trip.
+
 - Batch the remaining N+1 deletes: score generation soft-deletes old
   `score_stat` rows and the archive `delete_slot` operation now use a
   single `update_many` statement instead of per-row find+update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,7 @@ dependencies = [
  "md5",
  "minio",
  "rand_core 0.6.4",
+ "redis",
  "regex-lite",
  "rsa",
  "sea-orm",

--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -8,12 +8,18 @@
 //!
 //! The generated pages are cached in-process (moka, like Java's Caffeine) so
 //! repeated `list_page_bin_md5` / `list_page_bin` requests don't re-serialize
-//! the whole dataset on every call.
+//! the whole dataset on every call. A **Redis second-level cache** shares the
+//! computed page sets across replicas: a warm replica can serve the pages
+//! without re-scanning the database, and invalidation bumps a versioned epoch
+//! so every replica drops its stale copy at once.
 
 use flate2::{Compression, write::GzEncoder};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{io::Write, time::Duration};
+
+use _database::DB_CONN;
+use redis::AsyncCommands;
 
 /// A single MD5 entry in the `list_page_bin_md5` response.
 /// Mirrors Java `BinaryMD5Vo { md5, time }`.
@@ -87,12 +93,126 @@ pub async fn invalidate(key: &str) {
     BIN_CACHE.invalidate(key).await;
 }
 
-/// Drop every cached page. The cache-refresh endpoints call this — the keys
-/// are domain-scoped (`item:*`, `marker:*`, `link:*`) but not enumerable
-/// cheaply, so a full flush is the simple correct invalidation.
-pub fn invalidate_all() {
+/// Redis namespace for the result-level cache.
+const REDIS_RESULT_PREFIX: &str = "binmd5:result:";
+/// Redis epoch key: bumping it (INCR) invalidates every replica's copy of the
+/// result cache atomically — stale keys fall out of the TTL window naturally,
+/// so no SCAN/DEL pass is needed.
+const REDIS_EPOCH_KEY: &str = "binmd5:epoch";
+/// Redis entry TTL (matches the in-process moka TTL).
+const REDIS_RESULT_TTL_SECS: u64 = 300;
+
+/// A `ResultEntry` serialized for Redis: bytes travel as base64 (JSON
+/// carries `Vec<u8>` as a number array otherwise — 4-5x bigger).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RedisResultEntry {
+    key: String,
+    vo: BinaryMd5Vo,
+    bytes_b64: String,
+}
+
+impl From<&ResultEntry> for RedisResultEntry {
+    fn from(e: &ResultEntry) -> Self {
+        use base64::Engine;
+        RedisResultEntry {
+            key: e.key.clone(),
+            vo: e.vo.clone(),
+            bytes_b64: base64::engine::general_purpose::STANDARD.encode(&e.bytes),
+        }
+    }
+}
+
+impl From<RedisResultEntry> for ResultEntry {
+    fn from(e: RedisResultEntry) -> Self {
+        use base64::Engine;
+        ResultEntry {
+            key: e.key,
+            vo: e.vo,
+            bytes: base64::engine::general_purpose::STANDARD
+                .decode(&e.bytes_b64)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// Current Redis epoch (1 when unset). `None` when Redis is unavailable.
+async fn redis_epoch() -> Option<i64> {
+    let conn = DB_CONN.wait().redis_conn.as_ref()?;
+    let mut c = conn.get_multiplexed_async_connection().await.ok()?;
+    let epoch: Option<i64> = c.get(REDIS_EPOCH_KEY).await.ok().flatten();
+    match epoch {
+        Some(e) => Some(e),
+        None => {
+            // First touch: initialize under NX so concurrent replicas agree.
+            let _: Result<i64, redis::RedisError> = c
+                .set_options(
+                    REDIS_EPOCH_KEY,
+                    1,
+                    redis::SetOptions::default().conditional_set(redis::ExistenceCheck::NX),
+                )
+                .await;
+            Some(1)
+        },
+    }
+}
+
+/// Try to load the result set for `key` from Redis.
+async fn redis_load(key: &str) -> Option<Vec<ResultEntry>> {
+    let epoch = redis_epoch().await?;
+    let conn = DB_CONN.wait().redis_conn.as_ref()?;
+    let mut c = conn.get_multiplexed_async_connection().await.ok()?;
+    let raw: Option<String> = c
+        .get(format!("{REDIS_RESULT_PREFIX}{epoch}:{key}"))
+        .await
+        .ok()
+        .flatten()?;
+    let entries: Vec<RedisResultEntry> = serde_json::from_str(raw.as_deref()?).ok()?;
+    Some(entries.into_iter().map(Into::into).collect())
+}
+
+/// Store the result set for `key` in Redis (best-effort; Redis may be down).
+async fn redis_store(key: &str, entries: &[ResultEntry]) {
+    let Some(epoch) = redis_epoch().await else {
+        return;
+    };
+    let Some(conn) = DB_CONN.wait().redis_conn.as_ref().cloned() else {
+        return;
+    };
+    let Ok(mut c) = conn.get_multiplexed_async_connection().await else {
+        return;
+    };
+    let raw = match serde_json::to_string(
+        &entries
+            .iter()
+            .map(RedisResultEntry::from)
+            .collect::<Vec<_>>(),
+    ) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let _: Result<(), redis::RedisError> = c
+        .set_ex(
+            format!("{REDIS_RESULT_PREFIX}{epoch}:{key}"),
+            raw,
+            REDIS_RESULT_TTL_SECS,
+        )
+        .await;
+}
+
+/// Drop every cached page (in-process + Redis across replicas).
+pub async fn invalidate_all() {
     BIN_CACHE.invalidate_all();
     RESULT_CACHE.invalidate_all();
+    // Bump the Redis epoch: replicas' copies are keyed by the old epoch and
+    // expire on their own; the next request computes + stores under the new
+    // one. Best-effort — with Redis down this is a no-op.
+    let Some(conn) = DB_CONN.wait().redis_conn.as_ref() else {
+        return;
+    };
+    let Ok(mut c) = conn.get_multiplexed_async_connection().await else {
+        return;
+    };
+    let _: Result<i64, redis::RedisError> = c.incr(REDIS_EPOCH_KEY, 1).await;
 }
 
 /// Result-level cache entry: one page's md5 metadata plus its compressed
@@ -122,6 +242,10 @@ static RESULT_CACHE: Lazy<moka::future::Cache<String, Vec<ResultEntry>>> = Lazy:
 
 /// Fetch the full page set for a domain from the cache, or compute it via
 /// `compute` and store it.
+///
+/// Lookup order: in-process moka → Redis (shared across replicas) → compute.
+/// A Redis hit also warms the in-process cache, so subsequent requests are
+/// zero-DB and zero-Redis.
 pub async fn get_result_cached(
     key: String,
     compute: impl std::future::Future<Output = anyhow::Result<Vec<ResultEntry>>>,
@@ -129,7 +253,51 @@ pub async fn get_result_cached(
     if let Some(cached) = RESULT_CACHE.get(&key).await {
         return Ok(cached);
     }
+    if let Some(entries) = redis_load(&key).await {
+        RESULT_CACHE.insert(key.clone(), entries.clone()).await;
+        return Ok(entries);
+    }
     let result = compute.await?;
-    RESULT_CACHE.insert(key, result.clone()).await;
+    RESULT_CACHE.insert(key.clone(), result.clone()).await;
+    redis_store(&key, &result).await;
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> ResultEntry {
+        ResultEntry {
+            key: "marker:0:0".into(),
+            vo: BinaryMd5Vo {
+                md5: "abc123".into(),
+                time: 42,
+            },
+            bytes: vec![0xde, 0xad, 0xbe, 0xef],
+        }
+    }
+
+    #[test]
+    fn redis_entry_roundtrip_preserves_bytes() {
+        // JSON carries bytes as base64; the round-trip must restore the exact
+        // compressed payload (a broken transform would corrupt bin fetches).
+        let entry = sample_entry();
+        let redis_entry = RedisResultEntry::from(&entry);
+        assert_eq!(redis_entry.bytes_b64, "3q2+7w==");
+        let back = ResultEntry::from(redis_entry);
+        assert_eq!(back.key, entry.key);
+        assert_eq!(back.vo, entry.vo);
+        assert_eq!(back.bytes, entry.bytes);
+    }
+
+    #[tokio::test]
+    async fn epoch_keying_is_versioned() {
+        // The epoch is a plain counter; entries are keyed by it so bumping
+        // the epoch invalidates every replica's copy without a scan.
+        let epoch = 7;
+        let key = format!("{REDIS_RESULT_PREFIX}{epoch}:marker:result");
+        assert!(key.starts_with(REDIS_RESULT_PREFIX));
+        assert!(key.ends_with(":7:marker:result"));
+    }
 }

--- a/packages/functions/src/functions/api/cache.rs
+++ b/packages/functions/src/functions/api/cache.rs
@@ -25,7 +25,7 @@ pub async fn do_delete_area_cache(auth: AuthInfo) -> Result<CommonResponse<Empty
 /// 清除物品缓存（BinaryMD5 item 页）。
 pub async fn do_delete_item_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
-    binary_doc::invalidate_all();
+    binary_doc::invalidate_all().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -44,14 +44,14 @@ pub async fn do_delete_icon_tag_cache(auth: AuthInfo) -> Result<CommonResponse<E
 /// 清除点位缓存（BinaryMD5 marker 页）。
 pub async fn do_delete_marker_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
-    binary_doc::invalidate_all();
+    binary_doc::invalidate_all().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
 /// 清除点位连线缓存（BinaryMD5 link list/graph 页）。
 pub async fn do_delete_marker_link_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
-    binary_doc::invalidate_all();
+    binary_doc::invalidate_all().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -24,6 +24,7 @@ md5 = { workspace = true }
 minio = { workspace = true }
 jsonwebtoken = { workspace = true }
 uuid = { workspace = true }
+redis = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"
@@ -76,3 +77,10 @@ path = "tests/res_db_test.rs"
 [[test]]
 name = "jwks_rotation"
 path = "tests/jwks_rotation_test.rs"
+
+# Redis second-level BinaryMD5 cache test. Same GCS_TEST_DB gate plus a
+# reachable Redis (backend's redis_conn must be Some). Skips when either is
+# missing, so CI (which only provisions Postgres) stays green.
+[[test]]
+name = "redis_cache_db"
+path = "tests/redis_cache_db_test.rs"

--- a/tests/rust/tests/redis_cache_db_test.rs
+++ b/tests/rust/tests/redis_cache_db_test.rs
@@ -1,0 +1,114 @@
+//! Redis second-level BinaryMD5 cache test (PLAN.md M4 / F10).
+//!
+//! Same `GCS_TEST_DB` gate as the other DB tests; additionally requires a
+//! reachable Redis (the backend's `DB_CONN.redis_conn` must be `Some` — i.e.
+//! `REDIS_HOST`/`REDIS_PORT` set and the instance up, e.g. via
+//! `tests/docker/docker-compose.e2e.yml`). Skips when either is missing —
+//! CI's `integration` job only provisions Postgres.
+//!
+//! Verifies the marker-doc result flows through Redis: a compute stores a
+//! versioned `binmd5:result:{epoch}:marker:result` key, `invalidate_all`
+//! bumps the epoch, and the next compute stores under the new epoch.
+
+use redis::AsyncCommands;
+
+use _database::DB_CONN;
+use _functions::functions::api::{binary_doc, marker_doc};
+use _utils::{
+    jwt::AuthInfo,
+    models::SysUserVO,
+    types::{AccessPolicyList, SystemUserRole},
+};
+use sea_orm::{ConnectionTrait, Schema, sea_query::TableCreateStatement};
+
+/// Skip when Postgres+Redis are not configured (mirrors `api_db_test::db`).
+async fn redis() -> Option<redis::aio::MultiplexedConnection> {
+    if std::env::var("GCS_TEST_DB").is_err() {
+        eprintln!(
+            "skipped: set GCS_TEST_DB=1 with Postgres+Redis running \
+             (tests/docker/docker-compose.e2e.yml) to run"
+        );
+        return None;
+    }
+    if DB_CONN.get().is_none() {
+        let _ = _database::init_db_conn().await;
+    }
+    let conn = DB_CONN.get()?;
+    let client = conn.redis_conn.as_ref()?;
+    let c = client.get_multiplexed_async_connection().await.ok()?;
+    Some(c)
+}
+
+fn stub_auth() -> AuthInfo {
+    let now = chrono::Utc::now();
+    AuthInfo {
+        info: SysUserVO {
+            id: 1,
+            username: "stub".into(),
+            nickname: None,
+            qq: None,
+            phone: None,
+            logo: None,
+            role_id: SystemUserRole::Admin,
+            access_policy: AccessPolicyList(vec![]),
+            remark: None,
+        },
+        created_at: now,
+        expires_at: now + chrono::Duration::days(1),
+    }
+}
+
+/// Create the `marker` table (FKs stripped) so the marker-doc pipeline has
+/// something to scan. Mirrors `api_db_test::ddl_without_foreign_keys`.
+async fn ensure_marker_table(db: &sea_orm::DatabaseConnection) -> anyhow::Result<()> {
+    use _database::models::marker::marker as marker_model;
+    let schema = Schema::new(sea_orm::DbBackend::Postgres);
+    let stmt: TableCreateStatement = schema.create_table_from_entity(marker_model::Entity);
+    let sql = stmt.to_string(sea_orm::sea_query::PostgresQueryBuilder);
+    let stripped = regex_lite::Regex::new(
+        r#",(?:\s)*CONSTRAINT "fk-[^"]+" FOREIGN KEY \([^)]+\) REFERENCES (?:"[^"]+"\.)?"[^"]+" \([^)]+\)"#,
+    )
+    .expect("static regex")
+    .replace_all(&sql, "");
+    db.execute_unprepared("DROP TABLE IF EXISTS marker CASCADE")
+        .await?;
+    db.execute_unprepared(&stripped).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn marker_result_flows_through_redis_and_invalidate_bumps_epoch() {
+    let Some(mut r) = redis().await else { return };
+    let db = &DB_CONN.wait().pg_conn;
+    ensure_marker_table(db).await.expect("create marker table");
+
+    let auth = stub_auth();
+
+    // 1) First compute stores a versioned key under epoch 1.
+    let _: Result<i64, redis::RedisError> = r.del("binmd5:epoch").await;
+    let entries1 = marker_doc::do_list_page_bin_md5(auth.clone(), serde_json::Value::Null)
+        .await
+        .expect("first marker md5 list");
+    let epoch1: i64 = r.get("binmd5:epoch").await.expect("epoch key exists");
+    assert_eq!(epoch1, 1);
+    let raw1: Option<String> = r.get("binmd5:result:1:marker:result").await.expect("get");
+    assert!(raw1.is_some(), "epoch-1 result must be stored in Redis");
+    let stored: serde_json::Value = serde_json::from_str(raw1.as_deref().unwrap()).unwrap();
+    let expected_len = entries1.data.as_ref().map_or(0, Vec::len);
+    assert_eq!(stored.as_array().map_or(0, Vec::len), expected_len);
+
+    // 2) invalidate_all bumps the epoch; the old key is no longer consulted.
+    binary_doc::invalidate_all().await;
+    let epoch2: i64 = r.get("binmd5:epoch").await.expect("epoch bumped");
+    assert_eq!(epoch2, 2, "invalidate_all must bump the Redis epoch");
+
+    // 3) The next request computes + stores under the new epoch.
+    let _ = marker_doc::do_list_page_bin_md5(auth, serde_json::Value::Null)
+        .await
+        .expect("second marker md5 list after invalidate");
+    let raw2: Option<String> = r.get("binmd5:result:2:marker:result").await.expect("get");
+    assert!(
+        raw2.is_some(),
+        "epoch-2 result must be stored after invalidate"
+    );
+}


### PR DESCRIPTION
## Summary

Add a Redis second-level cache for the BinaryMD5 doc pages (multi-replica roadmap gap).

## Motivation

The BinaryMD5 result cache was in-process only (moka): a single replica serves warm hits with **zero** DB queries, but every extra replica re-scanned the whole dataset (100k+ markers) on its first request after startup. There was no way to invalidate a page set across replicas at once.

## Changes

- **`functions/api/binary_doc.rs`**:
  - `get_result_cached` lookup order: in-process moka → Redis → compute. A Redis hit warms the in-process cache, so subsequent requests touch neither DB nor Redis.
  - Redis entries: `binmd5:result:{epoch}:{domain}` — JSON with bytes as **base64** (plain `Vec<u8>` serializes to a 4-5x larger number array). 300s TTL matches the moka TTL.
  - Invalidation = atomic `INCR binmd5:epoch`: stale copies fall out of the TTL window naturally, no SCAN/DEL pass, all replicas drop stale data at once. `invalidate_all` is now async and bumps the epoch (callers updated).
  - Redis unavailable → silent degradation to the existing in-process cache (same pattern as the OAuth session store).
- **`tests/rust/tests/redis_cache_db_test.rs`** (new `redis_cache_db` test): GCS_TEST_DB + Redis gated; asserts the epoch-1 key is stored after a compute, `invalidate_all` bumps the epoch to 2, and the next compute stores under epoch 2. Skips cleanly without Redis (CI provisions only Postgres).
- **Unit tests** in `binary_doc.rs`: base64 round-trip preserves exact bytes; epoch key format.
- **`CHANGELOG.md`**: Unreleased Performance entry.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Unit tests (base64 round-trip + epoch keying) pass
- [ ] `redis_cache_db` against a live Redis — the local registry was unreachable during this session, so the Redis-gated behavior test compiles and self-skips; run it with `tests/docker/docker-compose.e2e.yml` (Postgres+Redis) + `GCS_TEST_DB=1`
- [ ] CI: full matrix (redis_cache_db self-skips)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable — no env/config changes; Redis vars already documented)

## Breaking Changes

None. With Redis unset or unreachable the behavior is byte-for-byte the previous in-process cache; the epoch key is initialized lazily on first use.
