### PR TITLE
🐛 Stop browsers caching the BinaryMD5 blobs.

### DIFF
--- a/packages/router/src/routes/api/icon_doc/all_bin.rs
+++ b/packages/router/src/routes/api/icon_doc/all_bin.rs
@@ -18,7 +18,10 @@ pub async fn all_bin(
     match _functions::functions::api::icon_doc::do_all_bin(auth).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),

--- a/packages/router/src/routes/api/item_doc/list_page_bin.rs
+++ b/packages/router/src/routes/api/item_doc/list_page_bin.rs
@@ -20,7 +20,10 @@ pub async fn list_page_bin(
     match _functions::functions::api::item_doc::do_list_page_bin(auth, md5).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),

--- a/packages/router/src/routes/api/marker_doc/list_page_bin.rs
+++ b/packages/router/src/routes/api/marker_doc/list_page_bin.rs
@@ -20,7 +20,10 @@ pub async fn list_page_bin(
     match _functions::functions::api::marker_doc::do_list_page_bin(auth, md5).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),

--- a/packages/router/src/routes/api/marker_link_doc/doc.rs
+++ b/packages/router/src/routes/api/marker_link_doc/doc.rs
@@ -33,7 +33,10 @@ pub async fn all_bin(
     match _functions::functions::api::marker_link_doc::do_all_list_bin(auth).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),
@@ -67,7 +70,10 @@ pub async fn all_graph_bin(
     match _functions::functions::api::marker_link_doc::do_all_graph_bin(auth).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),

--- a/packages/router/src/routes/api/tag_doc/all_bin.rs
+++ b/packages/router/src/routes/api/tag_doc/all_bin.rs
@@ -18,7 +18,10 @@ pub async fn all_bin(
     match _functions::functions::api::tag_doc::do_all_bin(auth).await {
         Ok(bytes) => Ok((
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
             Bytes::from(bytes),
         )
             .into_response()),


### PR DESCRIPTION
## Summary

Add `Cache-Control: no-store` to every BinaryMD5 blob endpoint.

## Motivation

The frontend pulls the item/marker/tag blobs by md5 URL; without cache headers the browser heuristically cached old blobs (pre-`typeIdList`/pre-`itemList` formats), so the map showed empty panels/points even after the backend data was correct.

## Changes

`Cache-Control: no-store` on the octet-stream responses of `item_doc`, `marker_doc`, `marker_link_doc`, `icon_doc`, `tag_doc` bin endpoints.

## Breaking Changes

None.
