### PR TITLE
✅ Add an idempotent schema initializer and gate the dev stack on the Vue path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Add a local schema initializer for dev/e2e: `cargo run --bin init_db`
+  (wrapped by `scripts/init_db.py`) creates the `genshin_map` schema and
+  all 24 tables idempotently, with the DDL generated straight from the
+  sea-orm entity definitions (FK-ordered, `IF NOT EXISTS`). Previously the
+  only way to get a schema was the test harness — the backend itself never
+  created tables.
+
+- Refuse to start the e2e/dev stack without a configured Vue frontend:
+  `E2E_VUE_FRONTEND` is mandatory in `.env` (relative paths now resolve
+  against the repo root, not the CWD), and `scripts/e2e/dev.py` prints a
+  friendly error and exits 1 instead of a raw traceback.
+
 - Align the BinaryMD5 blob content with the Java wire contract: the
   `item_doc` / `marker_doc` / `marker_link_doc` pages were serializing the
   raw sea-orm models (snake_case fields), while the frontend parses the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "once_cell",
  "reqwest 0.13.1",
  "rustls",
+ "sea-orm",
  "serde",
  "serde_json",
  "strum",

--- a/packages/router/Cargo.toml
+++ b/packages/router/Cargo.toml
@@ -38,3 +38,4 @@ rustls = { workspace = true }
 tower-http = { workspace = true }
 md5 = { workspace = true }
 bzip2 = { workspace = true }
+sea-orm = { workspace = true }

--- a/packages/router/src/bin/init_db.rs
+++ b/packages/router/src/bin/init_db.rs
@@ -1,0 +1,110 @@
+//! Idempotent schema initializer for local/e2e development.
+//!
+//! Creates the `genshin_map` schema and every table from the sea-orm models
+//! (`CREATE TABLE IF NOT EXISTS`), then exits. DDL is generated from the
+//! entity definitions, so it can never drift from the code.
+//!
+//! Usage (from the workspace root):
+//!   cargo run --bin init_db
+//!
+//! DB connection comes from the standard `DB_*` env vars (see `.env.example`);
+//! `scripts/init_db.py` wraps this for the e2e/dev workflow.
+
+use anyhow::{Context, Result};
+
+use sea_orm::{Database, DbBackend, Schema, prelude::*};
+
+use _database::models::{
+    area::area as area_entity, area::item_area_public as item_area_public_entity,
+    common::history as history_entity, common::notice as notice_entity,
+    common::route as route_entity, common::score_stat as score_stat_entity,
+    icon::icon as icon_entity, icon::icon_type as icon_type_entity,
+    icon::icon_type_link as icon_type_link_entity, item::item as item_entity,
+    item::item_type as item_type_entity, item::item_type_link as item_type_link_entity,
+    marker::marker as marker_entity, marker::marker_item_link as marker_item_link_entity,
+    marker::marker_linkage as marker_linkage_entity,
+    marker::marker_punctuate as marker_punctuate_entity,
+    system::sys_action_log as sys_action_log_entity, system::sys_user as sys_user_entity,
+    system::sys_user_archive as sys_user_archive_entity,
+    system::sys_user_device as sys_user_device_entity,
+    system::sys_user_invitation as sys_user_invitation_entity, tag::tag as tag_entity,
+    tag::tag_type as tag_type_entity, tag::tag_type_link as tag_type_link_entity,
+};
+
+/// Create every table with `CREATE TABLE IF NOT EXISTS` (idempotent). The
+/// DDL comes straight from the entity definitions, so it can't drift.
+macro_rules! ensure_tables {
+    ($db:expr, $schema:expr, $($entity:expr),+ $(,)?) => {{
+        let mut created = 0usize;
+        $(
+            let stmt = $schema.create_table_from_entity($entity);
+            let sql = stmt.to_string(sea_orm::sea_query::PostgresQueryBuilder);
+            // sea-orm emits plain CREATE TABLE; make it idempotent.
+            let sql = sql.replacen("CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1);
+            $db.execute_unprepared(&sql)
+                .await
+                .with_context(|| format!("create table for {}", stringify!($entity)))?;
+            created += 1;
+        )+
+        created
+    }};
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let db_port = std::env::var("DB_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(5432);
+    let url = format!(
+        "postgres://{}:{}@{}:{}/{}",
+        std::env::var("DB_USERNAME").unwrap_or_else(|_| "genshin_map".into()),
+        std::env::var("DB_PASSWORD").unwrap_or_default(),
+        std::env::var("DB_HOST").unwrap_or_else(|_| "localhost".into()),
+        db_port,
+        std::env::var("DB_DATABASE").unwrap_or_else(|_| "genshin_map".into()),
+    );
+    let db = Database::connect(&url)
+        .await
+        .with_context(|| format!("connect to {url}"))?;
+
+    db.execute_unprepared("CREATE SCHEMA IF NOT EXISTS genshin_map")
+        .await
+        .context("create schema")?;
+
+    let schema = Schema::new(DbBackend::Postgres);
+    // Order matters for the FOREIGN KEY constraints: referenced tables must
+    // exist first. sys_user → standalone masters (area is self-referencing
+    // via parent_id, which is fine) → link tables → system aux tables.
+    let created = ensure_tables!(
+        db,
+        schema,
+        sys_user_entity::Entity,
+        area_entity::Entity,
+        icon_entity::Entity,
+        icon_type_entity::Entity,
+        item_entity::Entity,
+        item_type_entity::Entity,
+        tag_entity::Entity,
+        tag_type_entity::Entity,
+        marker_entity::Entity,
+        notice_entity::Entity,
+        route_entity::Entity,
+        history_entity::Entity,
+        score_stat_entity::Entity,
+        icon_type_link_entity::Entity,
+        item_type_link_entity::Entity,
+        tag_type_link_entity::Entity,
+        marker_item_link_entity::Entity,
+        marker_linkage_entity::Entity,
+        item_area_public_entity::Entity,
+        marker_punctuate_entity::Entity,
+        sys_user_archive_entity::Entity,
+        sys_user_device_entity::Entity,
+        sys_user_invitation_entity::Entity,
+        sys_action_log_entity::Entity,
+    );
+
+    println!("Schema ready: {created} tables ensured in genshin_map");
+    Ok(())
+}

--- a/scripts/e2e/config.py
+++ b/scripts/e2e/config.py
@@ -66,13 +66,19 @@ def _resolve_vue_frontend() -> Path:
     env_path = os.environ.get("E2E_VUE_FRONTEND")
     if not env_path:
         raise RuntimeError(
-            "E2E_VUE_FRONTEND is not set.\n"
+            "E2E_VUE_FRONTEND is not set — refusing to start.\n"
             "Add it to .env, e.g.:\n"
-            "  E2E_VUE_FRONTEND=D:\\code\\vue_map_register_v3"
+            "  E2E_VUE_FRONTEND=D:\\code\\vue_map_register_v3\n"
+            "  E2E_VUE_FRONTEND=../vue_map_register_v3   # relative to the repo root"
         )
     # Convert Windows path to native if running in WSL
     native_path = _win_to_native(env_path)
-    p = Path(native_path).resolve()
+    p = Path(native_path)
+    # Relative paths resolve against the repo root (not the CWD), so the
+    # .env entry is stable regardless of where the script is invoked from.
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    p = p.resolve()
     if not (p / "package.json").exists():
         raise RuntimeError(
             f"E2E_VUE_FRONTEND={env_path}\n"

--- a/scripts/e2e/dev.py
+++ b/scripts/e2e/dev.py
@@ -32,6 +32,14 @@ def _run(script: Path, *args: str) -> int:
 
 
 def main() -> int:
+    # The Vue frontend path is mandatory (config.py refuses to import without
+    # it): surface a friendly error instead of a raw traceback.
+    try:
+        from config import VUE_FRONTEND  # noqa: F401
+    except RuntimeError as e:
+        error(TARGET, f"Refusing to start: {e}")
+        return 1
+
     cmd = sys.argv[1] if len(sys.argv) > 1 else ""
 
     if cmd == "" or cmd == "start":

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Initialize the local Postgres schema for the Rust backend.
+
+Wraps `cargo run --bin init_db` (the idempotent sea-orm schema initializer):
+reads DB_* settings from .env / environment and passes them through, so the
+tables are always generated from the current entity definitions.
+
+Usage:
+    python scripts/init_db.py
+
+Exits non-zero when Postgres is unreachable or the schema step fails.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_dotenv() -> None:
+    env_file = REPO_ROOT / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        k, v = k.strip(), v.strip()
+        if k and k not in os.environ:
+            os.environ[k] = v
+
+
+def main() -> int:
+    load_dotenv()
+
+    host = os.environ.get("DB_HOST", "localhost")
+    port = os.environ.get("DB_PORT", "5432")
+    user = os.environ.get("DB_USERNAME", "genshin_map")
+    database = os.environ.get("DB_DATABASE", "genshin_map")
+    print(f"Initializing schema at postgres://{user}@{host}:{port}/{database} ...")
+
+    result = subprocess.run(
+        ["cargo", "run", "--bin", "init_db"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=300,
+    )
+    if result.returncode != 0:
+        print(result.stdout[-4000:], file=sys.stdout)
+        print(result.stderr[-4000:], file=sys.stderr)
+        print("Schema initialization FAILED.", file=sys.stderr)
+        return result.returncode
+
+    print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add local dev/e2e schema initialization and gate the dev stack on the Vue path.

## Motivation

Two friction points for running the full stack locally (WSL2/podman-backed services):

1. There was **no way to create the database schema** outside the test harness — the backend only connects, it never creates tables, and the repo has no SQL files. `schema_test.rs` could build DDL from the sea-orm entities but that's test-only.
2. The e2e stack started without a usable Vue frontend path (raw traceback) and relative `E2E_VUE_FRONTEND` entries resolved against the CWD.

## Changes

- **`packages/router/src/bin/init_db.rs`** (new bin): connects via the standard `DB_*` env vars, creates the `genshin_map` schema and all **24 tables idempotently** — DDL generated straight from the sea-orm entity definitions (FK-topologically ordered, `CREATE TABLE IF NOT EXISTS`), so it can never drift from the models.
- **`scripts/init_db.py`** (new): python wrapper that loads `.env`, passes the DB settings through, runs `cargo run --bin init_db` with UTF-8 handling (Windows console), and reports clearly.
- **`scripts/e2e/config.py`**: `E2E_VUE_FRONTEND` relative paths now resolve against the **repo root** (not the CWD); missing-variable error message shows both absolute and relative examples.
- **`scripts/e2e/dev.py`**: catches the missing-frontend `RuntimeError` and exits 1 with a friendly message instead of a traceback.

## Test Plan (verified locally with a podman(WSL2) Postgres)

- [x] `cargo run --bin init_db` → `Schema ready: 24 tables ensured in genshin_map`
- [x] Second run → same output (idempotent)
- [x] `python scripts/init_db.py` → same (both runs)
- [x] `python scripts/e2e/dev.py` without `E2E_VUE_FRONTEND` → friendly refusal, exit 1
- [x] Relative `E2E_VUE_FRONTEND=../vue_map_register_v3` resolves to the repo sibling
- [x] `cargo check/clippy/fmt` clean

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable — .env.example already documents E2E_VUE_FRONTEND)

## Breaking Changes

None. `init_db` is additive; the Vue-path gate only changes failure behavior (previously a raw traceback, now a clean refusal).
