### PR TITLE
✨ Add the tag_doc BinaryMD5 archive domain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Features
 
+- Add the missing `tag_doc` domain (the frontend's icon-tag sprite store
+  calls it): `GET /api/tag_doc/all_bin_md5` + `GET /api/tag_doc/all_bin`
+  serve the whole tag set as one GZIP-compressed JSON blob (Java `TagVo`
+  naming — `tag`, `typeIdList` from `tag_type_link`, icon `url`), cached at
+  the result level. The demo seed now also fills the `tag` / `tag_type` /
+  `tag_type_link` tables (5 tags).
+
 - Add a demo-data seeder for local development: `python scripts/seed_demo.py`
   fills an empty database with 3 areas, 7 items (传送锚点/七天神像/秘境/宝箱/
   材料) and 150 markers spread over the Mondstadt region, so a fresh local

--- a/packages/functions/src/functions/api/mod.rs
+++ b/packages/functions/src/functions/api/mod.rs
@@ -20,4 +20,5 @@ pub mod res;
 pub mod route;
 pub mod score;
 pub mod tag;
+pub mod tag_doc;
 pub mod tag_type;

--- a/packages/functions/src/functions/api/tag_doc.rs
+++ b/packages/functions/src/functions/api/tag_doc.rs
@@ -1,0 +1,124 @@
+//! BinaryMD5 archive export for icon tags.
+//!
+//! Mirrors Java `TagDocController` / `IconTagDao`: the whole tag set is one
+//! GZIP-compressed JSON blob (each tag carrying its `typeIdList` from
+//! `tag_type_link` and the icon `url`), keyed by the MD5 of the compressed
+//! bytes. Cached at the result level — warm requests do no DB scan.
+
+use anyhow::{Result, anyhow};
+use sea_orm::{ColumnTrait, QueryFilter};
+use serde::Serialize;
+
+use _database::{
+    DB_CONN,
+    models::{icon::icon as icon_model, tag::tag as tag_model, tag::tag_type_link as ttl_model},
+};
+use _utils::{db_operations::SafeEntityTrait, jwt::AuthInfo, models::wrapper::CommonResponse};
+
+use super::binary_doc::{
+    BinaryMd5Vo, CachedPage, ResultEntry, get_or_compute, get_result_cached, serialize_compress_md5,
+};
+
+/// camelCase tag view for the BinaryMD5 blob (Java `TagVo` naming).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TagDocVo {
+    pub version: i64,
+    pub creator_id: Option<i64>,
+    pub create_time: chrono::NaiveDateTime,
+    pub updater_id: Option<i64>,
+    pub update_time: Option<chrono::NaiveDateTime>,
+    pub tag: String,
+    pub type_id_list: Vec<i64>,
+    pub icon_id: i64,
+    pub url: Option<String>,
+}
+
+/// `GET /tag_doc/all_bin_md5` — MD5 of the single all-tags blob.
+pub async fn do_all_bin_md5(
+    _auth: AuthInfo,
+    _payload: serde_json::Value,
+) -> Result<CommonResponse<BinaryMd5Vo>> {
+    let entry = tag_result().await?;
+    Ok(CommonResponse::new(Ok(entry.vo)))
+}
+
+/// `GET /tag_doc/all_bin` — the all-tags blob (compressed bytes).
+pub async fn do_all_bin(_auth: AuthInfo) -> Result<Vec<u8>> {
+    let entry = tag_result().await?;
+    Ok(entry.bytes)
+}
+
+/// Compute (and cache) the single tag blob.
+async fn tag_result() -> Result<ResultEntry> {
+    let db = &DB_CONN.wait().pg_conn;
+
+    let entries = get_result_cached("tag:result".into(), async {
+        let tags = tag_model::Entity::find_safety().all(db).await?;
+
+        // typeIdList per tag (tag_type_link is keyed by tag_name).
+        let mut type_map: std::collections::HashMap<String, Vec<i64>> =
+            std::collections::HashMap::new();
+        for link in ttl_model::Entity::find_safety().all(db).await? {
+            type_map
+                .entry(link.tag_name)
+                .or_default()
+                .push(link.type_id);
+        }
+
+        // icon url per icon id.
+        let icon_ids: Vec<i64> = tags.iter().map(|t| t.icon_id).collect();
+        let mut url_map: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+        if !icon_ids.is_empty() {
+            for icon in icon_model::Entity::find_safety()
+                .filter(icon_model::Column::Id.is_in(icon_ids))
+                .all(db)
+                .await?
+            {
+                url_map.insert(icon.id, icon.url);
+            }
+        }
+
+        let vos: Vec<TagDocVo> = tags
+            .into_iter()
+            .map(|t| {
+                let type_id_list = type_map.remove(&t.tag).unwrap_or_default();
+                TagDocVo {
+                    version: t.version,
+                    creator_id: t.creator_id,
+                    create_time: t.create_time,
+                    updater_id: t.updater_id,
+                    update_time: t.update_time,
+                    tag: t.tag,
+                    type_id_list,
+                    icon_id: t.icon_id,
+                    url: url_map.get(&t.icon_id).cloned(),
+                }
+            })
+            .collect();
+
+        let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
+        let page = get_or_compute("tag:all".to_string(), async {
+            Ok(CachedPage {
+                md5: md5_hex,
+                time: chrono::Utc::now().timestamp_millis(),
+                bytes: compressed,
+            })
+        })
+        .await?;
+        Ok(vec![ResultEntry {
+            key: "tag:all".to_string(),
+            vo: BinaryMd5Vo {
+                md5: page.md5,
+                time: page.time,
+            },
+            bytes: page.bytes,
+        }])
+    })
+    .await?;
+
+    entries
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("empty tag result"))
+}

--- a/packages/router/src/routes/api/mod.rs
+++ b/packages/router/src/routes/api/mod.rs
@@ -19,6 +19,7 @@ pub mod res;
 pub mod route;
 pub mod score;
 pub mod tag;
+pub mod tag_doc;
 pub mod tag_type;
 
 use anyhow::Result;
@@ -48,6 +49,7 @@ pub async fn router() -> Result<Router> {
         .nest("/route", route::router().await?)
         .nest("/score", score::router().await?)
         .nest("/tag", tag::router().await?)
+        .nest("/tag_doc", tag_doc::router().await?)
         .nest("/tag_type", tag_type::router().await?)
         .layer(from_extractor::<crate::middlewares::ExtractAuthInfo>());
 

--- a/packages/router/src/routes/api/tag_doc/all_bin.rs
+++ b/packages/router/src/routes/api/tag_doc/all_bin.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+
+use axum::{
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::middlewares::ExtractAuthInfo;
+use axum::http::header;
+
+/// 获取所有标签信息的压缩数据
+/// GET /tag_doc/all_bin
+#[tracing::instrument(skip(auth))]
+pub async fn all_bin(
+    ExtractAuthInfo(auth): ExtractAuthInfo,
+) -> Result<Response, (StatusCode, String)> {
+    match _functions::functions::api::tag_doc::do_all_bin(auth).await {
+        Ok(bytes) => Ok((
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/octet-stream")],
+            Bytes::from(bytes),
+        )
+            .into_response()),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+    }
+}

--- a/packages/router/src/routes/api/tag_doc/all_bin_md5.rs
+++ b/packages/router/src/routes/api/tag_doc/all_bin_md5.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+
+use axum::{extract::Json, http::StatusCode, response::IntoResponse};
+
+use crate::middlewares::ExtractAuthInfo;
+
+/// 获取所有标签信息的 MD5
+/// GET /tag_doc/all_bin_md5
+#[tracing::instrument(skip(auth))]
+pub async fn all_bin_md5(
+    ExtractAuthInfo(auth): ExtractAuthInfo,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    match _functions::functions::api::tag_doc::do_all_bin_md5(auth, serde_json::json!({})).await {
+        Ok(v) => Ok((StatusCode::OK, Json(v))),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+    }
+}

--- a/packages/router/src/routes/api/tag_doc/mod.rs
+++ b/packages/router/src/routes/api/tag_doc/mod.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+
+use axum::{Router, routing::get};
+
+mod all_bin;
+mod all_bin_md5;
+
+pub async fn router() -> Result<Router> {
+    let ret = Router::new()
+        .route("/all_bin_md5", get(all_bin_md5::all_bin_md5))
+        .route("/all_bin", get(all_bin::all_bin));
+
+    Ok(ret)
+}

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -67,6 +67,9 @@ def main() -> int:
         "item",
         "item_type_link",
         "item_type",
+        "tag_type_link",
+        "tag_type",
+        "tag",
         "icon",
         "area",
     ):
@@ -147,6 +150,44 @@ def main() -> int:
             f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
             f"type_id, item_id) "
             f"VALUES (0, {iid}, {now}, NULL, NULL, NULL, false, {type_id}, {iid})"
+        )
+
+    # ── Tags (icon-tag sprite; tag_type_link keyed by tag name) ──────────────
+    tag_types = [
+        (1, "锚点"),
+        (2, "神像"),
+        (3, "秘境"),
+        (4, "宝箱"),
+        (5, "材料"),
+    ]
+    for tid, name in tag_types:
+        cur.execute(
+            f'INSERT INTO "genshin_map"."tag_type" '
+            f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
+            f"name, parent_id, is_final) "
+            f"VALUES (0, {tid}, {now}, NULL, NULL, NULL, false, %s, {tid}, true)",
+            (name,),
+        )
+    tags = [
+        (1, "anchor", 1, 1),
+        (2, "statue", 1, 2),
+        (3, "domain", 1, 3),
+        (4, "chest", 1, 4),
+        (5, "material", 1, 5),
+    ]
+    for tid, tag_name, icon_id, type_id in tags:
+        cur.execute(
+            f'INSERT INTO "genshin_map"."tag" '
+            f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, tag, icon_id) "
+            f"VALUES (0, {tid}, {now}, NULL, NULL, NULL, false, %s, {icon_id})",
+            (tag_name,),
+        )
+        cur.execute(
+            f'INSERT INTO "genshin_map"."tag_type_link" '
+            f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
+            f"type_id, tag_name) "
+            f"VALUES (0, {tid}, {now}, NULL, NULL, NULL, false, {type_id}, %s)",
+            (tag_name,),
         )
 
     # ── Markers: ~150 points spread over the Mondstadt region ────────────────


### PR DESCRIPTION
## Summary

Add the missing `tag_doc` domain — the frontend's icon-tag sprite store calls it and was getting 501s.

## Motivation

The frontend (`iconTag` store) fetches `/api/tag_doc/all_bin_md5` + `/api/tag_doc/all_bin` to build the icon-tag sprite; the Rust backend had no `tag_doc` domain, so every request fell through to the 501 fallback and the tag store failed.

## Changes

- `functions/api/tag_doc.rs` (new): single GZIP JSON blob of all tags (Java `TagVo` naming — `tag`, `typeIdList` from `tag_type_link`, icon `url`), result-level cached; `all_bin_md5` / `all_bin` handlers.
- Routes: `/api/tag_doc/all_bin_md5` + `/api/tag_doc/all_bin` (registered under the api nest; both root and `/api` prefixes work).
- `scripts/seed_demo.py`: seeds `tag` / `tag_type` / `tag_type_link` (5 tags tied to the item types + icons).
- `CHANGELOG.md` entry.

## Test Plan (verified locally)

- [x] check / clippy / fmt clean
- [x] Live backend: `/api/tag_doc/all_bin_md5` → md5; `all_bin` → gzip blob with 5 tags, each carrying `typeIdList` + icon `url`

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

None.
