### PR TITLE
🐛 Filter notices by channel and validity like the frontend expects.

### DIFF
--- a/packages/functions/src/functions/api/notice.rs
+++ b/packages/functions/src/functions/api/notice.rs
@@ -3,7 +3,7 @@ use chrono::Utc;
 
 use sea_orm::{
     ActiveValue::{NotSet, Set},
-    QuerySelect,
+    QueryOrder,
     prelude::*,
 };
 
@@ -47,17 +47,46 @@ pub async fn do_get_notice_list(
 ) -> Result<CommonResponse<NoticeListResponse>> {
     let db = &DB_CONN.wait().pg_conn;
 
-    let size = payload.page.size.unwrap_or(10) as u64;
-    let current = payload.page.current.unwrap_or(1);
-    let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
-
     let mut query = notice_model::Entity::find_safety();
     if let Some(title) = payload.title {
         query = query.filter(notice_model::Column::Title.like(format!("%{}%", title)));
     }
+    // 公告量小：全量取回后在内存做 channel/有效期过滤（对齐前端参数，
+    // jsonb 数组的 SQL 过滤跨方言繁琐且不值得）。
+    let mut rows = query
+        .order_by_desc(notice_model::Column::SortIndex)
+        .all(db)
+        .await?;
 
-    let total = query.clone().count(db).await?;
-    let items = query.limit(size).offset(offset).all(db).await?;
+    if let Some(channels) = payload.channels {
+        let wanted: Vec<String> = channels
+            .iter()
+            .map(|c| {
+                serde_json::to_string(c)
+                    .unwrap_or_default()
+                    .trim_matches('"')
+                    .to_string()
+            })
+            .collect();
+        rows.retain(|n| {
+            let chans: Vec<String> =
+                serde_json::from_value(serde_json::to_value(&n.channel).unwrap_or_default())
+                    .unwrap_or_default();
+            chans.iter().any(|c| wanted.contains(c))
+        });
+    }
+    if payload.get_valid.unwrap_or(false) {
+        let now = Utc::now().naive_utc();
+        rows.retain(|n| {
+            n.valid_time_start.is_none_or(|s| s <= now) && n.valid_time_end.is_none_or(|e| e >= now)
+        });
+    }
+
+    let total = rows.len();
+    let size = payload.page.size.unwrap_or(10) as usize;
+    let current = payload.page.current.unwrap_or(1) as usize;
+    let offset = (current.saturating_sub(1)) * size;
+    let items = rows.into_iter().skip(offset).take(size);
 
     let mut arr = Vec::with_capacity(items.len());
     for it in items {

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -167,7 +167,7 @@ def main() -> int:
             f"(version, id, create_time, update_time, creator_id, updater_id, del_flag, "
             f"channel, title, content, valid_time_start, valid_time_end, sort_index) "
             f"VALUES (0, {nid}, {now}, NULL, 1, NULL, false, %s, %s, %s, {now}, NULL, {nid})",
-            ('["WEB"]', title, content),
+            ('["COMMON"]', title, content),
         )
 
     # ── Tags (icon-tag sprite; tag_type_link keyed by tag name) ──────────────


### PR DESCRIPTION
## Summary

Filter notices by channel/validity — the frontend requests `channels: [COMMON, DASHBOARD]` + `getValid`, and the demo seed used `WEB`, so the panel showed its empty state ("公告被派蒙吃掉了").

## Changes

- `functions/api/notice.rs`: `do_get_notice_list` now honors `channels` (in-memory filter on the JSONB array — notice volumes are tiny), `getValid` (valid_time window), and sorts by `sortIndex` desc before paging.
- `scripts/seed_demo.py`: notices seed with channel `["COMMON"]`.
- Verified with the exact frontend request shape: `{channels:[COMMON,DASHBOARD], sort:["sortIndex-"], getValid:true, size:100}` → 2 items.

## Breaking Changes

None.
