### PR TITLE
⚡ Extend BinaryMD5 result cache TTL to 1 hour for slow remote scans.

### DIFF
--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -67,7 +67,7 @@ pub struct CachedPage {
 static BIN_CACHE: Lazy<moka::future::Cache<String, CachedPage>> = Lazy::new(|| {
     moka::future::Cache::builder()
         .max_capacity(10_000)
-        .time_to_live(Duration::from_secs(300))
+        .time_to_live(Duration::from_secs(3600))
         .build()
 });
 
@@ -100,7 +100,7 @@ const REDIS_RESULT_PREFIX: &str = "binmd5:result:";
 /// so no SCAN/DEL pass is needed.
 const REDIS_EPOCH_KEY: &str = "binmd5:epoch";
 /// Redis entry TTL (matches the in-process moka TTL).
-const REDIS_RESULT_TTL_SECS: u64 = 300;
+const REDIS_RESULT_TTL_SECS: u64 = 3600;
 
 /// A `ResultEntry` serialized for Redis: bytes travel as base64 (JSON
 /// carries `Vec<u8>` as a number array otherwise — 4-5x bigger).
@@ -236,7 +236,7 @@ pub struct ResultEntry {
 static RESULT_CACHE: Lazy<moka::future::Cache<String, Vec<ResultEntry>>> = Lazy::new(|| {
     moka::future::Cache::builder()
         .max_capacity(64)
-        .time_to_live(Duration::from_secs(300))
+        .time_to_live(Duration::from_secs(3600))
         .build()
 });
 


### PR DESCRIPTION
## Summary

Result-level BinaryMD5 cache TTL 300s → 3600s.

## Motivation

marker_doc against the remote dev DB takes ~6min cold (100k wide rows over the network). A 5-minute TTL meant re-paying that scan on almost every expiry. Invalidation is handled by the refresh endpoints, so a longer TTL is safe.

## Changes

\unctions/api/binary_doc.rs\: moka + Redis result TTL 300 → 3600 seconds.

## Test Plan

- [x] check / clippy / fmt clean

## Breaking Changes

None.