### PR TITLE
🐛 Align BinaryMD5 blobs and missing endpoints with the Java contract.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Align the BinaryMD5 blob content with the Java wire contract: the
+  `item_doc` / `marker_doc` / `marker_link_doc` pages were serializing the
+  raw sea-orm models (snake_case fields), while the frontend parses the
+  decompressed JSON by the Java `ItemVo` / `MarkerVo` / `MarkerLinkageVo`
+  names (camelCase) — the client would have read empty objects. The blobs
+  now serialize through the camelCase VOs (`ItemVO` / `MarkerVO` / a new
+  `LinkVo`). The `api_db` test decompresses an item page and asserts
+  `areaId` is present and `area_id` is not.
+
+- Add the missing `/api/icon_doc` domain (Java `IconDocController`):
+  `GET /icon_doc/all_bin_md5` and `GET /icon_doc/all_bin` serve the whole
+  icon set as one GZIP-compressed JSON blob (each icon carrying its
+  `typeIdList` from `icon_type_link`), cached at the result level. `api_db`
+  asserts the blob shape and camelCase `typeIdList`.
+
+- Wire the missing `GET /res/get` route (the `do_get` function existed).
+
+- Align the user-list route with the Java contract: `POST
+  /system/user/info/list` → `/system/user/info/userList` (the frontend
+  calls the Java path).
+
 - Fix `item_common` to match the Java contract (it wrote to the wrong
   table): `add` now batch-links existing items into `item_area_public`
   (deduped by name, names already common are skipped) instead of inserting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "flate2",
  "jsonwebtoken",
  "md5",
  "minio",

--- a/packages/functions/src/functions/api/icon_doc.rs
+++ b/packages/functions/src/functions/api/icon_doc.rs
@@ -1,0 +1,101 @@
+//! BinaryMD5 archive export for icons.
+//!
+//! Mirrors Java `IconDocController` / `IconDaoImpl`: the whole icon set is
+//! one GZIP-compressed JSON blob (each icon carrying its `typeIdList` from
+//! `icon_type_link`), keyed by the MD5 of the compressed bytes.
+//!
+//! Cached at the result level, so warm requests perform no database scan.
+
+use anyhow::{Result, anyhow};
+use sea_orm::{ColumnTrait, QueryFilter};
+use serde::Serialize;
+
+use _database::{
+    DB_CONN, models::icon::icon as icon_model, models::icon::icon_type_link as itl_model,
+};
+use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
+
+use super::binary_doc::{
+    BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
+};
+
+/// camelCase icon view for the BinaryMD5 blob (Java `IconVo` naming).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IconDocVo {
+    pub id: i64,
+    pub name: String,
+    pub url: String,
+    pub type_id_list: Vec<i64>,
+}
+
+/// `GET /icon_doc/all_bin_md5` — MD5 of the single all-icons blob.
+pub async fn do_all_bin_md5(
+    _auth: AuthInfo,
+    _payload: serde_json::Value,
+) -> Result<CommonResponse<BinaryMd5Vo>> {
+    let entry = icon_result().await?;
+    Ok(CommonResponse::new(Ok(entry.vo)))
+}
+
+/// `GET /icon_doc/all_bin` — the all-icons blob (compressed bytes).
+pub async fn do_all_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
+    let entry = icon_result().await?;
+    Ok(entry.bytes)
+}
+
+/// Compute (and cache) the single icon blob.
+async fn icon_result() -> Result<ResultEntry> {
+    let db = &DB_CONN.wait().pg_conn;
+
+    let entries = get_result_cached("icon:result".into(), async {
+        let icons = icon_model::Entity::find_safety().all(db).await?;
+        let ids: Vec<i64> = icons.iter().map(|i| i.id).collect();
+
+        // typeIdList per icon (Java: `IconTypeLink` by icon_id).
+        let mut type_map: std::collections::HashMap<i64, Vec<i64>> =
+            std::collections::HashMap::new();
+        if !ids.is_empty() {
+            for link in itl_model::Entity::find_safety()
+                .filter(itl_model::Column::IconId.is_in(ids))
+                .all(db)
+                .await?
+            {
+                type_map.entry(link.icon_id).or_default().push(link.type_id);
+            }
+        }
+
+        let vos: Vec<IconDocVo> = icons
+            .into_iter()
+            .map(|i| IconDocVo {
+                id: i.id,
+                name: i.name,
+                url: i.url,
+                type_id_list: type_map.remove(&i.id).unwrap_or_default(),
+            })
+            .collect();
+        let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
+        let page = get_or_compute("icon:all".to_string(), async {
+            Ok(CachedPage {
+                md5: md5_hex,
+                time: chrono::Utc::now().timestamp_millis(),
+                bytes: compressed,
+            })
+        })
+        .await?;
+        Ok(vec![ResultEntry {
+            key: "icon:all".to_string(),
+            vo: BinaryMd5Vo {
+                md5: page.md5,
+                time: page.time,
+            },
+            bytes: page.bytes,
+        }])
+    })
+    .await?;
+
+    entries
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("empty icon result"))
+}

--- a/packages/functions/src/functions/api/item_doc.rs
+++ b/packages/functions/src/functions/api/item_doc.rs
@@ -12,11 +12,32 @@ use anyhow::{Result, anyhow};
 use std::collections::BTreeMap;
 
 use _database::{DB_CONN, models::item::item as item_model};
-use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
+use _utils::{
+    db_operations::SafeEntityTrait,
+    jwt::AuthInfo,
+    models::{item::ItemVO, wrapper::CommonResponse},
+};
 
 use super::binary_doc::{
     BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
 };
+
+/// camelCase item view for the BinaryMD5 pages (Java `ItemVo` naming).
+fn item_to_vo(it: &item_model::Model) -> ItemVO {
+    ItemVO {
+        id: it.id,
+        name: it.name.clone(),
+        area_id: it.area_id,
+        default_refresh_time: it.default_refresh_time,
+        default_content: it.default_content.clone(),
+        default_count: it.default_count,
+        icon_tag: it.icon_tag.clone(),
+        icon_style_type: it.icon_style_type,
+        hidden_flag: it.hidden_flag,
+        sort_index: it.sort_index,
+        special_flag: it.special_flag,
+    }
+}
 
 /// `GET /item_doc/list_page_bin_md5`
 ///
@@ -64,12 +85,16 @@ async fn item_result() -> Result<Vec<ResultEntry>> {
                 .push(item);
         }
 
-        // Each group → one page → cached (serialize + compress + MD5)
+        // Each group → one page → cached (serialize + compress + MD5).
+        // The blob is serialized through the camelCase `ItemVO` (the wire
+        // contract of the item_doc pages is the Java `ItemVo` naming —
+        // snake_case models would break the frontend parser).
         let mut entries = Vec::with_capacity(groups.len());
         for (flag, group_items) in &groups {
             let key = format!("item:{flag}");
             let page = get_or_compute(key.clone(), async {
-                let (compressed, md5_hex) = serialize_compress_md5(group_items)?;
+                let vos: Vec<_> = group_items.iter().map(|m| item_to_vo(m)).collect();
+                let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                 Ok(CachedPage {
                     md5: md5_hex,
                     time: chrono::Utc::now().timestamp_millis(),

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -53,6 +53,12 @@ fn model_to_vo(it: marker_model::Model) -> MarkerVO {
     }
 }
 
+/// camelCase marker view for the BinaryMD5 pages (the wire contract of the
+/// `marker_doc` blob is the Java `MarkerVo` naming).
+pub(crate) fn model_to_vo_doc(it: &marker_model::Model) -> MarkerVO {
+    model_to_vo(it.clone())
+}
+
 pub async fn do_tweak(
     auth: AuthInfo,
     payload: MarkerTweakRequest,

--- a/packages/functions/src/functions/api/marker_doc.rs
+++ b/packages/functions/src/functions/api/marker_doc.rs
@@ -74,7 +74,14 @@ async fn marker_result() -> Result<Vec<ResultEntry>> {
                 for (page_index, page_markers) in &pages {
                     let key = marker_page_key(*flag, *page_index);
                     let page = get_or_compute(key.clone(), async {
-                        let (compressed, md5_hex) = serialize_compress_md5(&page_markers)?;
+                        // camelCase `MarkerVO` naming (Java `MarkerVo` wire
+                        // contract) — snake_case models would break the
+                        // frontend parser.
+                        let vos: Vec<_> = page_markers
+                            .iter()
+                            .map(|m| super::marker::model_to_vo_doc(m))
+                            .collect();
+                        let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                         Ok(CachedPage {
                             md5: md5_hex,
                             time: chrono::Utc::now().timestamp_millis(),
@@ -95,7 +102,11 @@ async fn marker_result() -> Result<Vec<ResultEntry>> {
                 // Other flags: single page (index 0)
                 let key = marker_page_key(*flag, 0);
                 let page = get_or_compute(key.clone(), async {
-                    let (compressed, md5_hex) = serialize_compress_md5(&group_markers)?;
+                    let vos: Vec<_> = group_markers
+                        .iter()
+                        .map(|m| super::marker::model_to_vo_doc(m))
+                        .collect();
+                    let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                     Ok(CachedPage {
                         md5: md5_hex,
                         time: chrono::Utc::now().timestamp_millis(),

--- a/packages/functions/src/functions/api/marker_link_doc.rs
+++ b/packages/functions/src/functions/api/marker_link_doc.rs
@@ -6,6 +6,7 @@
 //! at the result level, so warm requests perform no database scan.
 
 use anyhow::{Result, anyhow};
+use serde::Serialize;
 
 use _database::{DB_CONN, models::marker::marker_linkage as ml_model};
 use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
@@ -13,6 +14,26 @@ use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::Com
 use super::binary_doc::{
     BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
 };
+
+/// camelCase linkage view for the BinaryMD5 `list` blob (Java
+/// `MarkerLinkageVo` naming).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LinkVo {
+    id: i64,
+    from_id: i64,
+    to_id: i64,
+    path: Option<serde_json::Value>,
+}
+
+fn link_to_vo(l: &ml_model::Model) -> LinkVo {
+    LinkVo {
+        id: l.id,
+        from_id: l.from_id,
+        to_id: l.to_id,
+        path: l.path.clone(),
+    }
+}
 
 /// `GET /marker_link_doc/all_list_bin_md5` — MD5 of the flat linkage list blob.
 pub async fn do_all_list_bin_md5(
@@ -53,7 +74,10 @@ async fn linkage_result(key: &'static str, graph: bool) -> Result<ResultEntry> {
         let data: serde_json::Value = if graph {
             serde_json::to_value(build_graph(&linkages))?
         } else {
-            serde_json::to_value(&linkages)?
+            // camelCase `MarkerLinkageVo` naming (Java wire contract) —
+            // snake_case models would break the frontend parser.
+            let vos: Vec<_> = linkages.iter().map(link_to_vo).collect();
+            serde_json::to_value(&vos)?
         };
         let (compressed, md5_hex) = serialize_compress_md5(&data)?;
         let page = get_or_compute(key.to_string(), async {

--- a/packages/functions/src/functions/api/mod.rs
+++ b/packages/functions/src/functions/api/mod.rs
@@ -3,6 +3,7 @@ pub mod binary_doc;
 pub mod cache;
 pub mod history;
 pub mod icon;
+pub mod icon_doc;
 pub mod icon_type;
 pub mod item;
 pub mod item_common;

--- a/packages/router/src/routes/api/icon_doc/all_bin.rs
+++ b/packages/router/src/routes/api/icon_doc/all_bin.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+
+use axum::{
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::middlewares::ExtractAuthInfo;
+use axum::http::header;
+
+/// 获取所有图标信息的压缩数据
+/// GET /icon_doc/all_bin
+#[tracing::instrument(skip(auth))]
+pub async fn all_bin(
+    ExtractAuthInfo(auth): ExtractAuthInfo,
+) -> Result<Response, (StatusCode, String)> {
+    match _functions::functions::api::icon_doc::do_all_bin(auth).await {
+        Ok(bytes) => Ok((
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/octet-stream")],
+            Bytes::from(bytes),
+        )
+            .into_response()),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+    }
+}

--- a/packages/router/src/routes/api/icon_doc/all_bin_md5.rs
+++ b/packages/router/src/routes/api/icon_doc/all_bin_md5.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+
+use axum::{extract::Json, http::StatusCode, response::IntoResponse};
+
+use crate::middlewares::ExtractAuthInfo;
+
+/// 获取所有图标信息的 MD5
+/// GET /icon_doc/all_bin_md5
+#[tracing::instrument(skip(auth))]
+pub async fn all_bin_md5(
+    ExtractAuthInfo(auth): ExtractAuthInfo,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    match _functions::functions::api::icon_doc::do_all_bin_md5(auth, serde_json::json!({})).await {
+        Ok(v) => Ok((StatusCode::OK, Json(v))),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+    }
+}

--- a/packages/router/src/routes/api/icon_doc/mod.rs
+++ b/packages/router/src/routes/api/icon_doc/mod.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+
+use axum::{Router, routing::get};
+
+mod all_bin;
+mod all_bin_md5;
+
+pub async fn router() -> Result<Router> {
+    let ret = Router::new()
+        .route("/all_bin_md5", get(all_bin_md5::all_bin_md5))
+        .route("/all_bin", get(all_bin::all_bin));
+
+    Ok(ret)
+}

--- a/packages/router/src/routes/api/mod.rs
+++ b/packages/router/src/routes/api/mod.rs
@@ -2,6 +2,7 @@ pub mod area;
 pub mod cache;
 pub mod history;
 pub mod icon;
+pub mod icon_doc;
 pub mod icon_type;
 pub mod item;
 pub mod item_common;
@@ -30,6 +31,7 @@ pub async fn router() -> Result<Router> {
         .nest("/cache", cache::router().await?)
         .nest("/history", history::router().await?)
         .nest("/icon", icon::router().await?)
+        .nest("/icon_doc", icon_doc::router().await?)
         .nest("/icon_type", icon_type::router().await?)
         .nest("/item", item::router().await?)
         .nest("/item_common", item_common::router().await?)

--- a/packages/router/src/routes/api/res/get.rs
+++ b/packages/router/src/routes/api/res/get.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+use axum::{extract::Json, http::StatusCode, response::IntoResponse};
+
+/// 获取资源信息
+/// GET /res/get
+#[tracing::instrument]
+pub async fn get() -> Result<impl IntoResponse, (StatusCode, String)> {
+    match crate::functions::api::res::do_get().await {
+        Ok(v) => Ok((StatusCode::OK, Json(v))),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+    }
+}

--- a/packages/router/src/routes/api/res/mod.rs
+++ b/packages/router/src/routes/api/res/mod.rs
@@ -1,11 +1,17 @@
-mod upload;
-
 use anyhow::Result;
 
-use axum::{Router, routing::put};
+use axum::{
+    Router,
+    routing::{get, put},
+};
+
+mod get;
+mod upload;
 
 pub async fn router() -> Result<Router> {
-    let ret = Router::new().route("/upload/image", put(upload::upload_image));
+    let ret = Router::new()
+        .route("/get", get(get::get))
+        .route("/upload/image", put(upload::upload_image));
 
     Ok(ret)
 }

--- a/packages/router/src/routes/system/mod.rs
+++ b/packages/router/src/routes/system/mod.rs
@@ -46,7 +46,7 @@ pub async fn router() -> Result<Router> {
             post(user::update_password_by_admin),
         )
         .route("/user/{work_id}", delete(user::delete))
-        .route("/user/info/list", post(user::list))
+        .route("/user/info/userList", post(user::list))
         .route("/user/kick_out/{work_id}", delete(user::kick_out))
         .layer(from_extractor::<crate::middlewares::ExtractAuthInfo>());
 

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -25,6 +25,7 @@ minio = { workspace = true }
 jsonwebtoken = { workspace = true }
 uuid = { workspace = true }
 redis = { workspace = true }
+flate2 = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "^0.4"

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -15,13 +15,13 @@ use _database::DB_CONN;
 use _database::models::{
     area::area as area_model, area::item_area_public as iap_model,
     common::history as history_model, common::score_stat as score_stat_model,
-    item::item as item_model, marker::marker as marker_model,
-    marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
-    system::sys_action_log as action_log_model, system::sys_user as sys_user_model,
-    system::sys_user_device as device_model,
+    icon::icon as icon_model, icon::icon_type_link as itl_model, item::item as item_model,
+    marker::marker as marker_model, marker::marker_item_link as mil_model,
+    marker::marker_punctuate as mp_model, system::sys_action_log as action_log_model,
+    system::sys_user as sys_user_model, system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
-    area as area_fns, cache as cache_fns, item_common as item_common_fns, item_doc,
+    area as area_fns, cache as cache_fns, icon_doc, item_common as item_common_fns, item_doc,
     marker as marker_fns, punctuate as punctuate_fns, punctuate_audit as audit_fns,
     score as score_fns,
 };
@@ -174,6 +174,29 @@ async fn seed_common_item(
         .last_insert_id)
 }
 
+/// Seed an icon row (used by the icon_doc assertions).
+async fn seed_icon(
+    db: &sea_orm::DatabaseConnection,
+    now: chrono::NaiveDateTime,
+    name: &str,
+) -> anyhow::Result<i64> {
+    let am = icon_model::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        name: Set(name.to_string()),
+        url: Set(format!("https://example.test/{name}.png")),
+    };
+    Ok(icon_model::Entity::insert(am)
+        .exec(db)
+        .await?
+        .last_insert_id)
+}
+
 async fn seed_user(
     db: &sea_orm::DatabaseConnection,
     username: &str,
@@ -271,6 +294,8 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(iap_model::Entity),
+        ddl_without_foreign_keys(icon_model::Entity),
+        ddl_without_foreign_keys(itl_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
         ddl_without_foreign_keys(mil_model::Entity),
         ddl_without_foreign_keys(mp_model::Entity),
@@ -286,6 +311,8 @@ async fn area_and_item_doc_business_assertions() {
             "area",
             "item",
             "item_area_public",
+            "icon",
+            "icon_type_link",
             "marker",
             "marker_item_link",
             "marker_punctuate",
@@ -967,7 +994,7 @@ async fn area_and_item_doc_business_assertions() {
 
     // do_get_score_data reads the real score (not a fixed 1.0).
     let data = score_fns::do_get_score_data(
-        auth,
+        auth.clone(),
         ScoreDataRequest {
             end_time: end_ms,
             scope: "map".into(),
@@ -1064,5 +1091,72 @@ async fn area_and_item_doc_business_assertions() {
             .name,
         "紫晶矿",
         "delete must not touch the item row"
+    );
+
+    // ── Wire-contract assertions: BinaryMD5 blob content must use the Java
+    //    camelCase field naming (frontend parses the decompressed JSON by the
+    //    Java `ItemVo`/`MarkerVo`/`IconVo` names) ───────────────────────────
+    // item_doc page: decompress and check camelCase keys.
+    let item_bin = item_doc::do_list_page_bin(auth.clone(), md5_resp[0].md5.clone())
+        .await
+        .expect("fetch item page bin");
+    let mut decoder = flate2::read::GzDecoder::new(item_bin.as_slice());
+    let mut decoded = Vec::new();
+    std::io::Read::read_to_end(&mut decoder, &mut decoded).expect("gunzip item page");
+    let page: serde_json::Value = serde_json::from_slice(&decoded).expect("item page json");
+    let first = page[0].as_object().expect("page is an array of objects");
+    assert!(
+        first.contains_key("areaId") && !first.contains_key("area_id"),
+        "item page fields must be camelCase (Java ItemVo): {:?}",
+        first.keys().collect::<Vec<_>>()
+    );
+
+    // icon_doc: seed icons + a type link, then all_bin_md5 / all_bin.
+    let icon_1 = seed_icon(db, now, "icon-a").await.expect("seed icon a");
+    let icon_2 = seed_icon(db, now, "icon-b").await.expect("seed icon b");
+    itl_model::Entity::insert(itl_model::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        type_id: Set(7),
+        icon_id: Set(icon_1),
+    })
+    .exec(db)
+    .await
+    .expect("seed icon type link");
+
+    let icon_md5 = icon_doc::do_all_bin_md5(auth.clone(), serde_json::Value::Null)
+        .await
+        .expect("icon_doc md5")
+        .data
+        .expect("icon_doc md5 payload");
+    assert_eq!(icon_md5.md5.len(), 32, "icon blob md5");
+    let icon_bin = icon_doc::do_all_bin(auth.clone())
+        .await
+        .expect("fetch icon bin");
+    let mut decoder = flate2::read::GzDecoder::new(icon_bin.as_slice());
+    let mut decoded = Vec::new();
+    std::io::Read::read_to_end(&mut decoder, &mut decoded).expect("gunzip icon blob");
+    let icons: Vec<serde_json::Value> = serde_json::from_slice(&decoded).expect("icon json");
+    assert_eq!(icons.len(), 2, "both icons in the blob");
+    assert!(
+        icons.iter().any(|i| i["id"] == icon_2),
+        "second icon present in the blob"
+    );
+    let with_link = icons
+        .iter()
+        .find(|i| i["id"] == icon_1)
+        .expect("icon 1 present");
+    assert_eq!(
+        with_link["typeIdList"][0], 7,
+        "icon carries its typeIdList (camelCase, Java IconVo)"
+    );
+    assert!(
+        with_link.get("type_id_list").is_none(),
+        "no snake_case leak in the icon blob"
     );
 }


### PR DESCRIPTION
## Summary

Align BinaryMD5 blob content and missing endpoints with the Java contract (full cross-check of the Java `dev-single` controllers vs the Rust route table).

## Motivation

A route-by-route comparison against the Java backend (`kongying-tavern/genshin-map-cloud`, `dev-single` branch) surfaced a **data-contract break** plus missing endpoints:

1. The `item_doc` / `marker_doc` / `marker_link_doc` pages serialized raw sea-orm models — **snake_case** fields — while the frontend parses the decompressed JSON by the Java `ItemVo` / `MarkerVo` / `MarkerLinkageVo` **camelCase** names. Clients would have read empty objects from every page.
2. `GET /api/icon_doc/*` (Java `IconDocController`) was missing entirely.
3. `GET /res/get` had an implemented `do_get` but no route.
4. The user-list route was `/system/user/info/list`, the Java path is `/system/user/info/userList`.

## Changes

- **BinaryMD5 content**: item pages serialize through the camelCase `ItemVO`, marker pages through `MarkerVO` (new `pub(crate) model_to_vo_doc`), marker-link `list` blobs through a new camelCase `LinkVo`. MD5s change accordingly (content contract fix).
- **`icon_doc` domain** (new): `GET /icon_doc/all_bin` + `GET /icon_doc/all_bin_md5` — the whole icon set as one GZIP JSON blob with per-icon `typeIdList` (joined from `icon_type_link`), result-level cached.
- **`res/get`**: route wired to the existing `do_get`.
- **user-list path**: `/system/user/info/list` → `/system/user/info/userList`.
- **`api_db`**: decompresses an item page and asserts `areaId` present / `area_id` absent; seeds icons + a type link and asserts the icon blob shape and camelCase `typeIdList`.

## Test Plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `api_db` (extended) passes against live Postgres: camelCase blob assertions + icon_doc flow
- [ ] CI full matrix

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable)

## Known deviations (documented, not implemented)

- `GET /api/marker_doc/list_diff_snapshot` + `list_markers`: Java serves **protobuf**-encoded data — no protobuf contract exists in this codebase; out of scope.
- `POST /api/app/trigger/update`: Java broadcasts via **SocketIO** — no SocketIO in this codebase; out of scope.
- `tag` / `tag_type` domains exist in Rust but were removed from the Java `dev-single` branch (kept — harmless).

## Breaking Changes

The BinaryMD5 MD5 values change (blob content is now camelCase) — clients must refetch after upgrade. All other wire shapes are unchanged.
