### PR TITLE
🐛 Fix the demo seed coordinates and area codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix the demo seed to actually render: areas now carry the real frontend
+  codes (`A:MD:MENGDE` / `A:LY:LIYUE` / `A:DQ:1` — matched against
+  `AREA_ADDITIONAL_CONFIG_MAP` and the dadian tiles), and markers use game
+  coordinates (Mondstadt x 500..3500, y -2300..-4700, city ≈ [1600, -4050])
+  instead of an invented positive-y space that would have placed them far
+  off the tile map.
+
 - Serve the domain endpoints under **both** `/api/*` and the root: the
   Java contract puts every domain under `/api/*`, but the Vite dev proxy
   **strips** the `/api` prefix before forwarding (vite.config `rewrite`),

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -72,19 +72,20 @@ def main() -> int:
 
     now = "now()"
 
-    # ── Areas (root area self-references its parent_id) ──────────────────────
+    # ── Areas (root area self-references its parent_id; codes match the
+    #    frontend's AREA_ADDITIONAL_CONFIG_MAP / dadian tiles) ───────────────
     areas = [
-        (1, "蒙德", 1),
-        (2, "璃月", 1),
-        (3, "稻妻", 1),
+        (1, "蒙德", 1, "A:MD:MENGDE"),
+        (2, "璃月", 1, "A:LY:LIYUE"),
+        (3, "稻妻", 1, "A:DQ:1"),
     ]
-    for aid, name, parent in areas:
+    for aid, name, parent, code in areas:
         cur.execute(
             f'INSERT INTO "genshin_map"."area" '
             f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
             f"name, code, content, icon_tag, parent_id, is_final, hidden_flag, sort_index, special_flag) "
-            f"VALUES (0, {aid}, {now}, NULL, NULL, NULL, false, %s, NULL, NULL, '0', {parent}, true, 0, {aid}, 0)",
-            (name,),
+            f"VALUES (0, {aid}, {now}, NULL, NULL, NULL, false, %s, %s, NULL, '0', {parent}, true, 0, {aid}, 0)",
+            (name, code),
         )
 
     # ── Icons ────────────────────────────────────────────────────────────────
@@ -124,7 +125,9 @@ def main() -> int:
         )
 
     # ── Markers: ~150 points spread over the Mondstadt region ────────────────
-    # Teyvat coordinates; Mondstadt city sits around (2400, 1900).
+    # Game coordinates: Mondstadt spans roughly x 500..3500, y -4700..-2300
+    # (Mondstadt city ≈ [1600, -4050]); the frontend renders markers in this
+    # space on top of the 提瓦特 tile map.
     rng = random.Random(20260803)
     marker_id = 1
     title_by_item = {
@@ -138,8 +141,8 @@ def main() -> int:
     }
     for _ in range(150):
         item_id = rng.choice(list(title_by_item))
-        x = rng.randint(1800, 3200)
-        y = rng.randint(1200, 2600)
+        x = rng.randint(500, 3500)
+        y = -rng.randint(2300, 4700)
         position = f"{x}.{rng.randint(0, 9)},{y}.{rng.randint(0, 9)}"
         cur.execute(
             f'INSERT INTO "genshin_map"."marker" '


### PR DESCRIPTION
## Summary

Fix the demo seed so the frontend actually renders the map (areas need the real codes, markers need game coordinates).

## Motivation

After seeding, the map still rendered empty: the frontend resolves each area's tiles via its \code\ against \AREA_ADDITIONAL_CONFIG_MAP\ and the dadian config — the seeded areas had \code = NULL\. Markers were also placed in an invented positive-y space (city ≈ [1600, -4050] in game coords), far off the tile map.

## Changes

- \scripts/seed_demo.py\: areas carry \A:MD:MENGDE\ / \A:LY:LIYUE\ / \A:DQ:1\; markers use Mondstadt game coordinates (x 500..3500, y -2300..-4700).
- \CHANGELOG.md\ entry.

## Test Plan (verified locally)

- [x] Reseed → 3 areas / 7 items / 150 markers
- [x] Backend with \CDN_DADIAN_CONFIG\ (real \system.json.bz2\ from assets.yuanshen.site, 38 tiles), \CDN_UPSTREAM=https://assets.yuanshen.site\, \CORS_ALLOW_ORIGIN=http://127.0.0.1:9000\:
  - \/cdn/dadian-preview.json.bz2\ → 200, 32695 bytes, parses with 38 tiles
  - \/cdn/tiles_twt662/13/20_15.png\ → 200 (real PNG, 108KB)
  - CORS header present for the frontend origin

## Checklist

- [x] CHANGELOG entry added

## Breaking Changes

None (dev tooling only).