### PR TITLE
🐛 Treat parentId <= 0 as no filter in the area list.

### DIFF
--- a/packages/functions/src/functions/api/area.rs
+++ b/packages/functions/src/functions/api/area.rs
@@ -82,7 +82,9 @@ pub async fn do_list(
     payload: AreaListRequest,
 ) -> Result<CommonResponse<AreaListResponse>> {
     let mut query = area_model::Entity::find_safety();
-    if let Some(parent) = payload.parent_id {
+    // Java 契约：parentId <= 0（如 -1）表示“不按父级过滤、查全部”，
+    // 前端 area store 固定传 { parentId: -1, isTraverse: true }。
+    if let Some(parent) = payload.parent_id.filter(|p| *p > 0) {
         query = query.filter(area_model::Column::ParentId.eq(parent));
     }
     if let Some(hidden_flag) = payload.hidden_flag {


### PR DESCRIPTION
## Summary

Treat `parentId <= 0` as "no parent filter" in the area list.

## Motivation

The frontend area store always calls `listArea({ parentId: -1, isTraverse: true })` (Java semantics: -1 = fetch all). The Rust handler filtered by `parent_id = -1`, returning an empty array — so the area store wrote nothing to IndexedDB and the left panel stayed empty.

## Changes

`functions/api/area.rs`: `parentId` is only applied as a filter when `> 0`.

## Test Plan

- [x] check / clippy / fmt clean
- [x] Frontend-shaped request `{parentId:-1,isTraverse:true}` → 3 areas with codes

## Breaking Changes

None.
