### PR TITLE
🐛 Serve map assets straight from the CDN instead of the local proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Serve map assets straight from the CDN (the production contract):
+  `VITE_ASSETS_BASE` was pointed at the local backend's `/cdn` proxy, which
+  re-fetched every tile/icon upstream — hundreds of concurrent GB-scale
+  tile requests stalled through the dev proxy and the map rendered black
+  with no console errors. The e2e env override now keeps the CDN direct
+  (`https://assets.yuanshen.site`, which sends `Access-Control-Allow-Origin:
+  *`); only the small dadian config stays on the local backend
+  (`CDN_DADIAN_CONFIG`). The CDN proxy also gained `Cache-Control:
+  no-store` so transient upstream failures can't be heuristically cached by
+  browsers.
+
+### Fixed
+
 - Align every route the frontend actually calls (exhaustive audit of all 79
   generated API paths against the live backend — all now reachable):
   - Add the `app` domain: `POST /api/app/trigger/update` flushes the

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -191,6 +191,9 @@ fn cdn_proxy() -> axum::Router {
                                 }
                             }
                             builder = builder.header("Access-Control-Allow-Origin", "*");
+                            // 上游响应无缓存头：浏览器可能启发式缓存到之前
+                            // 网络抖动期的坏响应（502/空 body），禁止缓存。
+                            builder = builder.header("Cache-Control", "no-store");
                             builder
                                 .body(axum::body::Body::from(body))
                                 .unwrap_or_else(|_| {
@@ -204,6 +207,7 @@ fn cdn_proxy() -> axum::Router {
                         Err(e) => Response::builder()
                             .status(502)
                             .header("Access-Control-Allow-Origin", "*")
+                            .header("Cache-Control", "no-store")
                             .body(axum::body::Body::from(format!("CDN proxy error: {e}")))
                             .unwrap()
                             .into_response(),

--- a/scripts/e2e/setup_frontend.py
+++ b/scripts/e2e/setup_frontend.py
@@ -25,12 +25,15 @@ def ensure_env_override() -> None:
 VITE_API_BASE=/api
 VITE_API_PROXY_TARGET=http://127.0.0.1:{RUST_PORT}
 VITE_WS_BASE=ws://127.0.0.1:{RUST_PORT}/ws
-# CDN overrides: assets.yuanshen.site has CORS (*) but dadian-preview is 404.
-# v3.yuanshen.site has dadian-preview + tiles but NO CORS headers.
-# Solution: proxy v3 through Vite dev server (which adds CORS via changeOrigin).
-# Vite proxy strips /cdn prefix → fetches from v3.yuanshen.site
+# Map tiles/icons are GB-scale: they must come straight from the CDN (the
+# production contract), NOT through the local backend proxy — proxying
+# hundreds of concurrent tile requests through the dev backend stalls the
+# map. assets.yuanshen.site sends Access-Control-Allow-Origin: *.
+VITE_ASSETS_BASE=https://assets.yuanshen.site
+# The dadian config is small (tens of KB); serve it from the local backend
+# (CDN_DADIAN_CONFIG) so the tiles/area definitions are pinned to the
+# version this backend was tested with.
 VITE_CONFIG_ARCHIVE=http://127.0.0.1:{RUST_PORT}/cdn/dadian-preview.json.bz2
-VITE_ASSETS_BASE=http://127.0.0.1:{RUST_PORT}/cdn
 """
     env_local.write_text(content, encoding="utf-8")
     info(TARGET, f"Wrote {env_local}")


### PR DESCRIPTION
## Summary

Serve map assets straight from the CDN (the production contract) — the local /cdn proxy was the wrong path for GB-scale tiles.

## Motivation

\VITE_ASSETS_BASE\ was pointed at the local backend's \/cdn\ proxy, which re-fetches every tile/icon from upstream. The map loads hundreds of concurrent tile requests (GB-scale data): through the dev proxy they stall (each one a fresh upstream fetch, 15s timeouts), and the map rendered black with zero console errors. The production frontend loads \https://assets.yuanshen.site\ directly (its \.env\ default).

## Changes

- \scripts/e2e/setup_frontend.py\: \VITE_ASSETS_BASE=https://assets.yuanshen.site\ (CDN direct — it sends \Access-Control-Allow-Origin: *\); the small dadian config stays on the local backend (\CDN_DADIAN_CONFIG\).
- \outes/mod.rs\: the CDN proxy responses now carry \Cache-Control: no-store\ so transient upstream failures (200-with-empty-body during network hiccups) can't be heuristically cached by browsers.
- \CHANGELOG.md\ entry.

## Test Plan (verified locally)

- [x] CDN direct tile: 200, 28KB webp, \Access-Control-Allow-Origin: *\, 71ms
- [x] Icon via tiles.yuanshen.site: 200, 4KB
- [x] dadian via local backend: 200, 32KB
- [x] check / clippy / fmt clean

## Checklist

- [x] \cargo fmt --check\ passes
- [x] \cargo clippy --workspace --all-targets -- -D warnings\ passes
- [x] \cargo test --workspace\ passes
- [x] CHANGELOG entry added

## Breaking Changes

None (dev env override only).