### PR TITLE
🐛 Allow logged-in users (not just Admin) on archive and user endpoints.

### DIFF
--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -8,13 +8,13 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAdmin;
+use crate::middlewares::ExtractAuthInfo;
 
 /// 获取指定槽位的最新存档
 /// GET /archive/last/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn get_last(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;
@@ -30,7 +30,7 @@ pub async fn get_last(
 /// GET /archive/history/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn get_history(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;
@@ -46,7 +46,7 @@ pub async fn get_history(
 /// GET /archive/all_history
 #[tracing::instrument(skip(auth))]
 pub async fn get_all_history(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_all_history(auth, user_id).await {
@@ -67,7 +67,7 @@ pub struct ArchiveSaveParams {
 /// PUT /archive/{slot_index}/{name}
 #[tracing::instrument(skip(auth))]
 pub async fn put(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path((slot_index, name)): Path<(i64, String)>,
     Json(payload): Json<ArchiveSaveParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -90,7 +90,7 @@ pub async fn put(
 /// POST /archive/save/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn save(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
     Json(payload): Json<ArchiveSaveParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -113,7 +113,7 @@ pub async fn save(
 /// POST /archive/rename/{slot_index}/{new_name}
 #[tracing::instrument(skip(auth))]
 pub async fn rename(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path((slot_index, new_name)): Path<(i64, String)>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;
@@ -133,7 +133,7 @@ pub async fn rename(
 /// DELETE /archive/restore/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn restore(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;
@@ -149,7 +149,7 @@ pub async fn restore(
 /// DELETE /archive/slot/{slot_index}
 #[tracing::instrument(skip(auth))]
 pub async fn delete_slot(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let user_id = auth.info.id;

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -7,7 +7,7 @@ use axum::{
     response::IntoResponse,
 };
 
-use crate::middlewares::ExtractAdmin;
+use crate::middlewares::{ExtractAdmin, ExtractAuthInfo};
 use _functions::functions::system::user::*;
 use _utils::{models::Pagination, types::AccessPolicyItemEnum, types::SystemUserRole};
 
@@ -122,7 +122,7 @@ pub struct UserKickOutParams {
 /// POST /user/register
 #[tracing::instrument(skip(auth, payload))]
 pub async fn register(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserRegisterParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     Ok(do_register(
@@ -143,7 +143,7 @@ pub async fn register(
 /// POST /user/register/qq
 #[tracing::instrument(skip(auth, payload))]
 pub async fn register_qq(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserRegisterQQParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     Ok(do_register_qq(
@@ -165,7 +165,7 @@ pub async fn register_qq(
 /// GET /user/info/{userId}
 #[tracing::instrument(skip(auth))]
 pub async fn get_info(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(user_id): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     Ok(Json(
@@ -180,7 +180,7 @@ pub async fn get_info(
 /// POST /user/update
 #[tracing::instrument(skip(auth))]
 pub async fn update(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserUpdateParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     Ok(do_update(
@@ -203,7 +203,7 @@ pub async fn update(
 /// POST /user/update_password
 #[tracing::instrument(skip(auth, payload))]
 pub async fn update_password(
-    ExtractAdmin(auth): ExtractAdmin,
+    ExtractAuthInfo(auth): ExtractAuthInfo,
     Json(payload): Json<UserUpdatePasswordParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     Ok(do_update_password(


### PR DESCRIPTION
## Summary

Drop the Admin-only requirement from personal archive and user endpoints.

## Motivation

Logging in triggered two immediate 403s:

- `GET /api/system/archive/all_history` → 403
- `GET /api/system/user/info/1` → 403

Every `system/archive` handler and `system/user` register/info/update/update_password handler required `ExtractAdmin` (role_id must be Admin=0). The real DB's `admin` account has role_id=3 (MAP_PUNCTUATE), so the frontend — which calls these on login — got 403 and logged itself out in a loop ("已退出" twice). Archives are per-user data and `user/info` is the caller's own profile: the Java contract allows any logged-in user.

## Changes

- `routes/system/archive.rs`: all handlers `ExtractAdmin` → `ExtractAuthInfo` (any logged-in user).
- `routes/system/user.rs`: `register`, `register_qq`, `get_info`, `update`, `update_password` → `ExtractAuthInfo`; admin-only endpoints (`update_password_by_admin`, `delete`, `list`, `kick_out`) stay `ExtractAdmin`.

## Test Plan

- [x] check / clippy / fmt clean

## Breaking Changes

None — these endpoints previously 403'd for every non-Admin user.
