### PR TITLE
✨ Allow skipping login access-policy checks via SKIP_ACCESS_POLICY.

### DIFF
--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -36,6 +36,10 @@ async fn check_access_policy(
     ip: SocketAddr,
     user_agent: &str,
 ) -> Result<()> {
+    // 本地/测试环境可跳过全部登录环境策略（IP/设备绑定等）。
+    if std::env::var("SKIP_ACCESS_POLICY").as_deref() == Ok("true") {
+        return Ok(());
+    }
     let db = &DB_CONN.wait().pg_conn;
     let last = models::system::sys_user_device::Entity::find_safety()
         .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))


### PR DESCRIPTION
## Summary

Add a `SKIP_ACCESS_POLICY=true` env switch that bypasses login environment-policy checks (IP/device binding).

## Motivation

The dev DB's `langyo` account has `ip:same_last_ip` in its access_policy, binding logins to the last login IP. Local development (127.0.0.1) gets `Access denied: IP ... does not match the last login IP ...` and cannot log in — without touching the shared dev DB's security settings.

## Changes

`functions/system/oauth.rs`: `check_access_policy` returns early when `SKIP_ACCESS_POLICY=true`. Default behavior unchanged.

## Test Plan

- [x] check / clippy / fmt clean
- [x] Live: with the env set, `langyo` logs in successfully from a new IP

## Breaking Changes

None.
