### PR TITLE
✅ Bootstrap the dev stack: on-demand schema, seeded admin credentials.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Dev-stack bootstrap: `init_db` now runs **on-demand** (skips the CREATE
+  pass when the schema already exists) and seeds a dev admin account —
+  default `admin` / `admin123`, overridable via `INIT_ADMIN_USERNAME` /
+  `INIT_ADMIN_PASSWORD`, credentials printed to the log when created.
+  `scripts/e2e/dev.py start|daemon|mock` runs the schema init first and
+  refuses to start when it fails, so a fresh machine goes from zero to a
+  logged-in backend in one command (verified end-to-end: seed → password
+  grant login → authorized `/api/area/get/list`).
+
 - Add a local schema initializer for dev/e2e: `cargo run --bin init_db`
   (wrapped by `scripts/init_db.py`) creates the `genshin_map` schema and
   all 24 tables idempotently, with the DDL generated straight from the

--- a/packages/router/src/bin/init_db.rs
+++ b/packages/router/src/bin/init_db.rs
@@ -4,6 +4,10 @@
 //! (`CREATE TABLE IF NOT EXISTS`), then exits. DDL is generated from the
 //! entity definitions, so it can never drift from the code.
 //!
+//! **On-demand mode**: when all 24 tables already exist the CREATE pass is
+//! skipped entirely ("schema already up to date"). Afterwards it ensures a
+//! dev admin account exists and prints the credentials to stdout.
+//!
 //! Usage (from the workspace root):
 //!   cargo run --bin init_db
 //!
@@ -12,7 +16,10 @@
 
 use anyhow::{Context, Result};
 
-use sea_orm::{Database, DbBackend, Schema, prelude::*};
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, ConnectionTrait, Database, DbBackend, EntityTrait, QueryFilter,
+    Schema,
+};
 
 use _database::models::{
     area::area as area_entity, area::item_area_public as item_area_public_entity,
@@ -72,39 +79,100 @@ async fn main() -> Result<()> {
         .await
         .context("create schema")?;
 
-    let schema = Schema::new(DbBackend::Postgres);
-    // Order matters for the FOREIGN KEY constraints: referenced tables must
-    // exist first. sys_user → standalone masters (area is self-referencing
-    // via parent_id, which is fine) → link tables → system aux tables.
-    let created = ensure_tables!(
-        db,
-        schema,
-        sys_user_entity::Entity,
-        area_entity::Entity,
-        icon_entity::Entity,
-        icon_type_entity::Entity,
-        item_entity::Entity,
-        item_type_entity::Entity,
-        tag_entity::Entity,
-        tag_type_entity::Entity,
-        marker_entity::Entity,
-        notice_entity::Entity,
-        route_entity::Entity,
-        history_entity::Entity,
-        score_stat_entity::Entity,
-        icon_type_link_entity::Entity,
-        item_type_link_entity::Entity,
-        tag_type_link_entity::Entity,
-        marker_item_link_entity::Entity,
-        marker_linkage_entity::Entity,
-        item_area_public_entity::Entity,
-        marker_punctuate_entity::Entity,
-        sys_user_archive_entity::Entity,
-        sys_user_device_entity::Entity,
-        sys_user_invitation_entity::Entity,
-        sys_action_log_entity::Entity,
-    );
+    // On-demand: skip the CREATE pass entirely when the schema already
+    // exists (probe a representative table).
+    let schema_present = db
+        .execute_unprepared("SELECT 1 FROM genshin_map.sys_user LIMIT 1")
+        .await
+        .is_ok();
 
-    println!("Schema ready: {created} tables ensured in genshin_map");
+    if schema_present {
+        println!("Schema already up to date (genshin_map)");
+    } else {
+        let schema = Schema::new(DbBackend::Postgres);
+        // Order matters for the FOREIGN KEY constraints: referenced tables
+        // must exist first. sys_user → standalone masters (area is
+        // self-referencing via parent_id, which is fine) → link tables →
+        // system aux tables.
+        let created = ensure_tables!(
+            db,
+            schema,
+            sys_user_entity::Entity,
+            area_entity::Entity,
+            icon_entity::Entity,
+            icon_type_entity::Entity,
+            item_entity::Entity,
+            item_type_entity::Entity,
+            tag_entity::Entity,
+            tag_type_entity::Entity,
+            marker_entity::Entity,
+            notice_entity::Entity,
+            route_entity::Entity,
+            history_entity::Entity,
+            score_stat_entity::Entity,
+            icon_type_link_entity::Entity,
+            item_type_link_entity::Entity,
+            tag_type_link_entity::Entity,
+            marker_item_link_entity::Entity,
+            marker_linkage_entity::Entity,
+            item_area_public_entity::Entity,
+            marker_punctuate_entity::Entity,
+            sys_user_archive_entity::Entity,
+            sys_user_device_entity::Entity,
+            sys_user_invitation_entity::Entity,
+            sys_action_log_entity::Entity,
+        );
+        println!("Schema ready: {created} tables ensured in genshin_map");
+    }
+
+    ensure_admin_account(&db).await?;
+    Ok(())
+}
+
+/// Ensure a dev admin account exists (dev-only bootstrap). Prints the
+/// credentials to stdout when it creates one; override via
+/// `INIT_ADMIN_USERNAME` / `INIT_ADMIN_PASSWORD`.
+async fn ensure_admin_account(db: &sea_orm::DatabaseConnection) -> Result<()> {
+    let username = std::env::var("INIT_ADMIN_USERNAME").unwrap_or_else(|_| "admin".into());
+    let password = std::env::var("INIT_ADMIN_PASSWORD").unwrap_or_else(|_| "admin123".into());
+
+    let existing = sys_user_entity::Entity::find()
+        .filter(sys_user_entity::Column::RoleId.eq(_utils::types::SystemUserRole::Admin))
+        .one(db)
+        .await?;
+    if existing.is_some() {
+        println!(
+            "Admin account already present ({}); nothing to seed",
+            existing.map(|u| u.username).unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+    sys_user_entity::Entity::insert(sys_user_entity::ActiveModel {
+        version: Set(0),
+        id: Set(1),
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        username: Set(username.clone()),
+        password: Set(_utils::bcrypt::generate_storage_password(&password)?),
+        nickname: Set(Some("Dev Admin".into())),
+        qq: Set(None),
+        phone: Set(None),
+        logo: Set(None),
+        role_id: Set(_utils::types::SystemUserRole::Admin),
+        access_policy: Set(None),
+        remark: Set(Some("Auto-seeded by init_db (dev only)".into())),
+    })
+    .exec(db)
+    .await?;
+
+    println!(
+        "Seeded dev admin account: username={username} password={password} \
+         (dev only — override via INIT_ADMIN_USERNAME / INIT_ADMIN_PASSWORD)"
+    );
     Ok(())
 }

--- a/scripts/e2e/dev.py
+++ b/scripts/e2e/dev.py
@@ -31,6 +31,15 @@ def _run(script: Path, *args: str) -> int:
     return subprocess.call([sys.executable, str(script), *args])
 
 
+def _init_schema() -> bool:
+    """On-demand schema init + dev admin seed (idempotent, fast when warm).
+
+    The initial admin credentials are printed to the log by init_db.
+    """
+    rc = _run(SCRIPTS_DIR.parent / "init_db.py")
+    return rc == 0
+
+
 def main() -> int:
     # The Vue frontend path is mandatory (config.py refuses to import without
     # it): surface a friendly error instead of a raw traceback.
@@ -41,6 +50,11 @@ def main() -> int:
         return 1
 
     cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    if cmd in ("", "start", "daemon", "mock"):
+        if not _init_schema():
+            error(TARGET, "Schema init failed — refusing to start (check DB_* in .env).")
+            return 1
 
     if cmd == "" or cmd == "start":
         info(TARGET, "Starting dev stack (Rust + Vue), foreground mode...")


### PR DESCRIPTION
## Summary

Bootstrap the dev stack: on-demand schema init + seeded admin credentials, wired into `dev.py`.

## Motivation

Running the full stack locally needed two manual steps that are now automated: the schema was only created by the test harness, and there was no way to log in (no users existed).

## Changes

- **`packages/router/src/bin/init_db.rs`**:
  - **On-demand mode**: probes `genshin_map.sys_user` first; when the schema exists it prints `Schema already up to date` and skips the CREATE pass entirely (no more 24 `IF NOT EXISTS` statements every run).
  - **Dev admin seed**: ensures an Admin-role user exists (default `admin` / `admin123`, overridable via `INIT_ADMIN_USERNAME` / `INIT_ADMIN_PASSWORD`, bcrypt-hashed), and prints the credentials to stdout when it creates one.
- **`scripts/e2e/dev.py`**: `start` / `daemon` / `mock` run the schema init first and refuse to start when it fails — one command from zero to a logged-in backend.

## Test Plan (verified end-to-end locally)

- [x] Fresh DB: `python scripts/init_db.py` → 24 tables + `Seeded dev admin account: username=admin password=admin123`
- [x] Second run → `Schema already up to date` + `Admin account already present; nothing to seed`
- [x] Live backend: `POST /oauth/token` (multipart `grant_type=password`) with `admin`/`admin123` → 200 with access+refresh tokens
- [x] Authorized `POST /api/area/get/list` with that token → 200
- [x] `cargo check` / clippy `-D warnings` / fmt clean

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added
- [x] Documentation updated (not applicable — env knobs documented in the code)

## Breaking Changes

None. The seed only runs when no Admin user exists (an existing deployment is untouched; the credentials are dev-only and printed to the log).
