### PR TITLE
🐛 Accept both numeric and enum-name roleId on deserialization.

### DIFF
--- a/packages/utils/src/models/system.rs
+++ b/packages/utils/src/models/system.rs
@@ -21,6 +21,30 @@ where
     serializer.serialize_i32(*role as i32)
 }
 
+/// 反序列化同时接受数字（新契约）与枚举名（旧 Redis payload / 旧客户端）。
+fn deserialize_role_id<'de, D>(deserializer: D) -> Result<SystemUserRole, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = serde_json::Value::deserialize(deserializer)?;
+    match v {
+        serde_json::Value::Number(n) => match n.as_i64() {
+            Some(0) => Ok(SystemUserRole::Admin),
+            Some(1) => Ok(SystemUserRole::MapManager),
+            Some(2) => Ok(SystemUserRole::MapNeigui),
+            Some(3) => Ok(SystemUserRole::MapPunctuate),
+            Some(4) => Ok(SystemUserRole::MapUser),
+            Some(5) => Ok(SystemUserRole::Visitor),
+            _ => Err(serde::de::Error::custom(format!("unknown role id {n}"))),
+        },
+        serde_json::Value::String(s) => SystemUserRole::deserialize(serde_json::Value::String(s))
+            .map_err(serde::de::Error::custom),
+        _ => Err(serde::de::Error::custom(
+            "roleId must be an integer or enum name",
+        )),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SysUserVO {
@@ -37,8 +61,11 @@ pub struct SysUserVO {
     /// 头像链接
     pub logo: Option<String>,
 
-    /// 角色（序列化为数字 id，Java 契约）
-    #[serde(serialize_with = "serialize_role_id")]
+    /// 角色（序列化为数字 id，Java 契约；反序列化兼容数字与枚举名）
+    #[serde(
+        serialize_with = "serialize_role_id",
+        deserialize_with = "deserialize_role_id"
+    )]
     pub role_id: SystemUserRole,
     /// 权限策略
     pub access_policy: AccessPolicyList,


### PR DESCRIPTION
## Summary

Accept both numeric and enum-name `roleId` on deserialization.

## Motivation

PR #88 serialized `SysUserVO.roleId` as a number (the Java/frontend contract), but the Redis session payload written at login is re-parsed on token verification — and `SystemUserRole` only deserialized from enum names ("Admin"). Every authenticated request then failed with `expected value at line 1 column 95` → 401.

## Changes

`utils/models/system.rs`: `SysUserVO.role_id` gains `deserialize_with` accepting both the numeric id (0-5, mapped to `SystemUserRole`) and the legacy enum-name string.

## Test Plan (verified locally, WSL2 Ubuntu deployment)

- [x] check / clippy / fmt clean
- [x] Rebuild + restart backend → login 200, `area` / `item_type` / `notice` / `role` / `marker_doc` all 200 with the token

## Breaking Changes

None.
