### PR TITLE
🐛 Resolve marker iconTag from the tag table so sprite coords match the frontend.

### DIFF
--- a/packages/functions/src/functions/api/icon.rs
+++ b/packages/functions/src/functions/api/icon.rs
@@ -138,13 +138,15 @@ pub async fn do_update(auth: AuthInfo, payload: IconUpdateRequest) -> Result<Com
     Ok(CommonResponse::new(Ok(())))
 }
 
-/// icon_id -> icon.tag 映射（tag 名，前端 iconTag 契约的取值来源）。
+/// icon_id -> tag.tag 映射（前端 sprite 的 tagCoordMap key 是 tag 表的
+/// `tag` 字段（如 "陨石碎片"），不是 icon 表的 tag 描述）。
 pub(crate) async fn icon_tag_map(
     db: &sea_orm::DatabaseConnection,
 ) -> Result<std::collections::HashMap<i64, String>> {
+    use _database::models::tag::tag as tag_model;
     let mut map = std::collections::HashMap::new();
-    for icon in icon_model::Entity::find_safety().all(db).await? {
-        map.insert(icon.id, icon.tag);
+    for t in tag_model::Entity::find_safety().all(db).await? {
+        map.entry(t.icon_id).or_insert(t.tag);
     }
     Ok(map)
 }

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -17,9 +17,9 @@ use _database::models::{
     common::history as history_model, common::score_stat as score_stat_model,
     icon::icon as icon_model, icon::icon_type_link as itl_model, item::item as item_model,
     item::item_type_link as item_type_link_model, marker::marker as marker_model,
-    marker::marker_item_link as mil_model,
-    tag::tag as tag_model, tag::tag_type as tag_type_model, system::sys_action_log as action_log_model,
+    marker::marker_item_link as mil_model, system::sys_action_log as action_log_model,
     system::sys_user as sys_user_model, system::sys_user_device as device_model,
+    tag::tag as tag_model, tag::tag_type as tag_type_model,
 };
 use _functions::functions::api::{
     area as area_fns, cache as cache_fns, icon_doc, item_common as item_common_fns, item_doc,
@@ -1106,4 +1106,3 @@ async fn area_and_item_doc_business_assertions() {
         "item carries its typeIdList (Java ItemVo)"
     );
 }
-

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -282,6 +282,8 @@ async fn area_and_item_doc_business_assertions() {
             "marker",
             "marker_item_link",
             "marker_punctuate",
+            "tag",
+            "tag_type",
         ],
         &ddls,
     )

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -17,7 +17,8 @@ use _database::models::{
     common::history as history_model, common::score_stat as score_stat_model,
     icon::icon as icon_model, icon::icon_type_link as itl_model, item::item as item_model,
     item::item_type_link as item_type_link_model, marker::marker as marker_model,
-    marker::marker_item_link as mil_model, system::sys_action_log as action_log_model,
+    marker::marker_item_link as mil_model,
+    tag::tag as tag_model, tag::tag_type as tag_type_model, system::sys_action_log as action_log_model,
     system::sys_user as sys_user_model, system::sys_user_device as device_model,
 };
 use _functions::functions::api::{
@@ -264,6 +265,8 @@ async fn area_and_item_doc_business_assertions() {
         ddl_without_foreign_keys(itl_model::Entity),
         ddl_without_foreign_keys(marker_model::Entity),
         ddl_without_foreign_keys(mil_model::Entity),
+        ddl_without_foreign_keys(tag_model::Entity),
+        ddl_without_foreign_keys(tag_type_model::Entity),
     ];
     recreate_tables_fklless(
         db,
@@ -1103,3 +1106,4 @@ async fn area_and_item_doc_business_assertions() {
         "item carries its typeIdList (Java ItemVo)"
     );
 }
+


### PR DESCRIPTION
## Summary

\icon_tag_map\ now reads from the \	ag\ table (icon_id → tag.tag) instead of \icon.tag\.

## Motivation

The frontend's tag sprite (\	agCoordMap\) is keyed by the tag table's \	ag\ field (e.g. \陨石碎片\). \iconTag\ was resolved from \icon.tag\ (Chinese descriptions like \石碑\), so every marker fell back to a generic icon (all looked like chests). With the dev DB's tag rows now seeded, the lookup matches and markers get their real icons.

## Changes

\unctions/api/icon.rs\: \icon_tag_map\ queries \	ag\ (first tag per icon_id) instead of \icon\.

## Test Plan

- [x] check / clippy / fmt clean

## Breaking Changes

None.