### PR TITLE
🐛 Return userId and userRoles in the OAuth responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Return the Java-contract user fields in the OAuth responses: the login /
+  refresh payloads lacked `userId` and `userRoles` (Java
+  `AuthorizationServerConfiguration` additionalInfo), so the frontend's
+  `userStore.auth.userId` was `undefined` — its archive store crashed with
+  an IndexedDB `DataError` on every authenticated save and the left panel
+  never populated. The responses now carry `userId` (camelCase) and
+  `userRoles` (role codes: `ADMIN` / `MAP_MANAGER` / ...).
+
 - Carry the item `typeIdList` in every `ItemVO` (Java `ItemVo` parity): the
   field was missing, so the frontend's item panel (which filters/group by
   type) stayed empty. All producers now fill it from `item_type_link` —

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -182,7 +182,26 @@ async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLogi
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
         scope: OauthScopeType::All,
         jti,
+        // Java 契约（AuthorizationServerConfiguration additionalInfo）：
+        // 前端 `SysToken` 依赖 userId / userRoles 恢复用户态与权限掩码。
+        user_id: id,
+        user_roles: vec![role_code(item.role_id)],
+        env: None,
+        message: None,
     })
+}
+
+/// SystemUserRole → Java `RoleEnum` code（前端 `RoleTypeEnum` 契约）。
+fn role_code(role: _utils::types::SystemUserRole) -> String {
+    match role {
+        _utils::types::SystemUserRole::Admin => "ADMIN",
+        _utils::types::SystemUserRole::MapManager => "MAP_MANAGER",
+        _utils::types::SystemUserRole::MapNeigui => "MAP_NEIGUI",
+        _utils::types::SystemUserRole::MapPunctuate => "MAP_PUNCTUATE",
+        _utils::types::SystemUserRole::MapUser => "MAP_USER",
+        _utils::types::SystemUserRole::Visitor => "VISITOR",
+    }
+    .to_string()
 }
 
 async fn oauth_password_login_inner(
@@ -433,6 +452,11 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
     // 验证传入的 refresh token 并获取 claims
     let claims = verify_token(&refresh_token).await?;
 
+    let user = models::system::sys_user::Entity::find_safety_by_id(claims.sub)
+        .one(&DB_CONN.wait().pg_conn)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+
     let mut redis_conn = DB_CONN
         .wait()
         .redis_conn
@@ -499,5 +523,9 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
         scope: OauthScopeType::All,
         jti: new_jti,
+        user_id: claims.sub,
+        user_roles: vec![role_code(user.role_id)],
+        env: None,
+        message: None,
     })
 }

--- a/packages/utils/src/types/auth.rs
+++ b/packages/utils/src/types/auth.rs
@@ -11,12 +11,24 @@ pub struct OauthLoginResponse {
     pub refresh_token: String,
     /// 令牌类型
     pub token_type: OauthTokenType,
-    /// 令牌寿命
+    /// 有效期（秒）
     pub expires_in: i64,
-    /// 生效范围
+    /// 有效范围
     pub scope: OauthScopeType,
     /// 唯一标识
     pub jti: Uuid,
+    /// 用户 ID（Java 契约：OAuth 额外信息，camelCase）
+    #[serde(rename = "userId")]
+    pub user_id: i64,
+    /// 角色 code 列表（Java 契约，camelCase）
+    #[serde(rename = "userRoles")]
+    pub user_roles: Vec<String>,
+    /// 环境标识（Java 契约，camelCase）
+    #[serde(rename = "env")]
+    pub env: Option<String>,
+    /// 登录提示消息（如设备/IP 波动警告，Java 契约，camelCase）
+    #[serde(rename = "message")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Return the Java-contract user fields in the OAuth login/refresh responses.

## Motivation

The frontend `SysToken` type requires `userId` and `userRoles` (Java `AuthorizationServerConfiguration` puts them in the OAuth `additionalInfo`). The Rust responses lacked both, so `userStore.auth.userId` was `undefined` — the archive store's `db.userArchive.put({ id: userId! })` crashed with an IndexedDB `DataError` ("key path yielded a value that is not a valid key") on every authenticated save, and the left panel never populated.

## Changes

- `utils/types/auth.rs`: `OauthLoginResponse` gains `userId` / `userRoles` / `env` / `message` (camelCase serde renames — the OAuth-standard fields stay snake_case).
- `functions/system/oauth.rs`: `issue_token` fills `user_id` + `user_roles` (new `role_code` mapping `SystemUserRole` → `ADMIN` / `MAP_MANAGER` / `MAP_NEIGUI` / `MAP_PUNCTUATE` / `MAP_USER` / `VISITOR`); `oauth_refresh` loads the user by `claims.sub` and fills the same fields.
- `CHANGELOG.md` entry.

## Test Plan

- [x] `cargo check` / clippy `-D warnings` / fmt clean
- [x] Live backend: `POST /oauth/token` (admin) → `{"userId": 4, "userRoles": ["ADMIN"], ...}`

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

None — additive fields on the OAuth response.
