### PR TITLE
🐛 Serve the domain endpoints under the Java /api prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   against the repo root, not the CWD), and `scripts/e2e/dev.py` prints a
   friendly error and exits 1 instead of a raw traceback.
 
+- Serve the domain endpoints under the Java `/api/*` prefix: the router
+  merged the `area`/`icon`/`item`/`marker`/... routes at the root
+  (`/area/get/list`), while the frontend and the Vite proxy
+  (`VITE_API_BASE=/api`) call `/api/area/get/list` — every domain request
+  fell through to 501. `.merge(api::router())` is now `.nest("/api", ...)`
+  (verified against a locally running backend with a signed token).
+
 - Align the BinaryMD5 blob content with the Java wire contract: the
   `item_doc` / `marker_doc` / `marker_link_doc` pages were serializing the
   raw sea-orm models (snake_case fields), while the frontend parses the

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -18,7 +18,9 @@ pub async fn router() -> Result<Router> {
         .route("/oauth/qq", post(system::oauth::qq_login))
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/system", system::router().await?)
-        .merge(api::router().await?)
+        // Java contract: every domain endpoint lives under /api/* — the
+        // frontend and the Vite proxy (VITE_API_BASE=/api) call these paths.
+        .nest("/api", api::router().await?)
         .nest_service("/cdn", cdn_proxy())
         .fallback(|| async { (StatusCode::NOT_IMPLEMENTED, "Not Implemented").into_response() })
         .layer(cors_layer())


### PR DESCRIPTION
## Summary

Serve the domain endpoints under the Java `/api/*` prefix (found while running the full local stack).

## Motivation

The router merged the domain routes at the root (`/area/get/list`), but the frontend and the Vite proxy (`VITE_API_BASE=/api`, `VITE_API_PROXY_TARGET`) call `/api/area/get/list` — every domain request fell through to the 501 fallback. Verified live: signed-token requests to `/api/area/get/list` returned 501 before, 200 after.

## Changes

- `routes/mod.rs`: `.merge(api::router())` → `.nest("/api", api::router())`. `/system/*`, `/oauth/*`, `/.well-known/*`, `/cdn` are unaffected (they already had their prefixes).
- `CHANGELOG.md` entry.

## Test Plan

- [x] Live backend + signed HS256 token: `POST /api/area/get/list` → 200; `GET /api/item_doc/list_page_bin_md5` → 200; bare `/area/get/list` → 501
- [x] `cargo check --workspace --all-targets`, clippy `-D warnings`, fmt clean
- [ ] CI full matrix

## Breaking Changes

Yes — this is the intended contract fix: any client calling the unprefixed paths must switch to `/api/*`. The Java backend and the Vite proxy both use the prefixed form.
