### PR TITLE
🐛 Serialize hiddenFlag as a number for the frontend mask check.

### DIFF
--- a/packages/utils/src/types/common.rs
+++ b/packages/utils/src/types/common.rs
@@ -3,9 +3,49 @@ use strum::EnumIter;
 
 use sea_orm::prelude::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
+/// 序列化为**数字**（Java 契约）——前端 `checkHiddenFlag` 做 `1 << hiddenFlag`
+/// 位掩码运算，枚举名字符串（"Visible"）会变成 NaN 导致全部被过滤。
+impl Serialize for HiddenFlag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_i32(*self as i32)
+    }
+}
+
+/// 反序列化同时接受数字（新契约/前端）与枚举名（旧数据）。
+impl<'de> Deserialize<'de> for HiddenFlag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let v = serde_json::Value::deserialize(deserializer)?;
+        match v {
+            serde_json::Value::Number(n) => match n.as_i64() {
+                Some(0) => Ok(HiddenFlag::Visible),
+                Some(1) => Ok(HiddenFlag::Hidden),
+                Some(2) => Ok(HiddenFlag::Spy),
+                Some(3) => Ok(HiddenFlag::Suprise),
+                _ => Err(serde::de::Error::custom(format!("unknown hiddenFlag {n}"))),
+            },
+            serde_json::Value::String(s) => match s.as_str() {
+                "Visible" => Ok(HiddenFlag::Visible),
+                "Hidden" => Ok(HiddenFlag::Hidden),
+                "Spy" => Ok(HiddenFlag::Spy),
+                "Suprise" => Ok(HiddenFlag::Suprise),
+                _ => Err(serde::de::Error::custom(format!("unknown hiddenFlag {s}"))),
+            },
+            _ => Err(serde::de::Error::custom(
+                "hiddenFlag must be an integer or enum name",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
-/// 权限屏蔽标记
+/// 权限可见层级
 pub enum HiddenFlag {
     /// 可见
     #[sea_orm(num_value = 0)]


### PR DESCRIPTION
## Summary

Serialize `hiddenFlag` as a number (Java contract).

## Motivation

The frontend's `checkHiddenFlag` does `userHiddenFlagMask & (1 << hiddenFlag)` — the Rust enum-name string (`"Visible"`) became `NaN`, so **every** area/item/marker was filtered out and every left-panel list stayed empty even though IndexedDB had all the data.

## Changes

`utils/types/common.rs`: `HiddenFlag` now implements `Serialize`/`Deserialize` manually — serializes as the numeric value (0-3), deserializes both numbers and enum names.

## Test Plan

- [x] check / clippy / fmt clean
- [x] Live: `area` → `hiddenFlag: 0`, `item` → `hiddenFlag: 0`

## Breaking Changes

`hiddenFlag` in JSON responses changes from `"Visible"` to `0` — this is the Java/frontend contract.
