### PR TITLE
🐛 Seed timestamps in UTC and fix the demo seed delete order.

### DIFF
--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -64,8 +64,8 @@ def main() -> int:
         "marker",
         "history",
         "item_area_public",
-        "item",
         "item_type_link",
+        "item",
         "item_type",
         "tag_type_link",
         "tag_type",
@@ -76,7 +76,7 @@ def main() -> int:
     ):
         cur.execute(f'DELETE FROM "genshin_map"."{table}"')
 
-    now = "now()"
+    now = "(now() AT TIME ZONE 'UTC')"
 
     # ── Areas (root area self-references its parent_id; codes match the
     #    frontend's AREA_ADDITIONAL_CONFIG_MAP / dadian tiles) ───────────────


### PR DESCRIPTION
## Summary

Seed timestamps in UTC and fix the demo seed delete order.

## Motivation

- The demo seed wrote `valid_time_start` with the DB's local (CST) time, but the backend's `getValid` filter compares against UTC — every notice looked like it was in the future and the announcement panel stayed empty ("公告被派蒙吃掉了").
- The seed's wipe order deleted `item` before `item_type_link`, tripping the FK constraint and leaving the DB half-wiped.

## Changes

- `scripts/seed_demo.py`: `now = (now() AT TIME ZONE 'UTC')`; delete order moves `item_type_link` before `item`.
- Verified: reseed → notices 2/2 with the exact frontend request shape (`channels: [COMMON, DASHBOARD], getValid: true`), marker/item/tag doc md5s present.

## Breaking Changes

None.
