### PR TITLE
🐛 Carry the item typeIdList in ItemVO and fix the admin seed id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Carry the item `typeIdList` in every `ItemVO` (Java `ItemVo` parity): the
+  field was missing, so the frontend's item panel (which filters/group by
+  type) stayed empty. All producers now fill it from `item_type_link` —
+  `item` get/list + list_by_id, the `item_doc` BinaryMD5 pages (the
+  frontend's primary source) and `item_common` list. `api_db` asserts the
+  field on the decompressed page.
+
+- Fix the `init_db` admin seed to not pin id=1 (`NotSet`), so it survives
+  databases where the sequence has already handed out ids (e.g. after the
+  test harness rebuilt the tables).
+
 - Seed the item-type taxonomy in the demo data: the frontend's left panel
   groups items by `item_type` (via `/api/item_type/get/list_all`) — with an
   empty table the panel had no entries and no markers were selectable. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Seed the item-type taxonomy in the demo data: the frontend's left panel
+  groups items by `item_type` (via `/api/item_type/get/list_all`) — with an
+  empty table the panel had no entries and no markers were selectable. The
+  seeder now creates 5 types (传送锚点/七天神像/秘境/宝箱/材料) plus the
+  `item_type_link` rows.
+
 - Fix the demo seed to actually render: areas now carry the real frontend
   codes (`A:MD:MENGDE` / `A:LY:LIYUE` / `A:DQ:1` — matched against
   `AREA_ADDITIONAL_CONFIG_MAP` and the dadian tiles), and markers use game

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -23,6 +23,39 @@ use _utils::{
     },
 };
 
+/// 全部 `item_type_link` 的 item_id → type_id 列表映射。
+/// 前端按 `typeIdList` 过滤/分组物品，`ItemVO` 必须携带该字段。
+pub(crate) async fn type_id_map(
+    db: &sea_orm::DatabaseConnection,
+) -> Result<std::collections::HashMap<i64, Vec<i64>>> {
+    let links = link_model::Entity::find_safety().all(db).await?;
+    let mut map: std::collections::HashMap<i64, Vec<i64>> = std::collections::HashMap::new();
+    for l in links {
+        map.entry(l.item_id).or_default().push(l.type_id);
+    }
+    Ok(map)
+}
+
+pub(crate) fn item_to_vo(
+    it: &item_model::Model,
+    type_map: &std::collections::HashMap<i64, Vec<i64>>,
+) -> ItemVO {
+    ItemVO {
+        id: it.id,
+        name: it.name.clone(),
+        area_id: it.area_id,
+        default_refresh_time: it.default_refresh_time,
+        default_content: it.default_content.clone(),
+        default_count: it.default_count,
+        icon_tag: it.icon_tag.clone(),
+        icon_style_type: it.icon_style_type,
+        hidden_flag: it.hidden_flag,
+        sort_index: it.sort_index,
+        special_flag: it.special_flag,
+        type_id_list: type_map.get(&it.id).cloned().unwrap_or_default(),
+    }
+}
+
 // 批量更新物品（支持单条或多条）
 pub async fn do_update(
     auth: AuthInfo,
@@ -109,21 +142,10 @@ pub async fn do_get_list(
 
     let total = query.clone().count(db).await?;
     let items = query.limit(size).offset(offset).all(db).await?;
+    let type_map = type_id_map(db).await?;
     let mut arr = Vec::with_capacity(items.len());
     for it in items {
-        arr.push(ItemVO {
-            id: it.id,
-            name: it.name,
-            area_id: it.area_id,
-            default_refresh_time: it.default_refresh_time,
-            default_content: it.default_content,
-            default_count: it.default_count,
-            icon_tag: it.icon_tag,
-            icon_style_type: it.icon_style_type,
-            hidden_flag: it.hidden_flag,
-            sort_index: it.sort_index,
-            special_flag: it.special_flag,
-        });
+        arr.push(item_to_vo(&it, &type_map));
     }
     let payload = ItemListResponse {
         total: total as i64,
@@ -200,21 +222,10 @@ pub async fn do_get_list_by_id(
         .filter(item_model::Column::Id.is_in(payload))
         .all(db)
         .await?;
+    let type_map = type_id_map(db).await?;
     let mut arr = Vec::with_capacity(items.len());
     for it in items {
-        arr.push(ItemVO {
-            id: it.id,
-            name: it.name,
-            area_id: it.area_id,
-            default_refresh_time: it.default_refresh_time,
-            default_content: it.default_content,
-            default_count: it.default_count,
-            icon_tag: it.icon_tag,
-            icon_style_type: it.icon_style_type,
-            hidden_flag: it.hidden_flag,
-            sort_index: it.sort_index,
-            special_flag: it.special_flag,
-        });
+        arr.push(item_to_vo(&it, &type_map));
     }
     let payload = ItemListResponse {
         total: arr.len() as i64,

--- a/packages/functions/src/functions/api/item_common.rs
+++ b/packages/functions/src/functions/api/item_common.rs
@@ -11,10 +11,7 @@ use sea_orm::{ActiveValue::Set, ColumnTrait, QueryFilter, QueryOrder, QuerySelec
 use _utils::{
     jwt::AuthInfo,
     models::{
-        common::EmptyResponse,
-        item::{ItemListResponse, ItemVO},
-        wrapper::CommonResponse,
-        wrapper::Pagination,
+        common::EmptyResponse, item::ItemListResponse, wrapper::CommonResponse, wrapper::Pagination,
     },
 };
 
@@ -25,24 +22,10 @@ use _database::{
     models::{area::item_area_public as iap_model, item::item as item_model},
 };
 
+use super::item::{item_to_vo, type_id_map};
+
 /// 批量添加上限（防恶意大列表）。
 const MAX_BATCH: usize = 1000;
-
-fn to_vo(it: &item_model::Model) -> ItemVO {
-    ItemVO {
-        id: it.id,
-        name: it.name.clone(),
-        area_id: it.area_id,
-        default_refresh_time: it.default_refresh_time,
-        default_content: it.default_content.clone(),
-        default_count: it.default_count,
-        icon_tag: it.icon_tag.clone(),
-        icon_style_type: it.icon_style_type,
-        hidden_flag: it.hidden_flag,
-        sort_index: it.sort_index,
-        special_flag: it.special_flag,
-    }
-}
 
 /// `POST /item_common/get/list`
 ///
@@ -79,9 +62,10 @@ pub async fn do_get_list(
     }
 
     let mut arr = Vec::with_capacity(links.len());
+    let type_map = type_id_map(db).await?;
     for link in links {
         if let Some(it) = by_id.get(&link.item_id) {
-            arr.push(to_vo(it));
+            arr.push(item_to_vo(it, &type_map));
         }
     }
 

--- a/packages/functions/src/functions/api/item_doc.rs
+++ b/packages/functions/src/functions/api/item_doc.rs
@@ -12,32 +12,13 @@ use anyhow::{Result, anyhow};
 use std::collections::BTreeMap;
 
 use _database::{DB_CONN, models::item::item as item_model};
-use _utils::{
-    db_operations::SafeEntityTrait,
-    jwt::AuthInfo,
-    models::{item::ItemVO, wrapper::CommonResponse},
-};
+use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
 
 use super::binary_doc::{
     BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
 };
 
-/// camelCase item view for the BinaryMD5 pages (Java `ItemVo` naming).
-fn item_to_vo(it: &item_model::Model) -> ItemVO {
-    ItemVO {
-        id: it.id,
-        name: it.name.clone(),
-        area_id: it.area_id,
-        default_refresh_time: it.default_refresh_time,
-        default_content: it.default_content.clone(),
-        default_count: it.default_count,
-        icon_tag: it.icon_tag.clone(),
-        icon_style_type: it.icon_style_type,
-        hidden_flag: it.hidden_flag,
-        sort_index: it.sort_index,
-        special_flag: it.special_flag,
-    }
-}
+use super::item::{item_to_vo, type_id_map};
 
 /// `GET /item_doc/list_page_bin_md5`
 ///
@@ -75,6 +56,7 @@ async fn item_result() -> Result<Vec<ResultEntry>> {
     get_result_cached("item:result".into(), async {
         // Query all non-deleted items (once per TTL window)
         let items = item_model::Entity::find_safety().all(db).await?;
+        let type_map = type_id_map(db).await?;
 
         // Group by hidden_flag (BTreeMap → sorted by flag value ascending)
         let mut groups: BTreeMap<i32, Vec<&item_model::Model>> = BTreeMap::new();
@@ -93,7 +75,10 @@ async fn item_result() -> Result<Vec<ResultEntry>> {
         for (flag, group_items) in &groups {
             let key = format!("item:{flag}");
             let page = get_or_compute(key.clone(), async {
-                let vos: Vec<_> = group_items.iter().map(|m| item_to_vo(m)).collect();
+                let vos: Vec<_> = group_items
+                    .iter()
+                    .map(|m| item_to_vo(m, &type_map))
+                    .collect();
                 let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                 Ok(CachedPage {
                     md5: md5_hex,

--- a/packages/router/src/bin/init_db.rs
+++ b/packages/router/src/bin/init_db.rs
@@ -151,7 +151,7 @@ async fn ensure_admin_account(db: &sea_orm::DatabaseConnection) -> Result<()> {
     let now = chrono::Utc::now().naive_utc();
     sys_user_entity::Entity::insert(sys_user_entity::ActiveModel {
         version: Set(0),
-        id: Set(1),
+        id: sea_orm::ActiveValue::NotSet,
         create_time: Set(now),
         update_time: Set(None),
         creator_id: Set(None),

--- a/packages/utils/src/models/item.rs
+++ b/packages/utils/src/models/item.rs
@@ -165,6 +165,10 @@ pub struct ItemVO {
     pub hidden_flag: crate::types::HiddenFlag,
     pub sort_index: i32,
     pub special_flag: Option<i32>,
+    /// 所属物品类型（`item_type_link`），Java `ItemVo.typeIdList`
+    /// 前端按类型过滤/分组物品，缺失会导致筛选面板恒空。
+    #[serde(default)]
+    pub type_id_list: Vec<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -65,6 +65,8 @@ def main() -> int:
         "history",
         "item_area_public",
         "item",
+        "item_type_link",
+        "item_type",
         "icon",
         "area",
     ):
@@ -104,17 +106,34 @@ def main() -> int:
             (name, url),
         )
 
+    # ── Item types (the frontend's left panel groups items by type) ─────────
+    item_types = [
+        (1, "传送锚点", "0", 1),
+        (2, "七天神像", "0", 2),
+        (3, "秘境", "0", 3),
+        (4, "宝箱", "0", 4),
+        (5, "材料", "0", 5),
+    ]
+    for tid, name, icon_tag, sort in item_types:
+        cur.execute(
+            f'INSERT INTO "genshin_map"."item_type" '
+            f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
+            f"icon_tag, name, content, parent_id, is_final, hidden_flag, sort_index) "
+            f"VALUES (0, {tid}, {now}, NULL, NULL, NULL, false, %s, %s, NULL, {tid}, true, 0, {sort})",
+            (icon_tag, name),
+        )
+
     # ── Items ────────────────────────────────────────────────────────────────
     items = [
-        (1, "传送锚点", 1, "0", 0),
-        (2, "七天神像", 1, "0", 0),
-        (3, "秘境", 2, "0", 0),
-        (4, "珍贵宝箱", 1, "0", 0),
-        (5, "普通宝箱", 1, "0", 0),
-        (6, "松茸", 1, "0", 0),
-        (7, "薄荷", 1, "0", 0),
+        (1, "传送锚点", 1, "0", 0, 1),
+        (2, "七天神像", 1, "0", 0, 2),
+        (3, "秘境", 2, "0", 0, 3),
+        (4, "珍贵宝箱", 1, "0", 0, 4),
+        (5, "普通宝箱", 1, "0", 0, 4),
+        (6, "松茸", 1, "0", 0, 5),
+        (7, "薄荷", 1, "0", 0, 5),
     ]
-    for iid, name, area_id, icon_tag, sort in items:
+    for iid, name, area_id, icon_tag, sort, type_id in items:
         cur.execute(
             f'INSERT INTO "genshin_map"."item" '
             f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
@@ -122,6 +141,12 @@ def main() -> int:
             f"icon_tag, icon_style_type, hidden_flag, sort_index, special_flag) "
             f"VALUES (0, {iid}, {now}, NULL, NULL, NULL, false, %s, {area_id}, 0, NULL, 1, %s, 0, 0, {sort}, NULL)",
             (name, icon_tag),
+        )
+        cur.execute(
+            f'INSERT INTO "genshin_map"."item_type_link" '
+            f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
+            f"type_id, item_id) "
+            f"VALUES (0, {iid}, {now}, NULL, NULL, NULL, false, {type_id}, {iid})"
         )
 
     # ── Markers: ~150 points spread over the Mondstadt region ────────────────
@@ -166,9 +191,14 @@ def main() -> int:
     item_count = cur.fetchone()[0]
     cur.execute('SELECT count(*) FROM "genshin_map"."area"')
     area_count = cur.fetchone()[0]
+    cur.execute('SELECT count(*) FROM "genshin_map"."item_type"')
+    type_count = cur.fetchone()[0]
 
     conn.close()
-    print(f"Demo data seeded: {area_count} areas, {item_count} items, {marker_count} markers")
+    print(
+        f"Demo data seeded: {area_count} areas, {type_count} item types, "
+        f"{item_count} items, {marker_count} markers"
+    )
     return 0
 
 

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -16,9 +16,10 @@ use _database::models::{
     area::area as area_model, area::item_area_public as iap_model,
     common::history as history_model, common::score_stat as score_stat_model,
     icon::icon as icon_model, icon::icon_type_link as itl_model, item::item as item_model,
-    marker::marker as marker_model, marker::marker_item_link as mil_model,
-    marker::marker_punctuate as mp_model, system::sys_action_log as action_log_model,
-    system::sys_user as sys_user_model, system::sys_user_device as device_model,
+    item::item_type_link as item_type_link_model, marker::marker as marker_model,
+    marker::marker_item_link as mil_model, marker::marker_punctuate as mp_model,
+    system::sys_action_log as action_log_model, system::sys_user as sys_user_model,
+    system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
     area as area_fns, cache as cache_fns, icon_doc, item_common as item_common_fns, item_doc,
@@ -294,6 +295,7 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(area_model::Entity),
         ddl_without_foreign_keys(item_model::Entity),
         ddl_without_foreign_keys(iap_model::Entity),
+        ddl_without_foreign_keys(item_type_link_model::Entity),
         ddl_without_foreign_keys(icon_model::Entity),
         ddl_without_foreign_keys(itl_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
@@ -311,6 +313,7 @@ async fn area_and_item_doc_business_assertions() {
             "area",
             "item",
             "item_area_public",
+            "item_type_link",
             "icon",
             "icon_type_link",
             "marker",
@@ -1158,5 +1161,54 @@ async fn area_and_item_doc_business_assertions() {
     assert!(
         with_link.get("type_id_list").is_none(),
         "no snake_case leak in the icon blob"
+    );
+
+    // ── ItemVo.typeIdList (Java parity): items carry their item_type_link
+    //    type ids, and the item_doc blob includes them (the frontend filters
+    //    the item panel by typeIdList). ────────────────────────────────────
+    let itl = item_type_link_model::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        type_id: Set(9),
+        item_id: Set(item_a),
+    };
+    item_type_link_model::Entity::insert(itl)
+        .exec(db)
+        .await
+        .expect("seed item type link");
+    // The item page cached earlier predates item_a — flush and recompute.
+    cache_fns::do_delete_item_cache(auth.clone())
+        .await
+        .expect("flush item doc cache");
+    let fresh_md5 = item_doc::do_list_page_bin_md5(auth.clone(), serde_json::Value::Null)
+        .await
+        .expect("item_doc md5 (fresh)")
+        .data
+        .expect("item_doc md5 payload (fresh)");
+    let fresh_hash = fresh_md5
+        .iter()
+        .find(|v| !v.md5.is_empty())
+        .map(|v| v.md5.clone())
+        .expect("at least one md5");
+    let item_bin = item_doc::do_list_page_bin(auth.clone(), fresh_hash)
+        .await
+        .expect("fetch item page bin (2)");
+    let mut decoder = flate2::read::GzDecoder::new(item_bin.as_slice());
+    let mut decoded = Vec::new();
+    std::io::Read::read_to_end(&mut decoder, &mut decoded).expect("gunzip item page (2)");
+    let page: Vec<serde_json::Value> =
+        serde_json::from_slice(&decoded).expect("item page json (2)");
+    let item_a_json = page
+        .iter()
+        .find(|i| i["id"] == item_a)
+        .expect("item a in page");
+    assert_eq!(
+        item_a_json["typeIdList"][0], 9,
+        "item carries its typeIdList (Java ItemVo)"
     );
 }


### PR DESCRIPTION
## Summary

Carry the item `typeIdList` in `ItemVO` (Java `ItemVo` parity) — the missing field left the frontend's item panel empty — and fix the `init_db` admin seed id clash.

## Motivation

The frontend filters/group items by `typeIdList` (`ItemSelecter`), but the Rust `ItemVO` never carried it: every item returned an empty list, so the left panel showed types but zero selectable items, and no markers were rendered. Also, `init_db`'s admin seed pinned `id=1`, which collides after the test harness rebuilds the tables (duplicate key).

## Changes

- `utils/models/item.rs`: `ItemVO.type_id_list` (serde default).
- `functions/api/item.rs`: shared `type_id_map` + helper `item_to_vo`; both list endpoints fill it from `item_type_link`.
- `functions/api/item_doc.rs`: the BinaryMD5 pages (the frontend's primary source) now include `typeIdList`.
- `functions/api/item_common.rs`: same.
- `router/bin/init_db.rs`: admin seed uses `NotSet` id.
- `scripts/seed_demo.py`: seeds 5 item types + `item_type_link` (pulled in from the pending demo-seed branch).
- `api_db`: asserts `typeIdList` on the decompressed item page (with a cache flush before re-reading).

## Test Plan (verified locally)

- [x] `cargo test -p genshin-cloud-tests --test api_db` passes (live PG)
- [x] Live backend after reseed + cache flush: item_doc page → all 7 items carry `typeIdList` ([1]..[5])
- [x] `init_db` re-run after the tests rebuilt tables → admin seeded without id clash
- [x] check / clippy / fmt clean

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

API responses gain a new `typeIdList` field (additive).
