### PR TITLE
🐛 Fix item_common to use the link table and type-safe user sort.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix `item_common` to match the Java contract (it wrote to the wrong
+  table): `add` now batch-links existing items into `item_area_public`
+  (deduped by name, names already common are skipped) instead of inserting
+  new `item` rows from positional `Vec<i64>` magic indices; `delete`
+  soft-deletes the link rows by `item_id` instead of soft-deleting the
+  item itself; `get/list` pages the link table joined to item info instead
+  of listing every item; the unreachable `do_update` and `do_get_single`
+  (no routes, no Java counterpart) are removed; the delete route now
+  returns the standard `CommonResponse` wrapper instead of `{}`. The
+  `api_db` test asserts the whole pipeline (link insert, name dedup,
+  soft-delete, item table untouched).
+
+- Replace the `UserSort` Debug-string handoff (route → business) with the
+  enum itself: `UserSort` moved to `_utils::types` and `do_list` matches
+  the variants directly, so renaming a variant is a compile error instead
+  of a silently-ignored sort key. Wire names (`createTime+`, `id-`, ...)
+  are unchanged.
+
 - Port the score field-level weighting (the last known Java-parity gap from
   the 0.2.0 release): `do_generate_score` now filters history to the
   `Position` (type=4) rows and weights each contribution by the number of

--- a/packages/functions/src/functions/api/item_common.rs
+++ b/packages/functions/src/functions/api/item_common.rs
@@ -1,27 +1,53 @@
+//! 公用物品（地区公用物品）业务层。
+//!
+//! 对齐 Java `ItemCommonService`：`item_area_public` 是 **item 的关联表**
+//! （把现有 item 标记为公用，按名称去重），不是 item 表本身。
+
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 
-use sea_orm::{
-    ActiveValue::{NotSet, Set},
-    QuerySelect,
-    prelude::*,
-};
+use sea_orm::{ActiveValue::Set, ColumnTrait, QueryFilter, QueryOrder, QuerySelect, prelude::*};
 
 use _utils::{
     jwt::AuthInfo,
     models::{
         common::EmptyResponse,
-        item::{ItemAddResponse, ItemListResponse, ItemSingleResponse, ItemVO},
+        item::{ItemListResponse, ItemVO},
         wrapper::CommonResponse,
         wrapper::Pagination,
     },
-    types::HiddenFlag,
 };
 
 use _utils::db_operations::SafeEntityTrait;
 
-use _database::{DB_CONN, models::item::item as item_model};
+use _database::{
+    DB_CONN,
+    models::{area::item_area_public as iap_model, item::item as item_model},
+};
 
+/// 批量添加上限（防恶意大列表）。
+const MAX_BATCH: usize = 1000;
+
+fn to_vo(it: &item_model::Model) -> ItemVO {
+    ItemVO {
+        id: it.id,
+        name: it.name.clone(),
+        area_id: it.area_id,
+        default_refresh_time: it.default_refresh_time,
+        default_content: it.default_content.clone(),
+        default_count: it.default_count,
+        icon_tag: it.icon_tag.clone(),
+        icon_style_type: it.icon_style_type,
+        hidden_flag: it.hidden_flag,
+        sort_index: it.sort_index,
+        special_flag: it.special_flag,
+    }
+}
+
+/// `POST /item_common/get/list`
+///
+/// 列出公用物品：分页查询 `item_area_public` 关联表，组合 item 信息。
+/// 响应形状与原来一致（`ItemListResponse`，纯 item 视图）。
 pub async fn do_get_list(
     _auth: AuthInfo,
     payload: Pagination,
@@ -32,28 +58,31 @@ pub async fn do_get_list(
     let current = payload.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
-    let total = item_model::Entity::find_safety().clone().count(db).await?;
-    let items = item_model::Entity::find_safety()
+    let total = iap_model::Entity::find_safety().clone().count(db).await?;
+    let links = iap_model::Entity::find_safety()
+        .order_by(iap_model::Column::Id, sea_orm::Order::Desc)
         .limit(size)
         .offset(offset)
         .all(db)
         .await?;
 
-    let mut arr = Vec::with_capacity(items.len());
-    for it in items {
-        arr.push(ItemVO {
-            id: it.id,
-            name: it.name,
-            area_id: it.area_id,
-            default_refresh_time: it.default_refresh_time,
-            default_content: it.default_content,
-            default_count: it.default_count,
-            icon_tag: it.icon_tag,
-            icon_style_type: it.icon_style_type,
-            hidden_flag: it.hidden_flag,
-            sort_index: it.sort_index,
-            special_flag: it.special_flag,
-        });
+    let ids: Vec<i64> = links.iter().map(|l| l.item_id).collect();
+    let mut by_id = std::collections::HashMap::with_capacity(ids.len());
+    if !ids.is_empty() {
+        for it in item_model::Entity::find_safety()
+            .filter(item_model::Column::Id.is_in(ids))
+            .all(db)
+            .await?
+        {
+            by_id.insert(it.id, it);
+        }
+    }
+
+    let mut arr = Vec::with_capacity(links.len());
+    for link in links {
+        if let Some(it) = by_id.get(&link.item_id) {
+            arr.push(to_vo(it));
+        }
     }
 
     let payload = ItemListResponse {
@@ -63,104 +92,85 @@ pub async fn do_get_list(
     Ok(CommonResponse::new(Ok(payload)))
 }
 
-pub async fn do_get_single(_auth: AuthInfo, id: i64) -> Result<CommonResponse<ItemSingleResponse>> {
-    let item = item_model::Entity::find_safety_by_id(id)
-        .one(&DB_CONN.wait().pg_conn)
-        .await?;
-    let item = item.ok_or(anyhow!("Item not found"))?;
-    let payload = ItemSingleResponse {
-        item: ItemVO {
-            id: item.id,
-            name: item.name,
-            area_id: item.area_id,
-            default_refresh_time: item.default_refresh_time,
-            default_content: item.default_content,
-            default_count: item.default_count,
-            icon_tag: item.icon_tag,
-            icon_style_type: item.icon_style_type,
-            hidden_flag: item.hidden_flag,
-            sort_index: item.sort_index,
-            special_flag: item.special_flag,
-        },
-    };
-    Ok(CommonResponse::new(Ok(payload)))
-}
+/// `PUT /item_common/add`
+///
+/// 对齐 Java：把 itemId 列表中**名称尚未成为公用物品**的 item 批量标记为
+/// 公用（写入 `item_area_public`）。同名 item 只取第一个；名称已存在于
+/// 关联表中的跳过。返回是否成功（至少插入一条）。
+pub async fn do_add(auth: AuthInfo, item_id_list: Vec<i64>) -> Result<CommonResponse<bool>> {
+    if item_id_list.len() > MAX_BATCH {
+        return Err(anyhow!(
+            "batch too large: {} > {}",
+            item_id_list.len(),
+            MAX_BATCH
+        ));
+    }
+    auth.require_non_anonymous()?;
+    let db = &DB_CONN.wait().pg_conn;
 
-pub async fn do_add(auth: AuthInfo, payload: Vec<i64>) -> Result<CommonResponse<ItemAddResponse>> {
-    const MAX_BATCH: usize = 1000;
-    if payload.len() > MAX_BATCH {
+    // 已存在的公用名称集合（Java：过滤掉名称已存在的）。
+    let existing_links = iap_model::Entity::find_safety().all(db).await?;
+    let existing_ids: Vec<i64> = existing_links.iter().map(|l| l.item_id).collect();
+    let mut existing_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if !existing_ids.is_empty() {
+        for it in item_model::Entity::find_safety()
+            .filter(item_model::Column::Id.is_in(existing_ids))
+            .all(db)
+            .await?
         {
-            return Err(anyhow!(
-                "batch too large: {} > {}",
-                payload.len(),
-                MAX_BATCH
-            ));
+            existing_names.insert(it.name);
         }
     }
 
-    auth.require_non_anonymous()?;
+    // 候选 item：按名称分组去重，取每组的第一个 id（Java 逻辑）。
+    let candidates = item_model::Entity::find_safety()
+        .filter(item_model::Column::Id.is_in(item_id_list))
+        .all(db)
+        .await?;
+    let mut first_by_name: std::collections::BTreeMap<String, i64> =
+        std::collections::BTreeMap::new();
+    for it in candidates {
+        if existing_names.contains(&it.name) {
+            continue;
+        }
+        first_by_name.entry(it.name).or_insert(it.id);
+    }
+
+    if first_by_name.is_empty() {
+        return Ok(CommonResponse::new(Ok(false)));
+    }
+
     let now = Utc::now().naive_utc();
-
-    let active = item_model::ActiveModel {
-        version: Set(0),
-        id: NotSet,
-        create_time: Set(now),
-        update_time: Set(None),
-        creator_id: Set(None),
-        updater_id: Set(None),
-        del_flag: Set(false),
-
-        name: Set("新物品".to_string()),
-        area_id: Set(payload.first().cloned().unwrap_or(0)),
-        default_refresh_time: Set(payload.get(2).cloned().unwrap_or(0)),
-        default_content: Set(None),
-        default_count: Set(payload.get(1).cloned().unwrap_or(1) as i32),
-        icon_tag: Set("0".into()),
-        icon_style_type: Set(_utils::types::IconStyleType::Default),
-        hidden_flag: Set(HiddenFlag::Visible),
-        sort_index: Set(0),
-        special_flag: Set(None),
-    };
-
-    let res = active.insert(&DB_CONN.wait().pg_conn).await?;
-    Ok(CommonResponse::new(Ok(ItemAddResponse { id: res.id })))
+    let mut models = Vec::with_capacity(first_by_name.len());
+    for item_id in first_by_name.into_values() {
+        models.push(iap_model::ActiveModel {
+            version: Set(0),
+            id: sea_orm::ActiveValue::NotSet,
+            create_time: Set(now),
+            update_time: Set(None),
+            creator_id: Set(None),
+            updater_id: Set(None),
+            del_flag: Set(false),
+            item_id: Set(item_id),
+        });
+    }
+    iap_model::Entity::insert_many(models).exec(db).await?;
+    Ok(CommonResponse::new(Ok(true)))
 }
 
-pub async fn do_update(
-    auth: AuthInfo,
-    payload: serde_json::Value,
-) -> Result<CommonResponse<EmptyResponse>> {
-    auth.require_non_anonymous()?;
-    let id = payload.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
-    let item = item_model::Entity::find_safety_by_id(id)
-        .one(&DB_CONN.wait().pg_conn)
-        .await?;
-    let item = item.ok_or(anyhow::anyhow!("Item not found"))?;
-
-    let mut am: item_model::ActiveModel = item.into();
-    if let Some(name) = payload.get("name").and_then(|v| v.as_str()) {
-        am.name = Set(name.to_string());
-    }
-    if let Some(default_content) = payload.get("defaultContent").and_then(|v| v.as_str()) {
-        am.default_content = Set(Some(default_content.to_string()));
-    }
-
-    item_model::Entity::update_safety(am)?
-        .exec(&DB_CONN.wait().pg_conn)
-        .await?;
-    Ok(CommonResponse::new(Ok(EmptyResponse {})))
-}
-
+/// `DELETE /item_common/delete/{itemId}`
+///
+/// 对齐 Java：按 item_id 软删 `item_area_public` 关联行（不动 item 表）。
 pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
-    let item = item_model::Entity::find_safety_by_id(id)
-        .one(&DB_CONN.wait().pg_conn)
-        .await?;
-    let item = item.ok_or(anyhow::anyhow!("Item not found"))?;
-    let mut am: item_model::ActiveModel = item.into();
-    am.del_flag = Set(true);
-    item_model::Entity::delete_safety(am)?
-        .exec(&DB_CONN.wait().pg_conn)
+    let db = &DB_CONN.wait().pg_conn;
+    iap_model::Entity::update_many()
+        .col_expr(
+            iap_model::Column::DelFlag,
+            sea_orm::sea_query::Expr::value(true),
+        )
+        .filter(iap_model::Column::ItemId.eq(id))
+        .exec(db)
         .await?;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -13,7 +13,7 @@ use _utils::{
     db_operations::SafeEntityTrait,
     jwt::AuthInfo,
     models::{Pagination, SysUserVO},
-    types::{AccessPolicyItemEnum, SystemUserRole},
+    types::{AccessPolicyItemEnum, SystemUserRole, UserSort},
 };
 
 // 业务处理函数
@@ -211,7 +211,7 @@ pub async fn do_list(
     pagination: Pagination,
     nickname: String,
     role_ids: Option<Vec<SystemUserRole>>,
-    sort: Option<Vec<String>>,
+    sort: Option<Vec<UserSort>>,
     username: String,
 ) -> Result<serde_json::Value> {
     let db = &DB_CONN.wait().pg_conn;
@@ -227,19 +227,18 @@ pub async fn do_list(
         query = query.filter(sys_user_model::Column::RoleId.is_in(rids));
     }
 
-    // 排序：白名单映射（"CreateTime"/"CreateTimeReverse"/"Id"/"Nickname"...），
-    // 只允许已知列名，杜绝任意 SQL 注入。
+    // 排序：显式枚举映射（用户列表的 wire 契约是 serde rename，业务层按
+    // 枚举变体匹配——变体重命名会变成编译错误，而非静默忽略排序键）。
     if let Some(sorts) = sort {
         use sea_orm::QueryOrder;
         for s in sorts {
-            let (column, desc) = match s.as_str() {
-                "CreateTime" => (sys_user_model::Column::CreateTime, false),
-                "CreateTimeReverse" => (sys_user_model::Column::CreateTime, true),
-                "Id" => (sys_user_model::Column::Id, false),
-                "IdReverse" => (sys_user_model::Column::Id, true),
-                "Nickname" => (sys_user_model::Column::Nickname, false),
-                "NicknameReverse" => (sys_user_model::Column::Nickname, true),
-                _ => continue, // 未知排序键忽略
+            let (column, desc) = match s {
+                UserSort::CreateTime => (sys_user_model::Column::CreateTime, false),
+                UserSort::CreateTimeReverse => (sys_user_model::Column::CreateTime, true),
+                UserSort::Id => (sys_user_model::Column::Id, false),
+                UserSort::IdReverse => (sys_user_model::Column::Id, true),
+                UserSort::Nickname => (sys_user_model::Column::Nickname, false),
+                UserSort::NicknameReverse => (sys_user_model::Column::Nickname, true),
             };
             query = if desc {
                 query.order_by(column, sea_orm::Order::Desc)

--- a/packages/router/src/routes/api/item_common/delete.rs
+++ b/packages/router/src/routes/api/item_common/delete.rs
@@ -16,7 +16,7 @@ pub async fn delete(
     Path(item_id): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_common::do_delete(auth, item_id).await {
-        Ok(_) => Ok((StatusCode::OK, Json(serde_json::json!({})))),
+        Ok(v) => Ok((StatusCode::OK, Json(v))),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
     }
 }

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -12,22 +12,6 @@ use _functions::functions::system::user::*;
 use _utils::{models::Pagination, types::AccessPolicyItemEnum, types::SystemUserRole};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum UserSort {
-    #[serde(rename = "createTime+")]
-    CreateTime,
-    #[serde(rename = "createTime-")]
-    CreateTimeReverse,
-    #[serde(rename = "id+")]
-    Id,
-    #[serde(rename = "id-")]
-    IdReverse,
-    #[serde(rename = "nickname+")]
-    Nickname,
-    #[serde(rename = "nickname-")]
-    NicknameReverse,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserRegisterParams {
     /// 权限策略
@@ -122,7 +106,7 @@ pub struct UserListParams {
     /// 角色 ID
     pub role_ids: Option<Vec<SystemUserRole>>,
     /// 排序优先级
-    pub sort: Option<Vec<UserSort>>,
+    pub sort: Option<Vec<_utils::types::UserSort>>,
     /// 用户名
     pub username: String,
 }
@@ -278,9 +262,7 @@ pub async fn list(
             payload.pagination,
             payload.nickname,
             payload.role_ids,
-            payload
-                .sort
-                .map(|sorts| sorts.into_iter().map(|s| format!("{:?}", s)).collect()),
+            payload.sort,
             payload.username,
         )
         .await

--- a/packages/utils/src/types/system.rs
+++ b/packages/utils/src/types/system.rs
@@ -71,6 +71,26 @@ pub enum AccessPolicyItemEnum {
     DevBlockDisallowDevice,
 }
 
+/// Sort keys for the user list. The serde renames are the **wire contract**
+/// ("createTime+", "createTime-", "id+", "id-", "nickname+", "nickname-") —
+/// the business layer matches the enum variants directly, so renaming a
+/// variant is a compile error instead of a silently-ignored sort key.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter)]
+pub enum UserSort {
+    #[serde(rename = "createTime+")]
+    CreateTime,
+    #[serde(rename = "createTime-")]
+    CreateTimeReverse,
+    #[serde(rename = "id+")]
+    Id,
+    #[serde(rename = "id-")]
+    IdReverse,
+    #[serde(rename = "nickname+")]
+    Nickname,
+    #[serde(rename = "nickname-")]
+    NicknameReverse,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum SystemUserRole {

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -13,15 +13,17 @@
 
 use _database::DB_CONN;
 use _database::models::{
-    area::area as area_model, common::history as history_model,
-    common::score_stat as score_stat_model, item::item as item_model,
-    marker::marker as marker_model, marker::marker_item_link as mil_model,
-    marker::marker_punctuate as mp_model, system::sys_action_log as action_log_model,
-    system::sys_user as sys_user_model, system::sys_user_device as device_model,
+    area::area as area_model, area::item_area_public as iap_model,
+    common::history as history_model, common::score_stat as score_stat_model,
+    item::item as item_model, marker::marker as marker_model,
+    marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
+    system::sys_action_log as action_log_model, system::sys_user as sys_user_model,
+    system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
-    area as area_fns, cache as cache_fns, item_doc, marker as marker_fns,
-    punctuate as punctuate_fns, punctuate_audit as audit_fns, score as score_fns,
+    area as area_fns, cache as cache_fns, item_common as item_common_fns, item_doc,
+    marker as marker_fns, punctuate as punctuate_fns, punctuate_audit as audit_fns,
+    score as score_fns,
 };
 use _functions::functions::system::oauth as oauth_fns;
 use _utils::{
@@ -141,6 +143,37 @@ async fn seed_punctuate(
     Ok(mp_model::Entity::insert(am).exec(db).await?.last_insert_id)
 }
 
+/// Seed an item row (used by the item_common assertions).
+async fn seed_common_item(
+    db: &sea_orm::DatabaseConnection,
+    now: chrono::NaiveDateTime,
+    name: &str,
+) -> anyhow::Result<i64> {
+    let am = item_model::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        name: Set(name.to_string()),
+        area_id: Set(1),
+        default_refresh_time: Set(0),
+        default_content: Set(None),
+        default_count: Set(1),
+        icon_tag: Set("0".into()),
+        icon_style_type: Set(IconStyleType::Default),
+        hidden_flag: Set(HiddenFlag::Visible),
+        sort_index: Set(0),
+        special_flag: Set(None),
+    };
+    Ok(item_model::Entity::insert(am)
+        .exec(db)
+        .await?
+        .last_insert_id)
+}
+
 async fn seed_user(
     db: &sea_orm::DatabaseConnection,
     username: &str,
@@ -237,6 +270,7 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(score_stat_model::Entity),
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
+        ddl_without_foreign_keys(iap_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
         ddl_without_foreign_keys(mil_model::Entity),
         ddl_without_foreign_keys(mp_model::Entity),
@@ -251,6 +285,7 @@ async fn area_and_item_doc_business_assertions() {
             "score_stat",
             "area",
             "item",
+            "item_area_public",
             "marker",
             "marker_item_link",
             "marker_punctuate",
@@ -946,4 +981,88 @@ async fn area_and_item_doc_business_assertions() {
     .expect("get score data ok");
     assert_eq!(data.samples.len(), 1, "one sample returned");
     assert_eq!(data.samples[0].score, 4.0, "score read back from content");
+
+    // ── item_common: the add/delete/list pipeline operates on the
+    //    item_area_public link table (Java parity), NOT on the item table ──
+    // 3 items: a and a' share a name, c is unique.
+    let item_a = seed_common_item(db, now, "紫晶矿").await.expect("seed a");
+    let item_a_dup = seed_common_item(db, now, "紫晶矿").await.expect("seed a'");
+    let item_c = seed_common_item(db, now, "日落果").await.expect("seed c");
+
+    // add([a, c]) → true; list shows exactly those two (link rows, not all items).
+    let added = item_common_fns::do_add(stub_auth(), vec![item_a, item_c])
+        .await
+        .expect("item_common add")
+        .data
+        .expect("add ok");
+    assert!(added, "new names must be marked as common items");
+    let list = item_common_fns::do_get_list(
+        stub_auth(),
+        _utils::models::Pagination {
+            current: Some(1),
+            size: Some(10),
+        },
+    )
+    .await
+    .expect("item_common list")
+    .data
+    .expect("list ok");
+    assert_eq!(list.total, 2, "two common items linked");
+    let names: Vec<&str> = list.items.iter().map(|i| i.name.as_str()).collect();
+    assert!(names.contains(&"紫晶矿") && names.contains(&"日落果"));
+    // The item table itself must be untouched by the add (no new rows created).
+    let item_rows = item_model::Entity::find_safety()
+        .filter(item_model::Column::Id.is_in(vec![item_a, item_a_dup, item_c]))
+        .count(db)
+        .await
+        .expect("count seeded items");
+    assert_eq!(item_rows, 3, "add must not insert item rows");
+
+    // add([a_dup, c]) → a_dup shares a name already common, c already linked → false.
+    let added = item_common_fns::do_add(stub_auth(), vec![item_a_dup, item_c])
+        .await
+        .expect("item_common add dup")
+        .data
+        .expect("add dup ok");
+    assert!(!added, "duplicate names / existing links must be skipped");
+    let list = item_common_fns::do_get_list(
+        stub_auth(),
+        _utils::models::Pagination {
+            current: Some(1),
+            size: Some(10),
+        },
+    )
+    .await
+    .expect("item_common list after dup add")
+    .data
+    .expect("list ok");
+    assert_eq!(list.total, 2, "dup add must not grow the list");
+
+    // delete(a) → the link row is soft-deleted (item rows remain), list drops to 1.
+    item_common_fns::do_delete(stub_auth(), item_a)
+        .await
+        .expect("item_common delete");
+    let list = item_common_fns::do_get_list(
+        stub_auth(),
+        _utils::models::Pagination {
+            current: Some(1),
+            size: Some(10),
+        },
+    )
+    .await
+    .expect("item_common list after delete")
+    .data
+    .expect("list ok");
+    assert_eq!(list.total, 1, "delete must drop the link");
+    assert_eq!(list.items[0].id, item_c, "the surviving item is c");
+    assert_eq!(
+        item_model::Entity::find_safety_by_id(item_a)
+            .one(db)
+            .await
+            .expect("item a still exists")
+            .expect("item a row present")
+            .name,
+        "紫晶矿",
+        "delete must not touch the item row"
+    );
 }


### PR DESCRIPTION
## Summary

Fix `item_common` to match the Java contract and make the user-list sort type-safe (deep review of the "low-risk" interfaces).

## Motivation

A closer review (against the Java `ItemCommonService` source) found `item_common` was writing to the **wrong table** with positional magic indices, and `UserSort` was handed from route to business as a `Debug` string — a rename would silently disable sorting.

## Changes

### item_common (Java parity)
- **`add`** (`PUT /item_common/add`, `Vec<i64>` unchanged): batch-links existing items into `item_area_public` — names already common are skipped, duplicate names keep the first id (exactly the Java flow). Previously it inserted a **new `item` row** using `payload[0]` as `area_id`, `[1]` as `default_count`, `[2]` as `default_refresh_time` — created junk items and never linked anything.
- **`delete`**: soft-deletes `item_area_public` rows by `item_id` (previously soft-deleted the `item` row itself). Route now returns the standard `CommonResponse` wrapper instead of bare `{}`.
- **`get/list`**: pages the link table joined to item info (previously listed every item in the system).
- Removed dead code: `do_update` and `do_get_single` had no routes and no Java counterpart.

### UserSort (type safety)
- `UserSort` moved to `_utils::types`; `do_list` matches enum variants directly. Wire contract (`createTime+`, `id-`, ... serde renames) unchanged. Renaming a variant is now a compile error instead of `_ => continue` silently dropping the sort.

### Tests
- `api_db` extended: seeds 3 items (two sharing a name), asserts add links both unique names, the item table gains no rows, a duplicate-name/existing-link add returns false, delete drops only the link row.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `api_db` (extended) passes against live Postgres: link insert, name dedup, soft-delete, item rows untouched
- [ ] CI full matrix

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Breaking Changes

`/api/item_common/*` responses now reflect the Java behavior (no more junk `item` rows; `add` returns `true/false` instead of a fabricated item id). The wire shapes (`Vec<i64>` body, `/delete/{itemId}`, camelCase fields) are unchanged.
