### PR TITLE
🐛 Mount the domain routes at both /api and the root for the Vite proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Serve the domain endpoints under **both** `/api/*` and the root: the
+  Java contract puts every domain under `/api/*`, but the Vite dev proxy
+  **strips** the `/api` prefix before forwarding (vite.config `rewrite`),
+  so dev-mode frontends hit the unprefixed paths. Only `/api` (or only the
+  root, as before) broke one of the two clients — both are now mounted,
+  verified live through all three paths (direct `/api/area`, bare
+  `/area`, and `http://127.0.0.1:9000/api/area` via the Vite proxy).
+
+- Fix the e2e runner on Windows consoles: the emoji in the test report
+  crashed with `UnicodeEncodeError` under GBK/cp936; stdout/stderr are now
+  reconfigured to UTF-8. Full e2e verified locally: **5 passed, 0 failed,
+  0 skipped** (Shirabe browser + authenticated API assertions against the
+  seeded `admin` account).
+
 - Fix the e2e login client to match the backend contract: the Rust
   `/oauth/token` extracts the password grant via axum `Multipart`
   (Java-parity), so `run_tests.py`'s urlencoded login was rejected with a

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -18,8 +18,12 @@ pub async fn router() -> Result<Router> {
         .route("/oauth/qq", post(system::oauth::qq_login))
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/system", system::router().await?)
-        // Java contract: every domain endpoint lives under /api/* — the
-        // frontend and the Vite proxy (VITE_API_BASE=/api) call these paths.
+        // The domain endpoints live under /api/* (Java contract — the
+        // frontend's production build and direct clients call these paths).
+        // They are ALSO merged at the root: the Vite dev proxy rewrites
+        // `/api/*` → `/*` before forwarding (vite.config `rewrite`), so a
+        // dev-mode frontend hits the unprefixed paths. Both must work.
+        .merge(api::router().await?)
         .nest("/api", api::router().await?)
         .nest_service("/cdn", cdn_proxy())
         .fallback(|| async { (StatusCode::NOT_IMPLEMENTED, "Not Implemented").into_response() })

--- a/scripts/e2e/run_tests.py
+++ b/scripts/e2e/run_tests.py
@@ -17,6 +17,12 @@ import sys
 import time
 from pathlib import Path
 
+# Windows consoles default to GBK/cp936, which cannot encode the emoji used
+# in the test output (crash: UnicodeEncodeError). Force UTF-8 for the report.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 import urllib.request
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))


### PR DESCRIPTION
## Summary

Mount the domain routes at both `/api/*` and the root, and fix the e2e runner on Windows consoles (found by running the full local stack).

## Motivation

- PR #74 moved the domain routes to `/api/*` only (Java contract). But the Vite dev proxy **strips** the `/api` prefix before forwarding (vue_map_register_v3 `vite.config.ts` `rewrite: path => path.replace('/api', '')`), so dev-mode frontends hit the unprefixed paths — every request through the proxy fell to 501. Both clients need both paths.
- The e2e runner crashed on Windows consoles: emoji in the report can't encode under GBK/cp936 (`UnicodeEncodeError` before any test ran).

## Changes

- `routes/mod.rs`: domain routes are now both merged at the root **and** nested under `/api` (verified live: direct `/api/area/get/list`, bare `/area/get/list`, and `http://127.0.0.1:9000/api/area/get/list` through the Vite proxy all → 200).
- `scripts/e2e/run_tests.py`: reconfigure stdout/stderr to UTF-8 on Windows.
- `CHANGELOG.md` entries.

## Test Plan (full local stack, verified)

- [x] podman(WSL2) Postgres + Redis + native MinIO + Rust backend + Vue dev server all up
- [x] All three route paths → 200 with the seeded admin token
- [x] Image upload → MinIO → public URL fetch → 200
- [x] `python scripts/e2e/run_tests.py` (Shirabe browser): **5 passed, 0 failed, 0 skipped**
- [x] `cargo check` / clippy `-D warnings` / fmt clean

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

None — this restores the root paths (PR #74's removal was the break) while keeping `/api/*`.
