### PR TITLE
🐛 Fix the role contract that gates the whole frontend data pipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix the role contract that gates the whole frontend data pipeline:
+  `GET /system/role/list` was a stub returning `null` (the frontend builds
+  its role table from it), and `SysUserVO.roleId` serialized as the enum
+  name string (`"Admin"`) instead of the numeric id the frontend/Java use
+  (`roleMap.get(roleId)`). With the role table empty and `roleId` a string,
+  `userStore.info.roleId` stayed `undefined` and **every data store's
+  update condition** (`userStore.info?.roleId !== undefined`) never fired —
+  areas, item types, items, notices and markers all stayed empty. The
+  endpoint now returns the 6 roles (id/code/name/sort) and `roleId`
+  serializes as a number.
+
+### Fixed
+
 - Carry the marker `itemList` (Java `MarkerVo.itemList` / `MarkerItemLinkVo`
   with `itemId`/`count`/`iconTag`): the field was missing, so the frontend
   could not match any marker to a selected item and **no markers rendered**.

--- a/packages/router/src/routes/system/role.rs
+++ b/packages/router/src/routes/system/role.rs
@@ -2,13 +2,52 @@ use anyhow::Result;
 
 use axum::{extract::Json, http::StatusCode, response::IntoResponse};
 
-use crate::middlewares::ExtractAdmin;
+use crate::middlewares::ExtractAuthInfo;
+use _utils::models::SysRoleVo;
 
-/// 返回可用角色列表
+/// 角色列表（Java `SysRoleVo`；前端用 `code` 映射权限掩码）。
 /// GET /role/list
 #[tracing::instrument(skip(_auth))]
 pub async fn list(
-    ExtractAdmin(_auth): ExtractAdmin,
+    ExtractAuthInfo(_auth): ExtractAuthInfo,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    Ok(Json(()).into_response())
+    let roles = vec![
+        SysRoleVo {
+            id: 0,
+            name: "系统管理员".into(),
+            code: "ADMIN".into(),
+            sort: 2,
+        },
+        SysRoleVo {
+            id: 1,
+            name: "地图管理员".into(),
+            code: "MAP_MANAGER".into(),
+            sort: 3,
+        },
+        SysRoleVo {
+            id: 2,
+            name: "测试打点员".into(),
+            code: "MAP_NEIGUI".into(),
+            sort: 4,
+        },
+        SysRoleVo {
+            id: 3,
+            name: "地图打点员".into(),
+            code: "MAP_PUNCTUATE".into(),
+            sort: 5,
+        },
+        SysRoleVo {
+            id: 4,
+            name: "地图用户".into(),
+            code: "MAP_USER".into(),
+            sort: 6,
+        },
+        SysRoleVo {
+            id: 5,
+            name: "匿名用户".into(),
+            code: "VISITOR".into(),
+            sort: 100,
+        },
+    ];
+    Ok(Json(roles).into_response())
 }

--- a/packages/utils/src/models/system.rs
+++ b/packages/utils/src/models/system.rs
@@ -2,6 +2,25 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{AccessPolicyList, SystemUserRole};
 
+/// 角色列表 VO（Java `SysRoleVo`；前端按 `roleId`（数字）查表构建权限掩码，
+/// 序列化为字符串会断掉整条数据初始化链）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SysRoleVo {
+    pub id: i64,
+    pub name: String,
+    pub code: String,
+    pub sort: i64,
+}
+
+/// `roleId` 按 Java 契约序列化为**数字**（前端 `roleMap.get(roleId)` 用数字 id 匹配）。
+fn serialize_role_id<S>(role: &SystemUserRole, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_i32(*role as i32)
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SysUserVO {
@@ -18,7 +37,8 @@ pub struct SysUserVO {
     /// 头像链接
     pub logo: Option<String>,
 
-    /// 角色
+    /// 角色（序列化为数字 id，Java 契约）
+    #[serde(serialize_with = "serialize_role_id")]
     pub role_id: SystemUserRole,
     /// 权限策略
     pub access_policy: AccessPolicyList,


### PR DESCRIPTION
## Summary

Fix the role contract that gates the whole frontend data pipeline.

## Motivation

`GET /system/role/list` was a stub returning `null` — the frontend builds its role table from it — and `SysUserVO.roleId` serialized as the enum name string (`"Admin"`) instead of the numeric id the frontend/Java use (`roleMap.get(roleId)`). With the role table empty and `roleId` a string, `userStore.info.roleId` stayed `undefined`, so **every data store's update condition** (`userStore.info?.roleId !== undefined`) never fired: areas, item types, items, notices and markers all stayed empty (the "everything is empty" symptom).

## Changes

- `router/routes/system/role.rs`: `GET /system/role/list` returns the 6 roles (`{id, name, code, sort}` — ADMIN/MAP_MANAGER/MAP_NEIGUI/MAP_PUNCTUATE/MAP_USER/VISITOR, ids matching `SystemUserRole`, codes matching the frontend `RoleTypeEnum`).
- `utils/models/system.rs`: `SysUserVO.roleId` serializes as a **number** (Java contract) via `serialize_with`.
- `CHANGELOG.md` entry.

## Test Plan (verified locally)

- [x] check / clippy / fmt clean
- [x] `GET /system/role/list` → 6 roles with id/code/name/sort
- [x] `GET /system/user/info/4` → `"roleId": 0` (numeric)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG entry added

## Breaking Changes

`roleId` in user payloads changes from `"Admin"` to `0` — this is the Java/frontend contract fix (the string form was the break).
