### PR TITLE
🐛 Chunk marker link IN queries to stay under the PG parameter limit.

### DIFF
--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -38,19 +38,26 @@ pub(crate) async fn marker_item_map(
     if marker_ids.is_empty() {
         return Ok(map);
     }
-    let links = mil_model::Entity::find_safety()
-        .filter(mil_model::Column::MarkerId.is_in(marker_ids))
-        .all(db)
-        .await?;
+    let mut links: Vec<mil_model::Model> = Vec::new();
+    for chunk in marker_ids.chunks(1000) {
+        links.extend(
+            mil_model::Entity::find_safety()
+                .filter(mil_model::Column::MarkerId.is_in(chunk))
+                .all(db)
+                .await?,
+        );
+    }
     let item_ids: Vec<i64> = links.iter().map(|l| l.item_id).collect();
     let mut icon_tags: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
     if !item_ids.is_empty() {
-        for it in item_model::Entity::find_safety()
-            .filter(item_model::Column::Id.is_in(item_ids))
-            .all(db)
-            .await?
-        {
-            icon_tags.insert(it.id, it.icon_tag);
+        for chunk in item_ids.chunks(1000) {
+            for it in item_model::Entity::find_safety()
+                .filter(item_model::Column::Id.is_in(chunk))
+                .all(db)
+                .await?
+            {
+                icon_tags.insert(it.id, it.icon_tag);
+            }
         }
     }
     for l in links {
@@ -401,10 +408,15 @@ pub async fn do_get_id(
 
     // 如果提供了 item_id_list，则从 marker_item_link 收集 marker id
     if let Some(item_ids) = payload.item_id_list {
-        let links = mil_model::Entity::find_safety()
-            .filter(mil_model::Column::ItemId.is_in(item_ids))
-            .all(db)
-            .await?;
+        let mut links: Vec<mil_model::Model> = Vec::new();
+        for chunk in item_ids.chunks(1000) {
+            links.extend(
+                mil_model::Entity::find_safety()
+                    .filter(mil_model::Column::ItemId.is_in(chunk))
+                    .all(db)
+                    .await?,
+            );
+        }
         let ids: HashSet<i64> = links.into_iter().map(|l| l.marker_id).collect();
         let mut v: Vec<i64> = ids.into_iter().collect();
         v.sort_unstable();
@@ -430,10 +442,15 @@ pub async fn do_get_list_by_info(
 
     // 重用 do_get_id 的逻辑获取 id 列表，然后查询模型
     let ids = if let Some(item_ids) = payload.item_id_list {
-        let links = mil_model::Entity::find_safety()
-            .filter(mil_model::Column::ItemId.is_in(item_ids))
-            .all(db)
-            .await?;
+        let mut links: Vec<mil_model::Model> = Vec::new();
+        for chunk in item_ids.chunks(1000) {
+            links.extend(
+                mil_model::Entity::find_safety()
+                    .filter(mil_model::Column::ItemId.is_in(chunk))
+                    .all(db)
+                    .await?,
+            );
+        }
         let ids: HashSet<i64> = links.into_iter().map(|l| l.marker_id).collect();
         let mut v: Vec<i64> = ids.into_iter().collect();
         v.sort_unstable();


### PR DESCRIPTION
## Summary

Chunk `IN (...)` queries against `marker_item_link` so they stay under PostgreSQL's 65535 parameter limit.

## Motivation

After loading the real ~106k-marker dataset, `GET /marker_doc/list_page_bin_md5` returned 500:

```
Query Error: ... too many arguments for query: 104011
```

`marker_item_map` passed all ~104k marker ids in one `is_in(marker_ids)` — 104k bind parameters blew the PG limit. The same pattern existed in `do_get_id` / `do_get_list_by_info` for `item_id_list`.

## Changes

`functions/api/marker.rs`: split the `marker_item_link` and `item` lookups into 1000-id chunks in `marker_item_map`, `do_get_id`, `do_get_list_by_info`.

## Test Plan

- [x] check / clippy / fmt clean

## Breaking Changes

None.
