### PR TITLE
🐛 Carry the marker itemList so frontend marker filtering works.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Carry the marker `itemList` (Java `MarkerVo.itemList` / `MarkerItemLinkVo`
+  with `itemId`/`count`/`iconTag`): the field was missing, so the frontend
+  could not match any marker to a selected item and **no markers rendered**.
+  All `MarkerVO` producers fill it from `marker_item_link` (+ item
+  `icon_tag`) in one batch query — the `marker_doc` BinaryMD5 pages (the
+  frontend's primary source), `get/page`, `get/list_byid`, `get/list_byinfo`
+  and `get/id`. Verified: 150/150 seeded markers carry their `itemList`.
+
+### Fixed
+
 - Serve map assets straight from the CDN (the production contract):
   `VITE_ASSETS_BASE` was pointed at the local backend's `/cdn` proxy, which
   re-fetched every tile/icon upstream — hundreds of concurrent GB-scale

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -10,14 +10,15 @@ use sea_orm::{
 use std::collections::HashSet;
 
 use _database::{
-    DB_CONN, models::marker::marker as marker_model, models::marker::marker_item_link as mil_model,
+    DB_CONN, models::item::item as item_model, models::marker::marker as marker_model,
+    models::marker::marker_item_link as mil_model,
 };
 use _utils::{
     db_operations::SafeEntityTrait,
     jwt::AuthInfo,
     models::{
         marker::MarkerFilterRequest,
-        marker::{MarkerAddRequest, MarkerTweakRequest, MarkerUpdateData},
+        marker::{MarkerAddRequest, MarkerItemLinkVo, MarkerTweakRequest, MarkerUpdateData},
         marker::{
             MarkerAddResponse, MarkerEmptyResponse, MarkerIdListResponse, MarkerItemsResponse,
             MarkerListResponse, MarkerVO,
@@ -26,9 +27,48 @@ use _utils::{
     },
 };
 
+/// 批量读取点位物品关联（`marker_item_link` + item 的 `icon_tag`），
+/// 返回 marker_id → itemList。避免逐点查询的 N+1。
+pub(crate) async fn marker_item_map(
+    db: &sea_orm::DatabaseConnection,
+    marker_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Vec<MarkerItemLinkVo>>> {
+    let mut map: std::collections::HashMap<i64, Vec<MarkerItemLinkVo>> =
+        std::collections::HashMap::new();
+    if marker_ids.is_empty() {
+        return Ok(map);
+    }
+    let links = mil_model::Entity::find_safety()
+        .filter(mil_model::Column::MarkerId.is_in(marker_ids))
+        .all(db)
+        .await?;
+    let item_ids: Vec<i64> = links.iter().map(|l| l.item_id).collect();
+    let mut icon_tags: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+    if !item_ids.is_empty() {
+        for it in item_model::Entity::find_safety()
+            .filter(item_model::Column::Id.is_in(item_ids))
+            .all(db)
+            .await?
+        {
+            icon_tags.insert(it.id, it.icon_tag);
+        }
+    }
+    for l in links {
+        map.entry(l.marker_id).or_default().push(MarkerItemLinkVo {
+            item_id: l.item_id,
+            count: l.count,
+            icon_tag: icon_tags.get(&l.item_id).cloned().unwrap_or_default(),
+        });
+    }
+    Ok(map)
+}
+
 /// 批量调整点位数据，目前实现常用字段的替换/更新逻辑：
 /// 对于复杂的 item_list 调整暂时跳过（可在后续增强）。
-fn model_to_vo(it: marker_model::Model) -> MarkerVO {
+fn model_to_vo(
+    it: marker_model::Model,
+    item_map: &std::collections::HashMap<i64, Vec<MarkerItemLinkVo>>,
+) -> MarkerVO {
     MarkerVO {
         version: it.version,
         id: it.id,
@@ -50,13 +90,17 @@ fn model_to_vo(it: marker_model::Model) -> MarkerVO {
         refresh_time: it.refresh_time,
         hidden_flag: it.hidden_flag,
         extra: it.extra,
+        item_list: item_map.get(&it.id).cloned().unwrap_or_default(),
     }
 }
 
 /// camelCase marker view for the BinaryMD5 pages (the wire contract of the
 /// `marker_doc` blob is the Java `MarkerVo` naming).
-pub(crate) fn model_to_vo_doc(it: &marker_model::Model) -> MarkerVO {
-    model_to_vo(it.clone())
+pub(crate) fn model_to_vo_doc(
+    it: &marker_model::Model,
+    item_map: &std::collections::HashMap<i64, Vec<MarkerItemLinkVo>>,
+) -> MarkerVO {
+    model_to_vo(it.clone(), item_map)
 }
 
 pub async fn do_tweak(
@@ -412,6 +456,7 @@ pub async fn do_get_list_by_info(
 
     // Chunk the IDs to avoid exceeding sqlx's 65535 parameter limit
     // (104K markers would create 104K bind params).
+    let item_map = marker_item_map(db, &ids).await?;
     let mut arr = Vec::new();
     for chunk in ids.chunks(10000) {
         let items = marker_model::Entity::find_safety()
@@ -419,7 +464,7 @@ pub async fn do_get_list_by_info(
             .all(db)
             .await?;
         for it in items {
-            arr.push(model_to_vo(it));
+            arr.push(model_to_vo(it, &item_map));
         }
     }
     Ok(CommonResponse::new(Ok(MarkerListResponse {
@@ -453,9 +498,11 @@ pub async fn do_get_list_by_id(
         .filter(marker_model::Column::Id.is_in(payload))
         .all(db)
         .await?;
+    let ids: Vec<i64> = items.iter().map(|m| m.id).collect();
+    let item_map = marker_item_map(db, &ids).await?;
     let mut arr = Vec::with_capacity(items.len());
     for it in items {
-        arr.push(model_to_vo(it));
+        arr.push(model_to_vo(it, &item_map));
     }
     Ok(CommonResponse::new(Ok(MarkerItemsResponse { items: arr })))
 }
@@ -474,9 +521,11 @@ pub async fn do_get_page(
     let total = query.clone().count(db).await?;
     let items = query.limit(size).offset(offset).all(db).await?;
 
+    let ids: Vec<i64> = items.iter().map(|m| m.id).collect();
+    let item_map = marker_item_map(db, &ids).await?;
     let mut arr = Vec::with_capacity(items.len());
     for it in items {
-        arr.push(model_to_vo(it));
+        arr.push(model_to_vo(it, &item_map));
     }
     Ok(CommonResponse::new(Ok(MarkerListResponse {
         total: total as usize,

--- a/packages/functions/src/functions/api/marker_doc.rs
+++ b/packages/functions/src/functions/api/marker_doc.rs
@@ -55,6 +55,8 @@ async fn marker_result() -> Result<Vec<ResultEntry>> {
 
     get_result_cached("marker:result".into(), async {
         let markers = marker_model::Entity::find_safety().all(db).await?;
+        let ids: Vec<i64> = markers.iter().map(|m| m.id).collect();
+        let item_map = super::marker::marker_item_map(db, &ids).await?;
 
         // Group by hidden_flag (BTreeMap → sorted ascending)
         let mut groups: BTreeMap<i32, Vec<&marker_model::Model>> = BTreeMap::new();
@@ -79,7 +81,7 @@ async fn marker_result() -> Result<Vec<ResultEntry>> {
                         // frontend parser.
                         let vos: Vec<_> = page_markers
                             .iter()
-                            .map(|m| super::marker::model_to_vo_doc(m))
+                            .map(|m| super::marker::model_to_vo_doc(m, &item_map))
                             .collect();
                         let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                         Ok(CachedPage {
@@ -104,7 +106,7 @@ async fn marker_result() -> Result<Vec<ResultEntry>> {
                 let page = get_or_compute(key.clone(), async {
                     let vos: Vec<_> = group_markers
                         .iter()
-                        .map(|m| super::marker::model_to_vo_doc(m))
+                        .map(|m| super::marker::model_to_vo_doc(m, &item_map))
                         .collect();
                     let (compressed, md5_hex) = serialize_compress_md5(&vos)?;
                     Ok(CachedPage {

--- a/packages/utils/src/models/marker.rs
+++ b/packages/utils/src/models/marker.rs
@@ -4,6 +4,16 @@ use std::collections::HashMap;
 use crate::{models::wrapper::Pagination, types::HiddenFlag};
 use serde_json::Value;
 
+/// 点位物品关联（Java `MarkerItemLinkVo`；前端按 `itemList` 过滤/渲染点位，
+/// 缺失会导致任何点位都无法显示）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerItemLinkVo {
+    pub item_id: i64,
+    pub count: i32,
+    pub icon_tag: String,
+}
+
 /// 点位对外返回 VO
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,6 +39,9 @@ pub struct MarkerVO {
     pub hidden_flag: HiddenFlag,
     /// 直接保留原始 extra JSON
     pub extra: Option<Value>,
+    /// 点位物品关联（`marker_item_link`），前端过滤/图标依赖
+    #[serde(default)]
+    pub item_list: Vec<MarkerItemLinkVo>,
 }
 
 /// 空响应（会序列化为 {}）


### PR DESCRIPTION
## Summary

Carry the marker `itemList` (Java `MarkerVo.itemList` / `MarkerItemLinkVo`) — the missing field meant no marker could match a selected item, so **no markers rendered**.

## Motivation

The frontend filters/renders markers by matching the selected items against `marker.itemList`. The Rust `MarkerVO` never carried it (every marker returned an empty list), so the map showed zero points no matter what was selected.

## Changes

- `utils/models/marker.rs`: `MarkerVO.item_list` (`serde default`) + `MarkerItemLinkVo` (`itemId`, `count`, `iconTag` — the frontend contract).
- `functions/api/marker.rs`: `marker_item_map` batch helper (`marker_item_link` + item `icon_tag`, one query, no N+1); `model_to_vo`/doc fill `itemList`; all producers updated (`get/page`, `get/list_byid`, `get/list_byinfo`, `get/id`).
- `functions/api/marker_doc.rs`: the BinaryMD5 pages (the frontend's primary source) now include `itemList`.
- `CHANGELOG.md` entry.

## Test Plan (verified locally)

- [x] check / clippy / fmt clean
- [x] `marker_doc` blob after cache flush: 150/150 markers carry `itemList` (e.g. `{itemId: 7, count: 1, iconTag: "0"}`)
- [x] CDN-direct negative-coordinate tiles (`11/-2_3.png`, `13/-9_4.png` etc.) all 200

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

None — additive field.
