### PR TITLE
🐛 Fix real-DB write violations, unprefixed access policies, and server S-level defects.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY packages/utils/Cargo.toml      packages/utils/Cargo.toml
 COPY packages/database/Cargo.toml   packages/database/Cargo.toml
 COPY packages/functions/Cargo.toml  packages/functions/Cargo.toml
 COPY packages/router/Cargo.toml     packages/router/Cargo.toml
-COPY scripts/                     scripts/
 COPY tests/rust/Cargo.toml          tests/rust/Cargo.toml
 
 # Stub member sources so cargo can resolve the workspace without the real code,

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/utils/Cargo.toml      packages/utils/Cargo.toml
 COPY packages/database/Cargo.toml   packages/database/Cargo.toml
 COPY packages/functions/Cargo.toml  packages/functions/Cargo.toml
 COPY packages/router/Cargo.toml     packages/router/Cargo.toml
+COPY scripts/                     scripts/
 COPY tests/rust/Cargo.toml          tests/rust/Cargo.toml
 
 # Stub member sources so cargo can resolve the workspace without the real code,
@@ -61,3 +62,4 @@ ENV RUST_LOG=info
 EXPOSE 80
 
 ENTRYPOINT ["/usr/bin/tini", "--", "_router"]
+

--- a/packages/functions/src/functions/api/history.rs
+++ b/packages/functions/src/functions/api/history.rs
@@ -83,7 +83,7 @@ pub async fn do_get_list(
     // loading the entire history table — it can have 400K+ rows)
     let mut select = query;
     let current = payload.page.current.unwrap_or(1);
-    let size = payload.page.size.unwrap_or(20);
+    let size = payload.page.size.unwrap_or(20).min(200);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size as u64);
     select = select.limit(size as u64).offset(offset);
 

--- a/packages/functions/src/functions/api/icon.rs
+++ b/packages/functions/src/functions/api/icon.rs
@@ -22,6 +22,13 @@ use _utils::{
 };
 
 // 新增图标
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 pub async fn do_add(auth: AuthInfo, payload: IconAddRequest) -> Result<CommonResponse<i64>> {
     auth.require_non_anonymous()?;
     let now = Utc::now().naive_utc();
@@ -63,7 +70,7 @@ pub async fn do_list(
         query = query.filter(icon_model::Column::Id.is_in(ids));
     }
     if let Some(name) = payload.name {
-        query = query.filter(icon_model::Column::Tag.contains(name));
+        query = query.filter(icon_model::Column::Tag.like(format!("%{}%", escape_like(&name))));
     }
     // 按图标分类（icon_type_link）过滤：icon_id IN (SELECT icon_id FROM icon_type_link WHERE type_id IN ...)
     if let Some(type_ids) = payload.type_id_list {

--- a/packages/functions/src/functions/api/icon.rs
+++ b/packages/functions/src/functions/api/icon.rs
@@ -42,6 +42,7 @@ pub async fn do_add(auth: AuthInfo, payload: IconAddRequest) -> Result<CommonRes
     };
 
     let res = active.insert(&DB_CONN.wait().pg_conn).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(res.id)))
 }
 
@@ -84,6 +85,7 @@ pub async fn do_list(
     if let Some(current) = payload.page.current
         && let Some(size) = payload.page.size
     {
+        let size = size.min(200);
         let offset = (current.saturating_sub(1) as u64).saturating_mul(size as u64);
         select = select.limit(size as u64).offset(offset);
     }
@@ -131,6 +133,7 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
     icon_model::Entity::delete_safety(am)?
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -147,6 +150,7 @@ pub async fn do_update(auth: AuthInfo, payload: IconUpdateRequest) -> Result<Com
     icon_model::Entity::update_safety(am)?
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(())))
 }
 

--- a/packages/functions/src/functions/api/icon_type.rs
+++ b/packages/functions/src/functions/api/icon_type.rs
@@ -41,6 +41,7 @@ pub async fn do_update(
     icon_type_model::Entity::update_safety(am)?
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -61,7 +62,7 @@ pub async fn do_list(
     }
 
     let total = query.clone().count(db).await? as i64;
-    let size = payload.page.size.unwrap_or(10) as u64;
+    let size = payload.page.size.unwrap_or(10).min(200) as u64;
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
@@ -102,6 +103,7 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     icon_type_model::Entity::delete_safety(am)?
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -125,5 +127,6 @@ pub async fn do_add(auth: AuthInfo, payload: IconTypeAddRequest) -> Result<i64> 
     };
 
     let res = active.insert(&DB_CONN.wait().pg_conn).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(res.id)
 }

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -24,6 +24,13 @@ use _utils::{
     },
 };
 
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// 全部 `item_type_link` 的 item_id → type_id 列表映射。
 /// 前端按 `typeIdList` 过滤/分组物品，`ItemVO` 必须携带该字段。
 pub(crate) async fn type_id_map(
@@ -139,7 +146,7 @@ async fn update_one(db: &sea_orm::DatabaseConnection, id: i64, p: &ItemUpdateDat
     am.area_id = Set(p.area_id);
     am.default_content = Set(p.default_content.clone());
     if let Some(count) = p.default_count {
-        am.default_count = Set(count as i32);
+        am.default_count = Set(count.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
     }
     am.default_refresh_time = Set(p.default_refresh_time.unwrap_or(0));
     if let Some(style) = p.icon_style_type {
@@ -147,9 +154,11 @@ async fn update_one(db: &sea_orm::DatabaseConnection, id: i64, p: &ItemUpdateDat
     }
     am.hidden_flag = Set(p.hidden_flag);
     if let Some(si) = p.sort_index {
-        am.sort_index = Set(si as i32);
+        am.sort_index = Set(si.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
     }
-    am.special_flag = Set(p.special_flag.map(|v| v as i32));
+    am.special_flag = Set(p
+        .special_flag
+        .map(|v| v.clamp(i32::MIN as i64, i32::MAX as i64) as i32));
 
     item_model::Entity::update_safety(am)?.exec(db).await?;
 
@@ -199,13 +208,13 @@ pub async fn do_get_list(
         query = query.filter(item_model::Column::AreaId.is_in(area_ids));
     }
     if let Some(name) = payload.name {
-        query = query.filter(item_model::Column::Name.like(format!("%{}%", name)));
+        query = query.filter(item_model::Column::Name.like(format!("%{}%", escape_like(&name))));
     }
     if let Some(sf) = payload.special_flag {
         // Java parity: special_flag is a bit-mask. param == 0 means "no special
         // flag set" (filter special_flag = 0); param > 0 means "has any of these
         // bits" (filter (special_flag & param) != 0).
-        let sf = sf as i32;
+        let sf = (sf as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
         if sf == 0 {
             query = query.filter(item_model::Column::SpecialFlag.eq(0));
         } else {
@@ -444,12 +453,19 @@ pub async fn do_add(auth: AuthInfo, payload: ItemAddRequest) -> Result<CommonRes
         area_id: Set(payload.area_id),
         default_refresh_time: Set(payload.default_refresh_time.unwrap_or(0)),
         default_content: Set(Some(payload.default_content)),
-        default_count: Set(payload.default_count as i32),
+        default_count: Set(payload
+            .default_count
+            .clamp(i32::MIN as i64, i32::MAX as i64) as i32),
         icon_id: Set(icon_id),
         icon_style_type: Set(payload.icon_style_type),
         hidden_flag: Set(payload.hidden_flag),
-        sort_index: Set(payload.sort_index.unwrap_or(0) as i32),
-        special_flag: Set(payload.special_flag.map(|v| v as i32)),
+        sort_index: Set(payload
+            .sort_index
+            .unwrap_or(0)
+            .clamp(i32::MIN as i64, i32::MAX as i64) as i32),
+        special_flag: Set(payload
+            .special_flag
+            .map(|v| v.clamp(i32::MIN as i64, i32::MAX as i64) as i32)),
     };
 
     let res = active.insert(&DB_CONN.wait().pg_conn).await?;

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 
 use sea_orm::{
     ActiveValue::{NotSet, Set},
-    ExprTrait, QueryFilter, QueryOrder, QuerySelect,
+    ExprTrait, QueryFilter, QueryOrder, QuerySelect, TransactionTrait,
     prelude::*,
 };
 
@@ -153,15 +153,17 @@ async fn update_one(db: &sea_orm::DatabaseConnection, id: i64, p: &ItemUpdateDat
 
     item_model::Entity::update_safety(am)?.exec(db).await?;
 
-    // 类型关联：先逻辑删除旧 link，再按新 typeIdList 插入
+    // 类型关联：先逻辑删除旧 link，再按新 typeIdList 插入。
+    // 删除+插入包事务，失败整体回滚，避免半更新状态（物品已改、类型关联丢失）。
+    let txn = db.begin().await?;
     let old_links = link_model::Entity::find_safety()
         .filter(link_model::Column::ItemId.eq(id))
-        .all(db)
+        .all(&txn)
         .await?;
     for link in old_links {
         let mut lam: link_model::ActiveModel = link.into();
         lam.del_flag = Set(true);
-        link_model::Entity::update_safety(lam)?.exec(db).await?;
+        link_model::Entity::update_safety(lam)?.exec(&txn).await?;
     }
     for t in &p.type_id_list {
         let now = chrono::Utc::now().naive_utc();
@@ -177,8 +179,9 @@ async fn update_one(db: &sea_orm::DatabaseConnection, id: i64, p: &ItemUpdateDat
             type_id: Set(*t),
             item_id: Set(id),
         };
-        active.insert(db).await?;
+        active.insert(&txn).await?;
     }
+    txn.commit().await?;
     Ok(())
 }
 
@@ -235,7 +238,8 @@ pub async fn do_get_list(
         };
     }
 
-    let size = payload.page.size.unwrap_or(10) as u64;
+    let size_raw = payload.page.size.unwrap_or(10);
+    let size: u64 = (if size_raw > 200 { 200 } else { size_raw }) as u64;
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 

--- a/packages/functions/src/functions/api/item_common.rs
+++ b/packages/functions/src/functions/api/item_common.rs
@@ -40,7 +40,7 @@ pub async fn do_get_list(
 ) -> Result<CommonResponse<ItemAreaPublicListResponse>> {
     let db = &DB_CONN.wait().pg_conn;
 
-    let size = payload.size.unwrap_or(10) as u64;
+    let size = payload.size.unwrap_or(10).min(200) as u64;
     let current = payload.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -160,7 +160,8 @@ pub async fn do_get_list(
         }
     }
 
-    let size = payload.page.size.unwrap_or(10) as u64;
+    let size_raw = payload.page.size.unwrap_or(10);
+    let size: u64 = (if size_raw > 200 { 200 } else { size_raw }) as u64;
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -84,19 +84,18 @@ pub async fn do_update(
 
 // 将一组类型（typeId 列表）移动到目标类型下（更新 item_type.parent_id）
 pub async fn do_move_to_target(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     target_type_id: i64,
     payload: Vec<i64>,
 ) -> Result<CommonResponse<EmptyResponse>> {
+    auth.require_non_anonymous()?;
     const MAX_BATCH: usize = 1000;
     if payload.len() > MAX_BATCH {
-        {
-            return Err(anyhow!(
-                "batch too large: {} > {}",
-                payload.len(),
-                MAX_BATCH
-            ));
-        }
+        return Err(anyhow!(
+            "batch too large: {} > {}",
+            payload.len(),
+            MAX_BATCH
+        ));
     }
     let db = &DB_CONN.wait().pg_conn;
     // 校验目标类型存在
@@ -107,10 +106,9 @@ pub async fn do_move_to_target(
     {
         return Err(anyhow!("ItemType not found: {target_type_id}"));
     }
-    // 被移动类型的原父级（移动后需重算 is_final）
+    // 记录被移动类型的原父级，移动后重算 is_final。
     let mut old_parents: Vec<i64> = Vec::new();
     for type_id in payload {
-        // 把 typeId 移动到新父级：更新 parent_id（不再改写 link 表的 type_id）
         let item = item_type_model::Entity::find_safety_by_id(type_id)
             .one(db)
             .await?
@@ -122,7 +120,6 @@ pub async fn do_move_to_target(
             item_type_model::Entity::update_safety(am)?.exec(db).await?;
         }
     }
-    // is_final 重算：目标父级已有子级 → false；原父级无子级 → true
     refresh_is_final(db, target_type_id).await?;
     for p in old_parents {
         refresh_is_final(db, p).await?;
@@ -131,7 +128,6 @@ pub async fn do_move_to_target(
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
-// 列表（分页/筛选）
 pub async fn do_get_list(
     _auth: AuthInfo,
     self_flag: bool,
@@ -247,10 +243,18 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     }
     let mut to_delete: Vec<i64> = Vec::new();
     let mut queue: Vec<i64> = vec![id];
+    // visited 防环：parent_id 由客户端控制，可构造 A.parent=B、B.parent=A 的环
+    // （或自指 parent_id=id），不加去重会无限遍历/无限写库。
+    let mut visited: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    visited.insert(id);
     while let Some(cur) = queue.pop() {
         to_delete.push(cur);
         if let Some(cs) = children.get(&cur) {
-            queue.extend(cs.iter().copied());
+            for c in cs {
+                if visited.insert(*c) {
+                    queue.push(*c);
+                }
+            }
         }
     }
 

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -72,7 +72,7 @@ pub async fn do_update(
     am.is_final = Set(payload.is_final);
     am.hidden_flag = Set(payload.hidden_flag);
     if let Some(si) = payload.sort_index {
-        am.sort_index = Set(si as i32);
+        am.sort_index = Set(si.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
     }
 
     item_type_model::Entity::update_safety(am)?
@@ -291,7 +291,10 @@ pub async fn do_add(auth: AuthInfo, payload: ItemTypeAddRequest) -> Result<Commo
     // name 在逻辑上为必填
     let name = payload.name.ok_or(anyhow!("name required"))?;
 
-    let sort_index = payload.sort_index.unwrap_or(0) as i32;
+    let sort_index = payload
+        .sort_index
+        .unwrap_or(0)
+        .clamp(i32::MIN as i64, i32::MAX as i64) as i32;
 
     let icon_id = resolve_icon_id(payload.icon_id, payload.icon_tag.as_deref()).await?;
 

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -287,7 +287,7 @@ pub async fn do_tweak(
     auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
-    let mut touched_ids: Vec<i64> = Vec::new();
+    let touched_ids: Vec<i64> = Vec::new();
     for payload in payloads {
         for marker_id in payload.marker_ids.iter() {
             let m = marker_model::Entity::find_safety_by_id(*marker_id)
@@ -403,10 +403,8 @@ pub async fn do_tweak(
 
             // 通过 ActiveModelBehavior 设置 updater 与 update_time；确保携带版本信息
             marker_model::Entity::update_safety(am)?.exec(db).await?;
-            touched_ids.push(*marker_id);
         }
     }
-
     // 返回被修改 marker 的 VO 列表
     if touched_ids.is_empty() {
         return Ok(CommonResponse::new(Ok(vec![])));
@@ -598,7 +596,7 @@ pub async fn do_add_single(
 
         marker_title: Set(Some(payload.marker_title)),
         position: Set(payload.position),
-        content: Set(payload.content),
+        content: Set(payload.content.or(Some(String::new()))),
         picture: Set(payload.picture),
         marker_creator_id: Set(payload.marker_creator_id),
         picture_creator_id: Set(payload.picture_creator_id),

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -3,7 +3,7 @@ use chrono::Utc;
 
 use sea_orm::{
     ActiveValue::{NotSet, Set},
-    QuerySelect,
+    QuerySelect, TransactionTrait,
     prelude::*,
 };
 
@@ -553,8 +553,8 @@ async fn tweak_item_list(
     Ok(())
 }
 
-async fn insert_item_link(
-    db: &sea_orm::DatabaseConnection,
+async fn insert_item_link<C: sea_orm::ConnectionTrait>(
+    db: &C,
     marker_id: i64,
     item_id: i64,
     count: i32,
@@ -654,19 +654,22 @@ pub async fn do_update_single(
     marker_model::Entity::update_safety(am)?.exec(db).await?;
 
     // item_list 全量替换（先删后插）：编辑表单始终携带完整 itemList，
-    // 空列表视为清空全部关联。
+    // 空列表视为清空全部关联。删除+插入包事务，失败整体回滚，
+    // 避免留下半更新状态（点位已改、关联已丢）。
+    let txn = db.begin().await?;
     let existing = mil_model::Entity::find_safety()
         .filter(mil_model::Column::MarkerId.eq(payload.id))
-        .all(db)
+        .all(&txn)
         .await?;
     for link in existing {
         mil_model::Entity::delete_safety(link.into())?
-            .exec(db)
+            .exec(&txn)
             .await?;
     }
     for (item_id, count) in parse_item_entries(&payload.item_list) {
-        insert_item_link(db, payload.id, item_id, count).await?;
+        insert_item_link(&txn, payload.id, item_id, count).await?;
     }
+    txn.commit().await?;
 
     super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
@@ -851,7 +854,7 @@ pub async fn do_get_page(
 ) -> Result<CommonResponse<MarkerListResponse>> {
     let db = &DB_CONN.wait().pg_conn;
 
-    let size = payload.size.unwrap_or(10) as u64;
+    let size = payload.size.unwrap_or(10).min(200) as u64;
     let current = payload.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -382,7 +382,7 @@ pub async fn do_tweak(
                                 && let Some(i) = tweak_int_value(val)
                             {
                                 // HiddenFlag 是一个枚举；utils 中定义。尝试从整数转换。
-                                let hf = match i as i32 {
+                                let hf = match i.clamp(i32::MIN as i64, i32::MAX as i64) as i32 {
                                     0 => _utils::types::HiddenFlag::Visible,
                                     1 => _utils::types::HiddenFlag::Hidden,
                                     2 => _utils::types::HiddenFlag::Spy,
@@ -442,7 +442,11 @@ fn parse_item_entries(item_list: &[Option<serde_json::Value>]) -> Vec<(i64, i32)
                     .or_else(|| obj.get("itemId"))
                     .and_then(|x| x.as_i64())
                 {
-                    let count = obj.get("count").and_then(|x| x.as_i64()).unwrap_or(1) as i32;
+                    let count =
+                        obj.get("count")
+                            .and_then(|x| x.as_i64())
+                            .unwrap_or(1)
+                            .clamp(i32::MIN as i64, i32::MAX as i64) as i32;
                     ret.push((id, count));
                 }
             },
@@ -598,7 +602,7 @@ pub async fn do_add_single(
         position: Set(payload.position),
         content: Set(payload.content.or(Some(String::new()))),
         picture: Set(payload.picture),
-        marker_creator_id: Set(payload.marker_creator_id),
+        marker_creator_id: Set(auth.info.id),
         picture_creator_id: Set(payload.picture_creator_id),
         video_path: Set(payload.video_path),
         refresh_time: Set(payload.refresh_time.unwrap_or(0)),
@@ -638,7 +642,6 @@ pub async fn do_update_single(
     if let Some(extra) = payload.extra {
         am.extra = Set(Some(serde_json::to_value(extra)?));
     }
-    am.marker_creator_id = Set(payload.marker_creator_id);
     am.marker_title = Set(Some(payload.marker_title));
     am.picture = Set(payload.picture);
     am.picture_creator_id = Set(payload.picture_creator_id);

--- a/packages/functions/src/functions/api/notice.rs
+++ b/packages/functions/src/functions/api/notice.rs
@@ -25,6 +25,13 @@ use _utils::{
     },
 };
 
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// 解析有效期字段：接受毫秒数字或 ISO/普通时间字符串，解析失败回退 `now`。
 /// `None` 或 JSON `null` 表示前端传空（保持原值/NULL），不回退 `now`。
 fn parse_valid_time(
@@ -78,7 +85,7 @@ pub async fn do_update_notice(
             })
             .collect(),
     ));
-    am.sort_index = Set(payload.sort_index as i32);
+    am.sort_index = Set(payload.sort_index.clamp(i32::MIN as i64, i32::MAX as i64) as i32);
     am.valid_time_start = Set(parse_valid_time(payload.valid_time_start.as_ref(), now));
     am.valid_time_end = Set(parse_valid_time(payload.valid_time_end.as_ref(), now));
 
@@ -94,7 +101,8 @@ pub async fn do_get_notice_list(
 
     let mut query = notice_model::Entity::find_safety();
     if let Some(title) = payload.title {
-        query = query.filter(notice_model::Column::Title.like(format!("%{}%", title)));
+        query =
+            query.filter(notice_model::Column::Title.like(format!("%{}%", escape_like(&title))));
     }
     // 公告量小：全量取回后在内存做 channel/有效期过滤（对齐前端参数，
     // jsonb 数组的 SQL 过滤跨方言繁琐且不值得）。
@@ -226,7 +234,7 @@ pub async fn do_add_notice(
                 })
                 .collect(),
         )),
-        sort_index: Set(payload.sort_index as i32),
+        sort_index: Set(payload.sort_index.clamp(i32::MIN as i64, i32::MAX as i64) as i32),
         valid_time_start: Set(parse_valid_time(payload.valid_time_start.as_ref(), now)),
         valid_time_end: Set(parse_valid_time(payload.valid_time_end.as_ref(), now)),
     };

--- a/packages/functions/src/functions/api/notice.rs
+++ b/packages/functions/src/functions/api/notice.rs
@@ -129,7 +129,7 @@ pub async fn do_get_notice_list(
 
     let total = rows.len();
     let creator_ids: HashSet<i64> = rows.iter().filter_map(|n| n.creator_id).collect();
-    let size = payload.page.size.unwrap_or(10) as usize;
+    let size = payload.page.size.unwrap_or(10).min(200) as usize;
     let current = payload.page.current.unwrap_or(1) as usize;
     let offset = (current.saturating_sub(1)) * size;
     let items = rows.into_iter().skip(offset).take(size);

--- a/packages/functions/src/functions/api/res.rs
+++ b/packages/functions/src/functions/api/res.rs
@@ -39,6 +39,24 @@ fn ext_for_content_type(content_type: &str) -> &'static str {
     }
 }
 
+/// Verify the file-header magic number matches the declared content type.
+/// The content type is fully client-controlled, so MIME alone can't stop a
+/// fake `image/png` HTML/SVG from being stored and served publicly.
+/// Only image types are validated; other types pass through.
+fn magic_matches_content_type(content_type: &str, bytes: &[u8]) -> bool {
+    match content_type {
+        // PNG: \x89PNG
+        "image/png" => bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+        // JPEG: \xFF\xD8
+        "image/jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
+        // GIF: GIF8
+        "image/gif" => bytes.starts_with(b"GIF8"),
+        // WEBP: RIFF....WEBP
+        "image/webp" => bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP",
+        _ => true,
+    }
+}
+
 /// Store uploaded images in MinIO and return their public URLs.
 ///
 /// Returns `{"filePath": ..., "fileUrl": ...}` for the first uploaded file
@@ -64,6 +82,13 @@ pub async fn do_upload_image(
         .into_iter()
         .next()
         .ok_or_else(|| anyhow!("no file uploaded"))?;
+
+    if !magic_matches_content_type(&f.content_type, &f.bytes) {
+        return Err(anyhow!(
+            "uploaded file content does not match declared content type: {}",
+            f.content_type
+        ));
+    }
 
     let key = format!(
         "uploads/{}.{}",

--- a/packages/functions/src/functions/api/score.rs
+++ b/packages/functions/src/functions/api/score.rs
@@ -28,9 +28,10 @@ use _utils::{
 /// Deleted 计 1，content 无法解析时按 1 计）。相比旧的「每条计 1」，
 /// 改动字段越多的贡献得分越高。
 pub async fn do_generate_score(
-    _auth: AuthInfo,
+    auth: AuthInfo,
     payload: ScoreGenerateRequest,
 ) -> Result<CommonResponse<String>> {
+    auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
 
     // 解析时间范围

--- a/packages/functions/src/functions/api/tag.rs
+++ b/packages/functions/src/functions/api/tag.rs
@@ -24,6 +24,13 @@ use _utils::{
     },
 };
 
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// 新增标签
 pub async fn do_add(auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddResponse> {
     auth.require_non_anonymous()?;
@@ -63,12 +70,26 @@ pub async fn do_update(
         .one(db)
         .await?;
     let t = t.ok_or(anyhow!("Tag not found"))?;
+    let old_tag = t.tag.clone();
+    let new_tag = payload.base.tag;
     let mut am: tag_model::ActiveModel = t.into();
 
-    am.tag = Set(payload.base.tag);
+    am.tag = Set(new_tag.clone());
     am.icon_id = Set(payload.base.icon_id);
 
     tag_model::Entity::update_safety(am)?.exec(db).await?;
+
+    // 改名时同步 tag_type_link（该表以 tag_name 为键，否则旧关联悬空）
+    if new_tag != old_tag {
+        ttl_model::Entity::update_many()
+            .col_expr(
+                ttl_model::Column::TagName,
+                sea_orm::sea_query::Expr::value(new_tag.clone()),
+            )
+            .filter(ttl_model::Column::TagName.eq(old_tag))
+            .exec(db)
+            .await?;
+    }
     super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
@@ -82,7 +103,7 @@ pub async fn do_list(
     let mut query = tag_model::Entity::find_safety();
 
     if let Some(tag) = payload.tag {
-        query = query.filter(tag_model::Column::Tag.like(format!("%{}%", tag)));
+        query = query.filter(tag_model::Column::Tag.like(format!("%{}%", escape_like(&tag))));
     }
     if let Some(icon_id) = payload.icon_id {
         query = query.filter(tag_model::Column::IconId.eq(icon_id));

--- a/packages/functions/src/functions/api/tag.rs
+++ b/packages/functions/src/functions/api/tag.rs
@@ -45,6 +45,7 @@ pub async fn do_add(auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddResp
     };
 
     let res = tag_model::Entity::insert(am).exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(TagAddResponse {
         id: res.last_insert_id,
     })
@@ -68,6 +69,7 @@ pub async fn do_update(
     am.icon_id = Set(payload.base.icon_id);
 
     tag_model::Entity::update_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -105,7 +107,7 @@ pub async fn do_list(
         }
     }
 
-    let size = payload.page.size.unwrap_or(10) as u64;
+    let size = payload.page.size.unwrap_or(10).min(200) as u64;
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
@@ -143,6 +145,7 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     let mut am: tag_model::ActiveModel = t.into();
     am.del_flag = Set(true);
     tag_model::Entity::delete_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -190,6 +193,7 @@ pub async fn do_update_type(
         .await?;
     }
 
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -223,6 +227,7 @@ pub async fn do_create_by_name(auth: AuthInfo, tag_name: String) -> Result<Commo
     })
     .exec(db)
     .await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -239,6 +244,7 @@ pub async fn do_delete_by_name(auth: AuthInfo, tag_name: String) -> Result<Commo
     let mut am: tag_model::ActiveModel = t.into();
     am.del_flag = Set(true);
     tag_model::Entity::delete_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -259,6 +265,7 @@ pub async fn do_update_by_name(
     let mut am: tag_model::ActiveModel = t.into();
     am.icon_id = Set(icon_id);
     tag_model::Entity::update_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(true)))
 }
 

--- a/packages/functions/src/functions/api/tag_type.rs
+++ b/packages/functions/src/functions/api/tag_type.rs
@@ -42,6 +42,7 @@ pub async fn do_add(auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<Commo
     };
 
     let res = tag_type_model::Entity::insert(am).exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(res.last_insert_id)))
 }
 
@@ -64,6 +65,7 @@ pub async fn do_update(
     am.is_final = Set(payload.base.is_final);
 
     tag_type_model::Entity::update_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -92,7 +94,7 @@ pub async fn do_list(
         }
     }
 
-    let size = payload.page.size.unwrap_or(10) as u64;
+    let size = payload.page.size.unwrap_or(10).min(200) as u64;
     let current = payload.page.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 
@@ -131,5 +133,6 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     let mut am: tag_type_model::ActiveModel = t.into();
     am.del_flag = Set(true);
     tag_type_model::Entity::delete_safety(am)?.exec(db).await?;
+    super::binary_doc::invalidate_doc_cache().await;
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/packages/functions/src/functions/api/tag_type.rs
+++ b/packages/functions/src/functions/api/tag_type.rs
@@ -21,6 +21,13 @@ use _utils::{
     },
 };
 
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// 新增标签类型
 pub async fn do_add(auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<CommonResponse<i64>> {
     auth.require_non_anonymous()?;
@@ -78,7 +85,8 @@ pub async fn do_list(
     let mut query = tag_type_model::Entity::find_safety();
 
     if let Some(name) = payload.name {
-        query = query.filter(tag_type_model::Column::Name.like(format!("%{}%", name)));
+        query =
+            query.filter(tag_type_model::Column::Name.like(format!("%{}%", escape_like(&name))));
     }
     if let Some(parent_id) = payload.parent_id {
         query = query.filter(tag_type_model::Column::ParentId.eq(parent_id));

--- a/packages/functions/src/functions/system/action_log.rs
+++ b/packages/functions/src/functions/system/action_log.rs
@@ -19,6 +19,13 @@ fn action_to_str(action: SystemActionLogAction) -> String {
         .unwrap_or_default()
 }
 
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// List action logs with optional filtering by user_id / action.
 #[allow(clippy::too_many_arguments)]
 pub async fn do_list(
@@ -55,12 +62,12 @@ pub async fn do_list(
     if let Some(did) = device_id
         && !did.is_empty()
     {
-        query = query.filter(log_model::Column::DeviceId.contains(did));
+        query = query.filter(log_model::Column::DeviceId.like(format!("%{}%", escape_like(&did))));
     }
     if let Some(ip) = ipv4
         && !ip.is_empty()
     {
-        query = query.filter(log_model::Column::Ipv4.contains(ip));
+        query = query.filter(log_model::Column::Ipv4.like(format!("%{}%", escape_like(&ip))));
     }
     if let Some(err) = is_error {
         query = query.filter(log_model::Column::IsError.eq(err));

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -174,6 +174,10 @@ pub async fn do_save(
 }
 
 /// Rename an archive slot.
+///
+/// 注意：按 id 操作，**未校验存档归属**（user_id == 请求者）。当前无路由
+/// 接线（router 只用 do_rename_by_slot），一旦接线即构成 IDOR——任意登录
+/// 用户可按 id 改他人存档。启用前必须先按 `auth.info.id` 过滤归属。
 pub async fn do_rename(_auth: AuthInfo, id: i64, name: String) -> Result<CommonResponse<()>> {
     let db = &DB_CONN.wait().pg_conn;
     let a = archive_model::Entity::find_safety_by_id(id)
@@ -207,6 +211,10 @@ pub async fn do_rename_by_slot(
 }
 
 /// Restore from an archive (return the archived data).
+///
+/// 注意：按 id 操作，**未校验存档归属**（user_id == 请求者）。当前无路由
+/// 接线（router 只用 do_restore_slot），一旦接线即构成 IDOR——任意登录
+/// 用户可按 id 读取他人存档数据。启用前必须先按 `auth.info.id` 过滤归属。
 pub async fn do_restore(_auth: AuthInfo, id: i64) -> Result<CommonResponse<serde_json::Value>> {
     let db = &DB_CONN.wait().pg_conn;
     let a = archive_model::Entity::find_safety_by_id(id)
@@ -261,6 +269,10 @@ pub async fn do_delete_slot(user_id: i64, slot_index: i32) -> Result<CommonRespo
 }
 
 /// Delete an archive slot (soft delete).
+///
+/// 注意：按 id 操作，**未校验存档归属**（user_id == 请求者）。当前无路由
+/// 接线（router 只用 do_delete_slot），一旦接线即构成 IDOR——任意登录
+/// 用户可按 id 删除他人存档。启用前必须先按 `auth.info.id` 过滤归属。
 pub async fn do_delete(_auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
     let db = &DB_CONN.wait().pg_conn;
     let a = archive_model::Entity::find_safety_by_id(id)

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -40,15 +40,6 @@ fn extract_archive(body: &serde_json::Value) -> String {
         .unwrap_or_else(|| serde_json::to_string(body).unwrap_or_default())
 }
 
-/// 从任意 JSON body 中提取保存时间（毫秒时间戳），取不到默认当前时间。
-fn extract_time(body: &serde_json::Value) -> chrono::NaiveDateTime {
-    body.get("time")
-        .and_then(|v| v.as_f64())
-        .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms as i64))
-        .map(|dt| dt.naive_utc())
-        .unwrap_or_else(|| Utc::now().naive_utc())
-}
-
 /// Get the latest archive for a given slot index.
 pub async fn do_get_last(
     _auth: AuthInfo,
@@ -160,7 +151,8 @@ pub async fn do_save(
 ) -> Result<CommonResponse<serde_json::Value>> {
     let db = &DB_CONN.wait().pg_conn;
     let archive = extract_archive(&body);
-    let now = extract_time(&body);
+    // create_time 由服务端定，不信任客户端传入的 time（防止时间戳伪造/脏数据）
+    let now = Utc::now().naive_utc();
 
     let am = archive_model::ActiveModel {
         version: Set(0),

--- a/packages/functions/src/functions/system/invitation.rs
+++ b/packages/functions/src/functions/system/invitation.rs
@@ -278,7 +278,7 @@ pub async fn do_consume(
             .access_policy
             .as_ref()
             .and_then(|v| serde_json::from_value::<AccessPolicyList>(v.clone()).ok())),
-        remark: Set(None),
+        remark: Set(Some(String::new())),
     };
     let res = sys_user_model::Entity::insert(user_am).exec(&txn).await?;
 

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -329,7 +329,9 @@ fn check_login_rate_limit(ip: SocketAddr) -> Result<()> {
     let window = now / 60;
     let mut map = LOGIN_FAILURES.lock().unwrap();
     sweep_stale_login_failures(&mut map, window);
-    let entry = map.entry(ip.to_string()).or_insert((0, window));
+    // 限流 key 只取 IP（SocketAddr::ip()），不含客户端临时端口：
+    // 端口每次新建连接都不同，含端口会导致每个请求独立计数、限流永不触发。
+    let entry = map.entry(ip.ip().to_string()).or_insert((0, window));
     if entry.1 != window {
         *entry = (0, window);
     }
@@ -346,7 +348,8 @@ fn record_login_failure(ip: SocketAddr) {
     let window = now / 60;
     let mut map = LOGIN_FAILURES.lock().unwrap();
     sweep_stale_login_failures(&mut map, window);
-    let entry = map.entry(ip.to_string()).or_insert((0, window));
+    // 同 check_login_rate_limit：key 仅取 IP 不含临时端口
+    let entry = map.entry(ip.ip().to_string()).or_insert((0, window));
     if entry.1 != window {
         *entry = (0, window);
     }

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -140,24 +140,31 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
 }
 
 /// 为用户签发 access/refresh token（含 Redis 会话存储，Redis 不可用时降级）。
+///
+/// access 与 refresh 使用**不同的 jti**（S2：access token 无法冒充 refresh），
+/// Redis 键结构：
+/// - `jwt:access:{uid}:{access_jti}` → 用户 VO JSON（受保护端点校验）
+/// - `jwt:refresh:{uid}:{refresh_jti}` → 配对 access_jti 字符串（refresh
+///   端点校验；轮换时据此吊销旧 access token）
 async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLoginResponse> {
-    let jti = Uuid::now_v7();
+    let access_jti = Uuid::now_v7();
+    let refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, item.id, jti).await?;
-    let refresh_token = generate_token(now, item.id, jti).await?;
+    let access_token = generate_token(now, item.id, access_jti, "access").await?;
+    let refresh_token = generate_token(now, item.id, refresh_jti, "refresh").await?;
 
     let id = item.id;
     let vo: SysUserVO = item.clone().into();
 
     // Store token in Redis if available (graceful degradation for e2e mode
-    // where Redis is not running — token verification will fall back to
-    // JWT-only validation without Redis session lookup).
+    // where Redis is not running — oauth_parse_token will fall back to
+    // JWT + DB validation without Redis session lookup).
     if let Some(redis_client) = &DB_CONN.wait().redis_conn
         && let Ok(mut redis_conn) = redis_client.get_multiplexed_async_connection().await
     {
         let _ = redis_conn
             .set_options(
-                format!("jwt:access:{}:{}", id, jti),
+                format!("jwt:access:{}:{}", id, access_jti),
                 serde_json::to_string(&vo)?,
                 SetOptions::default()
                     .conditional_set(redis::ExistenceCheck::NX)
@@ -168,8 +175,8 @@ async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLogi
             .await;
         let _ = redis_conn
             .set_options(
-                format!("jwt:refresh:{}:{}", id, jti),
-                "",
+                format!("jwt:refresh:{}:{}", id, refresh_jti),
+                access_jti.to_string(),
                 SetOptions::default()
                     .conditional_set(redis::ExistenceCheck::NX)
                     .with_expiration(redis::SetExpiry::EX(
@@ -185,7 +192,7 @@ async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLogi
         token_type: OauthTokenType::Bearer,
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
         scope: OauthScopeType::All,
-        jti,
+        jti: access_jti,
         // Java 契约（AuthorizationServerConfiguration additionalInfo）：
         // 前端 `SysToken` 依赖 userId / userRoles 恢复用户态与权限掩码。
         user_id: id,
@@ -228,14 +235,36 @@ async fn oauth_password_login_inner(
 pub async fn oauth_parse_token(token: String) -> Result<(SysUserVO, Claims)> {
     let claims = verify_token(&token).await?;
 
-    // Try Redis session lookup; fall back to DB lookup if Redis is unavailable
-    // (graceful degradation for e2e mode).
-    if let Some(redis_client) = &DB_CONN.wait().redis_conn
-        && let Ok(mut redis_conn) = redis_client.get_multiplexed_async_connection().await
-    {
+    // S2：refresh token 不得当 access token 使用。旧令牌无 token_type
+    // 声明（None），走下方 access key 校验路径，保持兼容。
+    if claims.token_type.as_deref() == Some("refresh") {
+        return Err(anyhow!("Refresh token cannot be used as an access token"));
+    }
+
+    // S1：会话校验。Redis key 命中 → 放行；key 明确不存在 → 会话已被吊销
+    // （登出/踢出/改密/刷新轮换删除），必须拒绝；仅当 Redis 连接/命令失败
+    // （无法判定存在性）时降级 DB 校验。REDIS_REQUIRED=true 时 Redis 不可
+    // 用直接失败（fail-closed），不降级。
+    let redis_required = std::env::var("REDIS_REQUIRED").as_deref() == Ok("true");
+    if let Some(redis_client) = &DB_CONN.wait().redis_conn {
         let key = format!("jwt:access:{}:{}", claims.sub, claims.jti);
-        if let Ok(Some(item)) = redis_conn.get::<String>(key).await {
-            return Ok((serde_json::from_str(&item)?, claims));
+        match redis_client.get_multiplexed_async_connection().await {
+            Ok(mut redis_conn) => match redis_conn.get::<String>(key).await {
+                // 会话命中：以 Redis 中缓存的 VO 为准
+                Ok(Some(item)) => return Ok((serde_json::from_str(&item)?, claims)),
+                // 键明确不存在 = 吊销已生效（登出/踢出/改密/刷新轮换）
+                Ok(None) => return Err(anyhow!("Token revoked")),
+                // Redis 命令失败（连接中断等）→ 无法判定存在性
+                Err(_) if redis_required => {
+                    return Err(anyhow!("Redis unavailable (REDIS_REQUIRED=true)"));
+                },
+                Err(_) => {},
+            },
+            // Redis 连接失败 → 无法判定存在性
+            Err(_) if redis_required => {
+                return Err(anyhow!("Redis unavailable (REDIS_REQUIRED=true)"));
+            },
+            Err(_) => {},
         }
     }
 
@@ -395,10 +424,12 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
 
     let scope_enum = map_scope(&scope)?;
 
-    let jti = Uuid::now_v7();
+    // access/refresh 用不同 jti 并带 token_type 声明（与 issue_token 一致）
+    let access_jti = Uuid::now_v7();
+    let refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, id, jti).await?;
-    let _refresh_token = generate_token(now, id, jti).await?;
+    let access_token = generate_token(now, id, access_jti, "access").await?;
+    let _refresh_token = generate_token(now, id, refresh_jti, "refresh").await?;
 
     let mut redis_conn = DB_CONN
         .wait()
@@ -413,7 +444,7 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
 
     redis_conn
         .set_options(
-            format!("jwt:access:{}:{}", id, jti),
+            format!("jwt:access:{}:{}", id, access_jti),
             payload,
             SetOptions::default()
                 .conditional_set(redis::ExistenceCheck::NX)
@@ -424,8 +455,8 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
         .await?;
     redis_conn
         .set_options(
-            format!("jwt:refresh:{}:{}", id, jti),
-            "",
+            format!("jwt:refresh:{}:{}", id, refresh_jti),
+            access_jti.to_string(),
             SetOptions::default()
                 .conditional_set(redis::ExistenceCheck::NX)
                 .with_expiration(redis::SetExpiry::EX(
@@ -439,7 +470,7 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
         token_type: OauthTokenType::Bearer,
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
         scope: scope_enum,
-        jti,
+        jti: access_jti,
     })
 }
 
@@ -456,10 +487,17 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
     // 验证传入的 refresh token 并获取 claims
     let claims = verify_token(&refresh_token).await?;
 
+    // S2：只接受 refresh 类型令牌。access token 直接拒绝；旧格式令牌
+    // （无 token_type 声明）一律拒绝，强制重新登录（旧格式即本漏洞来源）。
+    if claims.token_type.as_deref() != Some("refresh") {
+        return Err(anyhow!("Not a refresh token"));
+    }
+
     let user = models::system::sys_user::Entity::find_safety_by_id(claims.sub)
         .one(&DB_CONN.wait().pg_conn)
         .await?
         .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+    let vo: SysUserVO = user.clone().into();
 
     let mut redis_conn = DB_CONN
         .wait()
@@ -469,33 +507,39 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
         .get_multiplexed_async_connection()
         .await?;
 
-    // 确认 refresh token 在 Redis 中存在
+    // 原子 claim 旧 refresh key（GETDEL）：返回 None 说明 key 已不存在
+    // （已被轮换/吊销/登出），拒绝重放；同时取出配对 access_jti。
     let refresh_key = format!("jwt:refresh:{}:{}", claims.sub, claims.jti);
-    let exists: Option<String> = redis_conn.get(&refresh_key).await?;
-    if exists.is_none() {
-        return Err(anyhow!("Refresh token not found"));
+    let old_access_jti: Option<String> = redis_conn.get_del(&refresh_key).await?;
+    if old_access_jti.is_none() {
+        return Err(anyhow!("Refresh token not found or already used"));
     }
 
-    // 生成新的 jti 和 token（旧 token 一次性使用：旋转后立即作废）
-    let new_jti = Uuid::now_v7();
+    // 吊销旧 access token（其 jti 记录在 refresh key 的 value 中）
+    if let Some(old_access_jti) = old_access_jti.as_deref()
+        && !old_access_jti.is_empty()
+    {
+        let _deleted: usize = redis_conn
+            .del(format!("jwt:access:{}:{}", claims.sub, old_access_jti))
+            .await?;
+    }
+
+    // 生成新的 jti 和 token（旧 refresh 已作废：轮换后立即失效）
+    let new_access_jti = Uuid::now_v7();
+    let new_refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, claims.sub, new_jti).await?;
-    let refresh_token_new = generate_token(now, claims.sub, new_jti).await?;
+    let access_token = generate_token(now, claims.sub, new_access_jti, "access").await?;
+    let refresh_token_new = generate_token(now, claims.sub, new_refresh_jti, "refresh").await?;
 
-    // 保持原来的访问负载（如果有），尝试读取旧的 access payload
-    let old_access_key = format!("jwt:access:{}:{}", claims.sub, claims.jti);
-    let access_payload: Option<String> = redis_conn.get(&old_access_key).await?;
-
-    // 写入新的 access/refresh 条目
-    let access_key = format!("jwt:access:{}:{}", claims.sub, new_jti);
-    let refresh_key_new = format!("jwt:refresh:{}:{}", claims.sub, new_jti);
-
-    let payload_to_store = access_payload.unwrap_or_else(|| serde_json::json!({}).to_string());
+    // 写入新的 access/refresh 条目（payload 取 DB 最新用户信息，
+    // 不再依赖旧 access key 的缓存内容）
+    let access_key = format!("jwt:access:{}:{}", claims.sub, new_access_jti);
+    let refresh_key_new = format!("jwt:refresh:{}:{}", claims.sub, new_refresh_jti);
 
     redis_conn
         .set_options(
             &access_key,
-            payload_to_store,
+            serde_json::to_string(&vo)?,
             SetOptions::default()
                 .conditional_set(redis::ExistenceCheck::NX)
                 .with_expiration(redis::SetExpiry::EX(
@@ -507,7 +551,7 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
     redis_conn
         .set_options(
             &refresh_key_new,
-            "",
+            new_access_jti.to_string(),
             SetOptions::default()
                 .conditional_set(redis::ExistenceCheck::NX)
                 .with_expiration(redis::SetExpiry::EX(
@@ -516,17 +560,13 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
         )
         .await?;
 
-    // 删除旧的 access/refresh 键
-    let _deleted_old_access: usize = redis_conn.del(old_access_key).await?;
-    let _deleted_old_refresh: usize = redis_conn.del(refresh_key).await?;
-
     Ok(OauthLoginResponse {
         access_token,
         refresh_token: refresh_token_new,
         token_type: OauthTokenType::Bearer,
         expires_in: EXPIRED_APPEND_DURATION.as_seconds_f32() as i64,
         scope: OauthScopeType::All,
-        jti: new_jti,
+        jti: new_access_jti,
         user_id: claims.sub,
         user_roles: vec![role_code(user.role_id)],
         env: None,

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -21,6 +21,12 @@ use _utils::{
     },
 };
 
+/// 基础设施错误（数据库 / Redis 等）不回传实现细节，统一为通用文案，
+/// 避免向客户端暴露 SQL / 连接等内部信息。
+fn internal_error(_err: impl std::fmt::Display) -> anyhow::Error {
+    anyhow!("Internal server error")
+}
+
 /// 按用户的 access_policy 校验登录环境（IP / 设备）。
 ///
 /// 数据源为 `sys_user_device` 表：
@@ -45,7 +51,8 @@ async fn check_access_policy(
         .filter(models::system::sys_user_device::Column::UserId.eq(Some(user_id)))
         .order_by_desc(models::system::sys_user_device::Column::LastLoginTime)
         .one(db)
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     for policy in access_policy {
         match policy {
@@ -77,7 +84,8 @@ async fn check_access_policy(
                         models::system::sys_user_device::Column::Ipv4.eq(Some(ip.ip().to_string())),
                     )
                     .one(db)
-                    .await?;
+                    .await
+                    .map_err(internal_error)?;
                 if blocked.is_some() {
                     return Err(anyhow!("Access denied: IP {} is blocked", ip));
                 }
@@ -88,7 +96,8 @@ async fn check_access_policy(
                     .filter(models::system::sys_user_device::Column::Status.ne(0))
                     .filter(models::system::sys_user_device::Column::DeviceId.eq(user_agent))
                     .one(db)
-                    .await?;
+                    .await
+                    .map_err(internal_error)?;
                 if blocked.is_some() {
                     return Err(anyhow!("Access denied: device is blocked"));
                 }
@@ -111,32 +120,51 @@ async fn record_device(user_id: i64, ip: SocketAddr, user_agent: &str) -> Result
 
     let now = chrono::Utc::now().naive_utc();
     if let Some(dev) = existing {
+        // 已有登记：仅刷新 IP / 最近登录时间。status（封禁状态）随
+        // `dev.into()` 原样保留，不因成功登录被静默重置为 0。
         let mut am: models::system::sys_user_device::ActiveModel = dev.into();
         am.ipv4 = Set(Some(ip.ip().to_string()));
         am.last_login_time = Set(Some(now));
         models::system::sys_user_device::Entity::update_safety(am)?
             .exec(db)
             .await?;
-    } else {
-        let am = models::system::sys_user_device::ActiveModel {
-            version: Set(0),
-            id: NotSet,
-            create_time: Set(now),
-            update_time: Set(None),
-            creator_id: Set(None),
-            updater_id: Set(None),
-            del_flag: Set(false),
-            user_id: Set(Some(user_id)),
-            device_id: Set(user_agent.to_string()),
-            ipv4: Set(Some(ip.ip().to_string())),
-            status: Set(0),
-            last_login_time: Set(Some(now)),
-        };
-        models::system::sys_user_device::Entity::insert(am)
-            .exec(db)
-            .await?;
+        return Ok(());
     }
-    Ok(())
+
+    // 首次登记：status 初始化为 0（正常）。
+    let am = models::system::sys_user_device::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(None),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        user_id: Set(Some(user_id)),
+        device_id: Set(user_agent.to_string()),
+        ipv4: Set(Some(ip.ip().to_string())),
+        status: Set(0),
+        last_login_time: Set(Some(now)),
+    };
+    // 并发首次登录同设备时，两次 check 都可能查不到（check-then-act
+    // 竞态）；数据库唯一约束冲突（Postgres SQLSTATE 23505）由后插者
+    // 触发，视为已登记成功，直接忽略。
+    match models::system::sys_user_device::Entity::insert(am)
+        .exec(db)
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(DbErr::Exec(RuntimeErr::SqlxError(err)))
+            if matches!(
+                err.as_ref(),
+                sea_orm::sqlx::Error::Database(db_err)
+                    if db_err.code().as_deref() == Some("23505")
+            ) =>
+        {
+            Ok(())
+        },
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// 为用户签发 access/refresh token（含 Redis 会话存储，Redis 不可用时降级）。
@@ -222,7 +250,7 @@ async fn oauth_password_login_inner(
     user_agent: &str,
 ) -> Result<OauthLoginResponse> {
     if !verify_password(password_raw, item.password.clone())? {
-        return Err(anyhow!("Invalid password"));
+        return Err(anyhow!("Invalid username or password"));
     }
 
     // 身份验证通过后，按用户的 access_policy 校验登录环境
@@ -273,7 +301,8 @@ pub async fn oauth_parse_token(token: String) -> Result<(SysUserVO, Claims)> {
         .filter(models::system::sys_user::Column::Id.eq(claims.sub))
         .filter(models::system::sys_user::Column::DelFlag.eq(false))
         .one(&DB_CONN.wait().pg_conn)
-        .await?
+        .await
+        .map_err(internal_error)?
         .ok_or(anyhow!("User not found for token"))?;
     Ok((user.into(), claims))
 }
@@ -285,10 +314,21 @@ const LOGIN_RATE_LIMIT_PER_MINUTE: u32 = 5;
 static LOGIN_FAILURES: Lazy<std::sync::Mutex<std::collections::HashMap<String, (u32, i64)>>> =
     Lazy::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// 清理早于当前窗口的限流条目。条目只对当前窗口计数（跨窗口在下次
+/// 访问时本就会被重置），直接移除过期条目可防止 `LOGIN_FAILURES`
+/// 按唯一 IP 无限累积。
+fn sweep_stale_login_failures(
+    map: &mut std::collections::HashMap<String, (u32, i64)>,
+    window: i64,
+) {
+    map.retain(|_, (_, entry_window)| *entry_window >= window);
+}
+
 fn check_login_rate_limit(ip: SocketAddr) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
     let window = now / 60;
     let mut map = LOGIN_FAILURES.lock().unwrap();
+    sweep_stale_login_failures(&mut map, window);
     let entry = map.entry(ip.to_string()).or_insert((0, window));
     if entry.1 != window {
         *entry = (0, window);
@@ -305,6 +345,7 @@ fn record_login_failure(ip: SocketAddr) {
     let now = chrono::Utc::now().timestamp();
     let window = now / 60;
     let mut map = LOGIN_FAILURES.lock().unwrap();
+    sweep_stale_login_failures(&mut map, window);
     let entry = map.entry(ip.to_string()).or_insert((0, window));
     if entry.1 != window {
         *entry = (0, window);
@@ -325,8 +366,14 @@ pub async fn oauth_password_login(
         .filter(models::system::sys_user::Column::DelFlag.eq(false))
         .filter(models::system::sys_user::Column::Username.eq(username))
         .one(&DB_CONN.wait().pg_conn)
-        .await?
-        .ok_or(anyhow!("User not found"))?;
+        .await
+        .map_err(internal_error)?;
+    let Some(item) = item else {
+        // 与“密码错误”返回同一文案并同样计入失败限流，
+        // 避免用户名枚举与无代价探测。
+        record_login_failure(ip);
+        return Err(anyhow!("Invalid username or password"));
+    };
     let user_id = item.id;
 
     let ret = oauth_password_login_inner(item, password_raw, ip, &user_agent).await;
@@ -354,7 +401,8 @@ pub async fn oauth_password_login(
         extra_data: Set(Some(Default::default())),
     }
     .insert(&DB_CONN.wait().pg_conn)
-    .await?;
+    .await
+    .map_err(internal_error)?;
 
     ret
 }
@@ -385,7 +433,8 @@ pub async fn oauth_qq_login(
         .filter(models::system::sys_user::Column::DelFlag.eq(false))
         .filter(models::system::sys_user::Column::Qq.eq(Some(qq_openid)))
         .one(db)
-        .await?
+        .await
+        .map_err(internal_error)?
         .ok_or(anyhow!("QQ account not registered"))?;
     let user_id = item.id;
 
@@ -413,7 +462,8 @@ pub async fn oauth_qq_login(
         extra_data: Set(Some(Default::default())),
     }
     .insert(&DB_CONN.wait().pg_conn)
-    .await?;
+    .await
+    .map_err(internal_error)?;
 
     ret
 }
@@ -437,7 +487,8 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("Redis not available"))?
         .get_multiplexed_async_connection()
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     // 对于匿名/客户端凭据，存储一个空的 payload 或简单标记
     let payload = serde_json::to_string(&serde_json::json!({"anon": true}))?;
@@ -452,7 +503,8 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
                     EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
                 )),
         )
-        .await?;
+        .await
+        .map_err(internal_error)?;
     redis_conn
         .set_options(
             format!("jwt:refresh:{}:{}", id, refresh_jti),
@@ -463,7 +515,8 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
                     EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
                 )),
         )
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     Ok(OauthAnonymousResponse {
         access_token,
@@ -495,7 +548,8 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
 
     let user = models::system::sys_user::Entity::find_safety_by_id(claims.sub)
         .one(&DB_CONN.wait().pg_conn)
-        .await?
+        .await
+        .map_err(internal_error)?
         .ok_or_else(|| anyhow::anyhow!("User not found"))?;
     let vo: SysUserVO = user.clone().into();
 
@@ -505,12 +559,16 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("Redis not available"))?
         .get_multiplexed_async_connection()
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     // 原子 claim 旧 refresh key（GETDEL）：返回 None 说明 key 已不存在
     // （已被轮换/吊销/登出），拒绝重放；同时取出配对 access_jti。
     let refresh_key = format!("jwt:refresh:{}:{}", claims.sub, claims.jti);
-    let old_access_jti: Option<String> = redis_conn.get_del(&refresh_key).await?;
+    let old_access_jti: Option<String> = redis_conn
+        .get_del(&refresh_key)
+        .await
+        .map_err(internal_error)?;
     if old_access_jti.is_none() {
         return Err(anyhow!("Refresh token not found or already used"));
     }
@@ -521,7 +579,8 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
     {
         let _deleted: usize = redis_conn
             .del(format!("jwt:access:{}:{}", claims.sub, old_access_jti))
-            .await?;
+            .await
+            .map_err(internal_error)?;
     }
 
     // 生成新的 jti 和 token（旧 refresh 已作废：轮换后立即失效）
@@ -546,7 +605,8 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
                     EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
                 )),
         )
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     redis_conn
         .set_options(
@@ -558,7 +618,8 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
                     EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
                 )),
         )
-        .await?;
+        .await
+        .map_err(internal_error)?;
 
     Ok(OauthLoginResponse {
         access_token,

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -46,7 +46,7 @@ pub async fn do_register(
         logo: Set(logo),
         role_id: Set(role_id.unwrap_or(SystemUserRole::MapUser)),
         access_policy: Set(access_policy.map(_utils::types::AccessPolicyList)),
-        remark: Set(remark),
+        remark: Set(Some(remark.unwrap_or_default())),
     };
 
     let res = sys_user_model::Entity::insert(am).exec(db).await?;
@@ -103,7 +103,7 @@ pub async fn do_register_qq(
         // 公开接口：不信任客户端传入的角色，固定注册为地图用户
         role_id: Set(SystemUserRole::MapUser),
         access_policy: Set(access_policy.map(_utils::types::AccessPolicyList)),
-        remark: Set(remark),
+        remark: Set(Some(remark.unwrap_or_default())),
     };
 
     let res = sys_user_model::Entity::insert(am).exec(db).await?;

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -17,6 +17,13 @@ use _utils::{
 };
 
 // 业务处理函数
+/// 转义 LIKE 通配符（% _ \），防止输入被当作模糊匹配通配符放大（PG 默认 ESCAPE 为反斜杠）。
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 pub async fn do_register(
     _auth: AuthInfo,
     access_policy: Option<Vec<AccessPolicyItemEnum>>,
@@ -304,7 +311,7 @@ pub async fn do_list(
     if let Some(nickname) = nickname
         && !nickname.is_empty()
     {
-        query = query.filter(sys_user_model::Column::Nickname.like(nickname));
+        query = query.filter(sys_user_model::Column::Nickname.like(escape_like(&nickname)));
     }
     if let Some(username) = username
         && !username.is_empty()

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -28,6 +28,17 @@ pub async fn do_register(
 ) -> Result<CommonResponse<i64>> {
     let db = &DB_CONN.wait().pg_conn;
 
+    // 注册前查重（应用层）：username 已被占用（未软删）则拒绝，防重复用户名
+    // 落库后 oauth_password_login 的 .one() 按名匹配取到错误账户。
+    let username_taken = sys_user_model::Entity::find_safety()
+        .filter(sys_user_model::Column::Username.eq(&username))
+        .count(db)
+        .await?
+        > 0;
+    if username_taken {
+        return Err(anyhow!("username exists"));
+    }
+
     let now = Utc::now().naive_utc();
     let am = sys_user_model::ActiveModel {
         version: Set(0),
@@ -325,7 +336,7 @@ pub async fn do_list(
         }
     }
 
-    let size = pagination.size.unwrap_or(10) as u64;
+    let size = pagination.size.unwrap_or(10).min(200) as u64;
     let current = pagination.current.unwrap_or(1);
     let offset = (current.saturating_sub(1) as u64).saturating_mul(size);
 

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -184,6 +184,7 @@ pub async fn do_update(
         .await
         .map_err(|e| (500, e.to_string()))?;
     let m = m.ok_or_else(|| (500, "User not found".to_string()))?;
+    let old_role = m.role_id;
     let mut am: sys_user_model::ActiveModel = m.into();
 
     if let Some(ap) = access_policy {
@@ -231,6 +232,15 @@ pub async fn do_update(
         .exec(db)
         .await
         .map_err(|e| (500, e.to_string()))?;
+    // 角色变更（仅 Admin 操作生效）后吊销该用户全部会话：被降权/换角的
+    // 用户不得继续持有旧角色权限（Redis VO 快照最长 15 天）。Redis 不可用
+    // 时忽略错误（降级）。
+    if is_admin
+        && let Some(rid) = role_id
+        && old_role != rid
+    {
+        let _ = revoke_user_sessions(id).await;
+    }
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -270,6 +280,9 @@ pub async fn do_update_password(
         .exec(db)
         .await
         .map_err(|e| (500, e.to_string()))?;
+    // 改密成功后吊销该用户全部会话（含其他设备）：已签发 token 一律失效。
+    // Redis 不可用时忽略错误（降级）。
+    let _ = revoke_user_sessions(user_id).await;
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -286,6 +299,9 @@ pub async fn do_update_password_by_admin(
     let mut am: sys_user_model::ActiveModel = m.into();
     am.password = Set(_utils::bcrypt::generate_storage_password(password)?);
     sys_user_model::Entity::update_safety(am)?.exec(db).await?;
+    // 管理员重置密码后吊销该用户全部会话，旧 token 一律失效（无旧密码
+    // 校验的管理员通道同样生效）。Redis 不可用时忽略错误（降级）。
+    let _ = revoke_user_sessions(user_id).await;
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -294,6 +310,9 @@ pub async fn do_delete(_auth: AuthInfo, work_id: i64) -> Result<()> {
     sys_user_model::Entity::delete_safety_by_id(work_id)?
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
+    // 删除后吊销该用户全部 Redis 会话：软删用户的 token 靠缓存 VO 仍能
+    // 最长有效 15 天，必须立即失效。Redis 不可用时忽略错误（降级）。
+    let _ = revoke_user_sessions(work_id).await;
     Ok(())
 }
 
@@ -356,13 +375,14 @@ pub async fn do_list(
     )))
 }
 
-pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
-    // 踢出用户：删除该用户在 Redis 中的全部会话令牌。
-    // JWT 本身无状态，登出/踢出依赖 Redis 会话（jwt:access:{uid}:{jti}）。
-    let user_id = work_id
-        .parse::<i64>()
-        .map_err(|_| anyhow!("Invalid user id"))?;
-
+/// 吊销指定用户的全部 Redis 会话（jwt:access:{uid}:* / jwt:refresh:{uid}:*）。
+///
+/// 供 do_kick_out / 删号 / 降权 / 改密共用：这些操作之后旧会话必须立即失效，
+/// 否则 Redis 中缓存的用户 VO 快照最长还能续命 15 天（被删/降权用户继续持有
+/// 旧权限、改密后旧设备仍可访问）。用 SCAN + pipeline 而非 KEYS：KEYS 会阻塞
+/// Redis 主线程（大 key 空间下长时间阻塞），SCAN 按游标分批遍历，收集后一次
+/// pipeline 删除。Redis 不可用时退化为无操作（与 oauth 的降级策略一致）。
+pub(crate) async fn revoke_user_sessions(user_id: i64) -> Result<()> {
     let Some(redis_client) = &DB_CONN.wait().redis_conn else {
         // Redis 不可用时退化为无操作（与 oauth 的降级策略一致）
         return Ok(());
@@ -374,8 +394,6 @@ pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
 
     let access_prefix = format!("jwt:access:{user_id}:*");
     let refresh_prefix = format!("jwt:refresh:{user_id}:*");
-    // 用 SCAN + pipeline 而非 KEYS：KEYS 会阻塞 Redis 主线程（大 key 空间下
-    // 长时间阻塞），SCAN 按游标分批遍历；收集后一次 pipeline 删除。
     for prefix in [access_prefix, refresh_prefix] {
         let keys = scan_keys(&mut redis_conn, &prefix).await?;
         if keys.is_empty() {
@@ -388,6 +406,15 @@ pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
         pipe.query_async::<()>(&mut redis_conn).await?;
     }
     Ok(())
+}
+
+pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
+    // 踢出用户：删除该用户在 Redis 中的全部会话令牌。
+    // JWT 本身无状态，登出/踢出依赖 Redis 会话（jwt:access:{uid}:{jti}）。
+    let user_id = work_id
+        .parse::<i64>()
+        .map_err(|_| anyhow!("Invalid user id"))?;
+    revoke_user_sessions(user_id).await
 }
 
 /// 用 SCAN 游标分批收集匹配 pattern 的 key（不阻塞 Redis 主线程）。

--- a/packages/router/src/bin/init_db.rs
+++ b/packages/router/src/bin/init_db.rs
@@ -143,7 +143,53 @@ async fn main() -> Result<()> {
 /// manually on the production database by ops; see its header comment.
 async fn ensure_indexes(db: &sea_orm::DatabaseConnection) -> Result<()> {
     // Strip full-line comments, then execute statement by statement.
-    let sql = include_str!("../../../../scripts/indexes_dev.sql")
+    let sql = r#"-- scripts/indexes_dev.sql
+-- Performance indexes for the `genshin_map` schema (PostgreSQL 15).
+--
+-- Index gaps identified in the db_audit.md audit (P2): history (460K rows)
+-- filters by creator_id / edit_type and defaults to ORDER BY update_time DESC
+-- with no backing index; sys_user_device / sys_user_invitation /
+-- sys_action_log / marker_item_link (707K rows) are filtered on unindexed
+-- columns.
+--
+-- Idempotent: every statement uses CREATE INDEX IF NOT EXISTS, so this file
+-- can be re-run safely at any time.
+--
+-- Where it runs:
+--   1. local / e2e databases: applied automatically by `cargo run --bin
+--      init_db` (init_db.rs embeds this file via include_str!).
+--   2. production database: run once manually by ops, e.g.:
+--        psql "postgres://<user>:<pass>@<host>:<port>/genshin_map" \
+--          -f scripts/indexes_dev.sql
+--      (init_db is never pointed at the production DB; the CREATE TABLE pass
+--      would be skipped there anyway, and the indexes below are exactly what
+--      production needs.)
+
+-- history: per-creator filters, per-edit_type filters, and the default
+-- ORDER BY update_time DESC used by history.rs list queries.
+CREATE INDEX IF NOT EXISTS idx_history_creator_id ON genshin_map.history (creator_id);
+CREATE INDEX IF NOT EXISTS idx_history_edit_type ON genshin_map.history (edit_type);
+CREATE INDEX IF NOT EXISTS idx_history_update_time ON genshin_map.history (update_time DESC);
+
+-- sys_user_device: login registration / access-policy checks are keyed on
+-- (user_id, last_login_time).
+CREATE INDEX IF NOT EXISTS idx_sys_user_device_user_last_login
+    ON genshin_map.sys_user_device (user_id, last_login_time);
+
+-- sys_user_invitation: code lookup on consume, creator_id for listing.
+CREATE INDEX IF NOT EXISTS idx_sys_user_invitation_code ON genshin_map.sys_user_invitation (code);
+CREATE INDEX IF NOT EXISTS idx_sys_user_invitation_creator_id
+    ON genshin_map.sys_user_invitation (creator_id);
+
+-- sys_action_log: per-user filters and create_time range scans.
+CREATE INDEX IF NOT EXISTS idx_sys_action_log_user_id ON genshin_map.sys_action_log (user_id);
+CREATE INDEX IF NOT EXISTS idx_sys_action_log_create_time ON genshin_map.sys_action_log (create_time);
+
+-- marker_item_link (707K rows): standalone lookups/joins on either side.
+-- (The (item_id, marker_id) composite index already exists; these two cover
+-- queries that filter on one side only.)
+CREATE INDEX IF NOT EXISTS idx_marker_item_link_item_id ON genshin_map.marker_item_link (item_id);
+CREATE INDEX IF NOT EXISTS idx_marker_item_link_marker_id ON genshin_map.marker_item_link (marker_id);"#
         .lines()
         .filter(|l| {
             let t = l.trim();

--- a/packages/router/src/bin/init_db.rs
+++ b/packages/router/src/bin/init_db.rs
@@ -5,8 +5,13 @@
 //! entity definitions, so it can never drift from the code.
 //!
 //! **On-demand mode**: when all 24 tables already exist the CREATE pass is
-//! skipped entirely ("schema already up to date"). Afterwards it ensures a
-//! dev admin account exists and prints the credentials to stdout.
+//! skipped entirely ("schema already up to date"). Afterwards it applies the
+//! performance indexes from `scripts/indexes_dev.sql` (idempotent), then
+//! ensures a dev admin account exists and prints the credentials to stdout.
+//!
+//! The index SQL file is also the ops source of truth for the production
+//! database — run it manually there (see the file header):
+//!   psql ".../genshin_map" -f scripts/indexes_dev.sql
 //!
 //! Usage (from the workspace root):
 //!   cargo run --bin init_db
@@ -125,7 +130,33 @@ async fn main() -> Result<()> {
         println!("Schema ready: {created} tables ensured in genshin_map");
     }
 
+    // Performance indexes (idempotent). Always runs — also on the on-demand
+    // path, where tables already exist but the indexes may not.
+    ensure_indexes(&db).await?;
+
     ensure_admin_account(&db).await?;
+    Ok(())
+}
+
+/// Apply the performance indexes from `scripts/indexes_dev.sql`
+/// (`CREATE INDEX IF NOT EXISTS`, idempotent). The same file is executed
+/// manually on the production database by ops; see its header comment.
+async fn ensure_indexes(db: &sea_orm::DatabaseConnection) -> Result<()> {
+    // Strip full-line comments, then execute statement by statement.
+    let sql = include_str!("../../../../scripts/indexes_dev.sql")
+        .lines()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with("--")
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    for stmt in sql.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+        db.execute_unprepared(stmt)
+            .await
+            .with_context(|| format!("create index: {stmt}"))?;
+    }
+    println!("Indexes ensured (scripts/indexes_dev.sql)");
     Ok(())
 }
 

--- a/packages/router/src/routes/api/app/mod.rs
+++ b/packages/router/src/routes/api/app/mod.rs
@@ -12,7 +12,7 @@ pub async fn trigger_update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::app::do_trigger_update(auth).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 

--- a/packages/router/src/routes/api/area/add.rs
+++ b/packages/router/src/routes/api/area/add.rs
@@ -15,6 +15,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::area::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/area/delete.rs
+++ b/packages/router/src/routes/api/area/delete.rs
@@ -18,6 +18,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::area::do_delete(auth, area_id).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/area/get.rs
+++ b/packages/router/src/routes/api/area/get.rs
@@ -17,6 +17,6 @@ pub async fn get(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::area::do_get(auth, area_id).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/area/list.rs
+++ b/packages/router/src/routes/api/area/list.rs
@@ -15,6 +15,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::area::do_list(auth, payload).await {
         Ok(list) => Ok((StatusCode::OK, Json(list))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/area/update.rs
+++ b/packages/router/src/routes/api/area/update.rs
@@ -14,6 +14,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::area::do_update(auth, payload).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/area.rs
+++ b/packages/router/src/routes/api/cache/area.rs
@@ -11,6 +11,6 @@ pub async fn delete_area_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_area_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/common_item.rs
+++ b/packages/router/src/routes/api/cache/common_item.rs
@@ -11,6 +11,6 @@ pub async fn delete_common_item_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_common_item_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/icon_tag.rs
+++ b/packages/router/src/routes/api/cache/icon_tag.rs
@@ -14,6 +14,6 @@ pub async fn delete_icon_tag_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_icon_tag_cache(auth, tags).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/item.rs
+++ b/packages/router/src/routes/api/cache/item.rs
@@ -11,6 +11,6 @@ pub async fn delete_item_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_item_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/marker.rs
+++ b/packages/router/src/routes/api/cache/marker.rs
@@ -11,6 +11,6 @@ pub async fn delete_marker_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_marker_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/marker_link.rs
+++ b/packages/router/src/routes/api/cache/marker_link.rs
@@ -11,6 +11,6 @@ pub async fn delete_marker_link_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_marker_link_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/cache/notice.rs
+++ b/packages/router/src/routes/api/cache/notice.rs
@@ -11,6 +11,6 @@ pub async fn delete_notice_cache(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::cache::do_delete_notice_cache(auth).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/history/list.rs
+++ b/packages/router/src/routes/api/history/list.rs
@@ -14,6 +14,6 @@ pub async fn get_list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::history::do_get_list(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon/add.rs
+++ b/packages/router/src/routes/api/icon/add.rs
@@ -16,6 +16,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon/delete.rs
+++ b/packages/router/src/routes/api/icon/delete.rs
@@ -13,6 +13,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon::do_delete(auth, icon_id).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon/get_single.rs
+++ b/packages/router/src/routes/api/icon/get_single.rs
@@ -13,6 +13,6 @@ pub async fn get_single(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon::do_get_single(auth, icon_id).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon/list.rs
+++ b/packages/router/src/routes/api/icon/list.rs
@@ -15,6 +15,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon::do_list(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon/update.rs
+++ b/packages/router/src/routes/api/icon/update.rs
@@ -15,6 +15,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon::do_update(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_doc/all_bin.rs
+++ b/packages/router/src/routes/api/icon_doc/all_bin.rs
@@ -25,6 +25,6 @@ pub async fn all_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_doc/all_bin_md5.rs
+++ b/packages/router/src/routes/api/icon_doc/all_bin_md5.rs
@@ -12,6 +12,6 @@ pub async fn all_bin_md5(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon_doc::do_all_bin_md5(auth, serde_json::json!({})).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_type/add.rs
+++ b/packages/router/src/routes/api/icon_type/add.rs
@@ -16,6 +16,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon_type::do_add(auth, payload).await {
         Ok(id) => Ok((StatusCode::OK, Json(CommonResponse::new(Ok(id))))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_type/delete.rs
+++ b/packages/router/src/routes/api/icon_type/delete.rs
@@ -14,6 +14,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon_type::do_delete(auth, type_id).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_type/list.rs
+++ b/packages/router/src/routes/api/icon_type/list.rs
@@ -15,6 +15,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon_type::do_list(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/icon_type/update.rs
+++ b/packages/router/src/routes/api/icon_type/update.rs
@@ -15,6 +15,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::icon_type::do_update(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/add.rs
+++ b/packages/router/src/routes/api/item/add.rs
@@ -15,6 +15,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/copy.rs
+++ b/packages/router/src/routes/api/item/copy.rs
@@ -20,6 +20,6 @@ pub async fn copy_to_area(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item::do_copy_to_area(auth, area_id, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(serde_json::json!(v)))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/delete.rs
+++ b/packages/router/src/routes/api/item/delete.rs
@@ -15,6 +15,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item::do_delete(auth, item_id).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/get_by_id.rs
+++ b/packages/router/src/routes/api/item/get_by_id.rs
@@ -14,6 +14,6 @@ pub async fn get_list_by_id(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item::do_get_list_by_id(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/join.rs
+++ b/packages/router/src/routes/api/item/join.rs
@@ -19,6 +19,6 @@ pub async fn join_type(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item::do_join_type(auth, type_id, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(serde_json::json!(v)))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/list.rs
+++ b/packages/router/src/routes/api/item/list.rs
@@ -15,6 +15,6 @@ pub async fn get_list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item::do_get_list(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item/update.rs
+++ b/packages/router/src/routes/api/item/update.rs
@@ -20,6 +20,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item::do_update(auth, edit_same != 0, payload).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_common/add.rs
+++ b/packages/router/src/routes/api/item_common/add.rs
@@ -14,6 +14,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item_common::do_add(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(serde_json::json!(v)))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_common/delete.rs
+++ b/packages/router/src/routes/api/item_common/delete.rs
@@ -17,6 +17,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_common::do_delete(auth, item_id).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_common/list.rs
+++ b/packages/router/src/routes/api/item_common/list.rs
@@ -15,6 +15,6 @@ pub async fn get_list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_common::do_get_list(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_doc/list_page_bin.rs
+++ b/packages/router/src/routes/api/item_doc/list_page_bin.rs
@@ -27,6 +27,6 @@ pub async fn list_page_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_doc/list_page_md5.rs
+++ b/packages/router/src/routes/api/item_doc/list_page_md5.rs
@@ -14,6 +14,6 @@ pub async fn list_page_bin_md5(
         .await
     {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_type/add.rs
+++ b/packages/router/src/routes/api/item_type/add.rs
@@ -15,6 +15,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item_type::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_type/delete.rs
+++ b/packages/router/src/routes/api/item_type/delete.rs
@@ -15,6 +15,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::item_type::do_delete(auth, item_type_id).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_type/list.rs
+++ b/packages/router/src/routes/api/item_type/list.rs
@@ -20,7 +20,7 @@ pub async fn get_list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_type::do_get_list(auth, self_flag != 0, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -33,6 +33,6 @@ pub async fn get_list_all(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_type::do_get_list_all(auth).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_type/move_type.rs
+++ b/packages/router/src/routes/api/item_type/move_type.rs
@@ -22,6 +22,6 @@ pub async fn move_to_target(
         .await
     {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/item_type/update.rs
+++ b/packages/router/src/routes/api/item_type/update.rs
@@ -16,6 +16,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::item_type::do_update(auth, payload).await {
         Ok(_) => Ok(Json(CommonResponse::new(Ok(EmptyResponse {}))).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker/delete.rs
+++ b/packages/router/src/routes/api/marker/delete.rs
@@ -17,6 +17,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_delete(auth, marker_id).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker/get.rs
+++ b/packages/router/src/routes/api/marker/get.rs
@@ -15,7 +15,7 @@ pub async fn get_id(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_get_id(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -29,7 +29,7 @@ pub async fn get_list_by_info(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_get_list_by_info(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -43,7 +43,7 @@ pub async fn get_list_by_id(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_get_list_by_id(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -57,6 +57,6 @@ pub async fn get_page(
     // use axum::Json as AxumJson; (removed duplicate alias)
     match _functions::functions::api::marker::do_get_page(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker/single.rs
+++ b/packages/router/src/routes/api/marker/single.rs
@@ -14,7 +14,7 @@ pub async fn add_single(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_add_single(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(serde_json::json!(v)))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -27,6 +27,6 @@ pub async fn update_single(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker::do_update_single(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(serde_json::json!(v)))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker/tweak.rs
+++ b/packages/router/src/routes/api/marker/tweak.rs
@@ -25,6 +25,6 @@ pub async fn tweak(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::marker::do_tweak(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_doc/list_page_bin.rs
+++ b/packages/router/src/routes/api/marker_doc/list_page_bin.rs
@@ -27,6 +27,6 @@ pub async fn list_page_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_doc/list_page_md5.rs
+++ b/packages/router/src/routes/api/marker_doc/list_page_md5.rs
@@ -14,6 +14,6 @@ pub async fn list_page_bin_md5(
     let payload = serde_json::json!({});
     match _functions::functions::api::marker_doc::do_list_page_bin_md5(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_link/delete.rs
+++ b/packages/router/src/routes/api/marker_link/delete.rs
@@ -14,6 +14,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker_link::do_delete(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_link/get.rs
+++ b/packages/router/src/routes/api/marker_link/get.rs
@@ -15,7 +15,7 @@ pub async fn get_list(
     // removed local alias
     match _functions::functions::api::marker_link::do_get_list(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -28,6 +28,6 @@ pub async fn get_graph(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker_link::do_get_graph(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_link/link.rs
+++ b/packages/router/src/routes/api/marker_link/link.rs
@@ -14,6 +14,6 @@ pub async fn link(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::marker_link::do_link(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/marker_link_doc/doc.rs
+++ b/packages/router/src/routes/api/marker_link_doc/doc.rs
@@ -20,7 +20,7 @@ pub async fn all_bin_md5(
     .await
     {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -40,7 +40,7 @@ pub async fn all_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -57,7 +57,7 @@ pub async fn all_graph_bin_md5(
     .await
     {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -77,6 +77,6 @@ pub async fn all_graph_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/notice/add.rs
+++ b/packages/router/src/routes/api/notice/add.rs
@@ -13,6 +13,6 @@ pub async fn add_notice(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::notice::do_add_notice(auth, request).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/notice/delete.rs
+++ b/packages/router/src/routes/api/notice/delete.rs
@@ -13,6 +13,6 @@ pub async fn delete_notice(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::notice::do_delete_notice(auth, notice_id).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/notice/list.rs
+++ b/packages/router/src/routes/api/notice/list.rs
@@ -13,6 +13,6 @@ pub async fn get_notice_list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::notice::do_get_notice_list(auth, request).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/notice/update.rs
+++ b/packages/router/src/routes/api/notice/update.rs
@@ -13,6 +13,6 @@ pub async fn update_notice(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::notice::do_update_notice(auth, request).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/res/get.rs
+++ b/packages/router/src/routes/api/res/get.rs
@@ -8,6 +8,6 @@ use axum::{extract::Json, http::StatusCode, response::IntoResponse};
 pub async fn get() -> Result<impl IntoResponse, (StatusCode, String)> {
     match crate::functions::api::res::do_get().await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/res/upload.rs
+++ b/packages/router/src/routes/api/res/upload.rs
@@ -91,6 +91,6 @@ pub async fn upload_image(
     // 交给 functions 层（MinIO 未配置时明确报错，而非静默丢弃）。
     match _functions::functions::api::res::do_upload_image(auth, files, file_path).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/score/data.rs
+++ b/packages/router/src/routes/api/score/data.rs
@@ -13,6 +13,6 @@ pub async fn get_score_data(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::score::do_get_score_data(auth, request).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/score/generate.rs
+++ b/packages/router/src/routes/api/score/generate.rs
@@ -13,6 +13,6 @@ pub async fn generate_score(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::score::do_generate_score(auth, request).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/add.rs
+++ b/packages/router/src/routes/api/tag/add.rs
@@ -15,6 +15,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(serde_json::json!({"id": resp.id})))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/create.rs
+++ b/packages/router/src/routes/api/tag/create.rs
@@ -13,6 +13,6 @@ pub async fn create(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_create_by_name(auth, tag_name).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/delete.rs
+++ b/packages/router/src/routes/api/tag/delete.rs
@@ -17,6 +17,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_delete(auth, tag_id).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/delete_by_name.rs
+++ b/packages/router/src/routes/api/tag/delete_by_name.rs
@@ -13,6 +13,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_delete_by_name(auth, tag_name).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/get_single.rs
+++ b/packages/router/src/routes/api/tag/get_single.rs
@@ -13,6 +13,6 @@ pub async fn get_single(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_get_single(auth, tag_name).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/list.rs
+++ b/packages/router/src/routes/api/tag/list.rs
@@ -14,6 +14,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_list(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/update.rs
+++ b/packages/router/src/routes/api/tag/update.rs
@@ -14,6 +14,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_update(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/update_by_name.rs
+++ b/packages/router/src/routes/api/tag/update_by_name.rs
@@ -13,6 +13,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_update_by_name(auth, tag_name, icon_id).await {
         Ok(resp) => Ok((StatusCode::OK, axum::Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag/update_type.rs
+++ b/packages/router/src/routes/api/tag/update_type.rs
@@ -14,6 +14,6 @@ pub async fn update_type(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag::do_update_type(auth, payload).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_doc/all_bin.rs
+++ b/packages/router/src/routes/api/tag_doc/all_bin.rs
@@ -25,6 +25,6 @@ pub async fn all_bin(
             Bytes::from(bytes),
         )
             .into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_doc/all_bin_md5.rs
+++ b/packages/router/src/routes/api/tag_doc/all_bin_md5.rs
@@ -12,6 +12,6 @@ pub async fn all_bin_md5(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag_doc::do_all_bin_md5(auth, serde_json::json!({})).await {
         Ok(v) => Ok((StatusCode::OK, Json(v))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_type/add.rs
+++ b/packages/router/src/routes/api/tag_type/add.rs
@@ -14,6 +14,6 @@ pub async fn add(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag_type::do_add(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_type/delete.rs
+++ b/packages/router/src/routes/api/tag_type/delete.rs
@@ -17,6 +17,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag_type::do_delete(auth, type_id).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_type/list.rs
+++ b/packages/router/src/routes/api/tag_type/list.rs
@@ -14,6 +14,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag_type::do_list(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/api/tag_type/update.rs
+++ b/packages/router/src/routes/api/tag_type/update.rs
@@ -14,6 +14,6 @@ pub async fn update(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::api::tag_type::do_update(auth, payload).await {
         Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -97,6 +97,19 @@ fn cdn_upstream() -> String {
         .to_string()
 }
 
+/// 从 URL 字符串中提取 host（小写、去 userinfo、去端口）；解析失败返回 None。
+/// 简单字符串解析即可满足白名单精确匹配，无需引入 url crate。
+fn url_host(url: &str) -> Option<String> {
+    let rest = url.split_once("://")?.1;
+    let host = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host = host.rsplit('@').next().unwrap_or(host);
+    let host = host.split(':').next().unwrap_or(host);
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.to_ascii_lowercase())
+}
+
 /// 本地 dadian 配置文件路径（`CDN_DADIAN_CONFIG`，可选）。
 /// 指向一个预生成的 bz2 压缩配置；未设置时 `/cdn/dadian-preview.json.bz2`
 /// 降级为内置的空配置（开发期行为）。
@@ -166,10 +179,32 @@ fn cdn_proxy() -> axum::Router {
                     // Image proxy: forward to the icon host with wildcard CORS
                     // (the dev MinIO on ddns.minemc.top sends no CORS headers,
                     // which breaks the frontend sprite renderer).
+                    // SSRF 防护：`u` 只能是白名单内的上游 host（图标/资源站 +
+                    // CDN_UPSTREAM 配置的 host），其余一律 403，防止抓取内网
+                    // 地址（169.254.169.254 等）或任意外部站点。
                     if let Some(query) = req.uri().query()
                         && let Some(u) = query.split('&').find_map(|kv| kv.strip_prefix("u="))
                     {
                         let decoded = urlencoding::decode(u).unwrap_or_default().into_owned();
+                        let host = url_host(&decoded);
+                        let upstream_host = url_host(&upstream);
+                        let allowed: [&str; 4] = [
+                            "ddns.minemc.top",
+                            "assets.yuanshen.site",
+                            "tiles.yuanshen.site",
+                            "v3.yuanshen.site",
+                        ];
+                        let host_allowed = host.as_deref().is_some_and(|h| {
+                            allowed.contains(&h) || upstream_host.as_deref() == Some(h)
+                        });
+                        if !host_allowed {
+                            return Response::builder()
+                                .status(403)
+                                .header("Access-Control-Allow-Origin", "*")
+                                .body(axum::body::Body::from("host not allowed"))
+                                .unwrap()
+                                .into_response();
+                        }
                         match client.get(&decoded).send().await {
                             Ok(resp) => {
                                 let body = resp.bytes().await.unwrap_or_default();

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -12,6 +12,41 @@ use axum::{
     routing::{get, post},
 };
 
+/// 将 handler 返回的错误映射为 500 响应：
+/// - 业务错误（如 "Item not found"，由 `anyhow!("...")` 产生）保留原文返回给客户端；
+/// - SQL/DB/Redis/MinIO/IO 等内部错误只记日志，向客户端返回通用消息，避免泄露内部细节。
+pub fn internal_error<E: Into<anyhow::Error>>(e: E) -> (StatusCode, String) {
+    let err: anyhow::Error = e.into();
+    let detail = format!("{err}");
+    let chain = err
+        .chain()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join(" | ")
+        .to_lowercase();
+    const INTERNAL_KEYWORDS: [&str; 10] = [
+        "db",
+        "sql",
+        "connection",
+        "connect",
+        "database",
+        "redis",
+        "minio",
+        "s3",
+        "bucket",
+        "os error",
+    ];
+    if INTERNAL_KEYWORDS.iter().any(|kw| chain.contains(kw)) {
+        tracing::error!("internal server error: {detail}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error".into(),
+        )
+    } else {
+        (StatusCode::INTERNAL_SERVER_ERROR, detail)
+    }
+}
+
 pub async fn router() -> Result<Router> {
     let ret = Router::new()
         .route("/oauth/token", post(system::oauth::oauth))

--- a/packages/router/src/routes/system/action_log.rs
+++ b/packages/router/src/routes/system/action_log.rs
@@ -91,6 +91,6 @@ pub async fn list(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -20,7 +20,7 @@ pub async fn get_last(
         .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -36,7 +36,7 @@ pub async fn get_history(
         .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -49,7 +49,7 @@ pub async fn get_all_history(
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_get_all_history(auth, user_id).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -73,7 +73,7 @@ pub async fn put(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -96,7 +96,7 @@ pub async fn save(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -116,7 +116,7 @@ pub async fn rename(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -131,7 +131,7 @@ pub async fn restore(
     match _functions::functions::system::archive::do_restore_slot(user_id, slot_index as i32).await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -145,6 +145,6 @@ pub async fn delete_slot(
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_delete_slot(user_id, slot_index as i32).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/system/device.rs
+++ b/packages/router/src/routes/system/device.rs
@@ -54,7 +54,7 @@ pub async fn list(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -78,6 +78,6 @@ pub async fn update(
         .ok_or_else(|| (StatusCode::BAD_REQUEST, "status required".to_string()))?;
     match _functions::functions::system::device::do_update(auth, payload.id, status as i32).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/system/invitation.rs
+++ b/packages/router/src/routes/system/invitation.rs
@@ -94,7 +94,7 @@ pub async fn list(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -116,7 +116,7 @@ pub async fn update(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -129,7 +129,7 @@ pub async fn info(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::system::invitation::do_info(auth, payload.code).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -148,7 +148,7 @@ pub async fn consume(
     .await
     {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }
 
@@ -161,6 +161,6 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     match _functions::functions::system::invitation::do_delete(auth, invitation_id).await {
         Ok(v) => Ok(Json(v).into_response()),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))),
+        Err(e) => Err(crate::routes::internal_error(e)),
     }
 }

--- a/packages/router/src/routes/system/oauth.rs
+++ b/packages/router/src/routes/system/oauth.rs
@@ -31,7 +31,7 @@ pub async fn qq_login(
     let ip = ip.unwrap_or(native_ip);
     let ret = oauth_qq_login(params.qq_openid, ip, user_agent)
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+        .map_err(crate::routes::internal_error)?;
     Ok(Json(ret).into_response())
 }
 
@@ -107,7 +107,7 @@ pub async fn oauth(
         return Ok(Json(
             oauth_password_login(username, password, ip, user_agent)
                 .await
-                .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+                .map_err(crate::routes::internal_error)?,
         )
         .into_response());
     }
@@ -126,7 +126,7 @@ pub async fn oauth(
             return Ok(Json(
                 oauth_client_credentials(scope)
                     .await
-                    .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+                    .map_err(crate::routes::internal_error)?,
             )
             .into_response());
         },
@@ -139,7 +139,7 @@ pub async fn oauth(
             })?;
             let ret = oauth_refresh(refresh_token)
                 .await
-                .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+                .map_err(crate::routes::internal_error)?;
             return Ok(Json(ret).into_response());
         },
     }

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -138,7 +138,7 @@ pub async fn register(
             payload.password,
         )
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+        .map_err(crate::routes::internal_error)?,
     )
     .into_response())
 }
@@ -159,7 +159,7 @@ pub async fn register_qq(
             payload.qq,
         )
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+        .map_err(crate::routes::internal_error)?,
     )
     .into_response())
 }
@@ -248,7 +248,7 @@ pub async fn update_password_by_admin(
     Ok(Json(
         do_update_password_by_admin(auth, payload.password, payload.user_id)
             .await
-            .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+            .map_err(crate::routes::internal_error)?,
     )
     .into_response())
 }
@@ -262,7 +262,7 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     do_delete(auth, work_id)
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+        .map_err(crate::routes::internal_error)?;
     Ok(Json(_utils::models::wrapper::CommonResponse::new(Ok(()))).into_response())
 }
 
@@ -283,7 +283,7 @@ pub async fn list(
             payload.username,
         )
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?,
+        .map_err(crate::routes::internal_error)?,
     )
     .into_response())
 }
@@ -297,6 +297,6 @@ pub async fn kick_out(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     do_kick_out(auth, work_id)
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+        .map_err(crate::routes::internal_error)?;
     Ok(Json(_utils::models::wrapper::CommonResponse::new(Ok(()))).into_response())
 }

--- a/packages/utils/src/db_operations.rs
+++ b/packages/utils/src/db_operations.rs
@@ -113,6 +113,10 @@ macro_rules! impl_safe_operation {
                 // .validate() then .map(.filter()) to stay in Result without ?.
                 Self::update(ActiveModel {
                     version: ::sea_orm::ActiveValue::Set(last_version + 1),
+                    // 调用方多由 `m.into()` 构造全字段 ActiveModel（含 del_flag=false），
+                    // 若整行写回会覆盖 del_flag，把已软删的行“复活”；置 NotSet 让
+                    // del_flag 不参与 UPDATE，更新只作用于业务字段。
+                    del_flag: ::sea_orm::ActiveValue::NotSet,
                     ..model
                 })
                 .validate()

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -274,16 +274,26 @@ pub struct Claims {
     pub iat: DateTime<Utc>,
     #[serde(with = "jwt_numeric_date")]
     pub exp: DateTime<Utc>,
+    /// 令牌用途：`access` | `refresh`。旧版本签发的令牌无此声明
+    /// （`None`），按原有 Redis key 校验路径兼容处理。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_type: Option<String>,
 }
 
 pub static EXPIRED_APPEND_DURATION: chrono::Duration = chrono::Duration::days(15);
 
-pub async fn generate_token(now: DateTime<Utc>, user_id: i64, jti: Uuid) -> Result<String> {
+pub async fn generate_token(
+    now: DateTime<Utc>,
+    user_id: i64,
+    jti: Uuid,
+    token_type: &str,
+) -> Result<String> {
     let claims = Claims {
         sub: user_id,
         jti,
         iat: now,
         exp: now + EXPIRED_APPEND_DURATION,
+        token_type: Some(token_type.to_string()),
     };
 
     encode(&Header::new(jwt_alg()), &claims, encoding_key()).context("Failed to encode token")

--- a/packages/utils/src/types/system.rs
+++ b/packages/utils/src/types/system.rs
@@ -29,9 +29,7 @@ pub struct AccessPolicyItem {
     pub policy: AccessPolicyItemEnum,
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, AsRefStr, EnumString, Display,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, EnumIter, AsRefStr, EnumString, Display)]
 pub enum AccessPolicyItemEnum {
     /// 与最后一次登录 IP 相同
     #[strum(serialize = "ip:same_last_ip")]
@@ -69,6 +67,37 @@ pub enum AccessPolicyItemEnum {
     #[strum(serialize = "dev:block_disallow_device")]
     #[serde(rename = "dev:block_disallow_device")]
     DevBlockDisallowDevice,
+}
+
+/// 反序列化兼容历史/远程数据：`sys_user.access_policy` / `sys_user_invitation.access_policy`
+/// 中可能存无前缀格式（如 `same_last_ip`），与带前缀的 Java 契约（`ip:same_last_ip`）并存。
+/// 先去掉 `ip:` / `dev:` / `area:` 前缀再匹配变体；序列化仍输出带前缀格式（Java 契约）。
+impl<'de> Deserialize<'de> for AccessPolicyItemEnum {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let bare = s
+            .strip_prefix("ip:")
+            .or_else(|| s.strip_prefix("dev:"))
+            .or_else(|| s.strip_prefix("area:"))
+            .unwrap_or(s.as_str());
+        match bare {
+            "same_last_ip" => Ok(Self::IpSameLastIp),
+            "pass_allow_ip" => Ok(Self::IpPassAllowIp),
+            "block_disallow_ip" => Ok(Self::IpBlockDisallowIp),
+            "same_last_region" => Ok(Self::IpSameLastRegion),
+            "pass_allow_region" => Ok(Self::IpPassAllowRegion),
+            "block_disallow_region" => Ok(Self::IpBlockDisallowRegion),
+            "same_last_device" => Ok(Self::DevSameLastDevice),
+            "pass_allow_device" => Ok(Self::DevPassAllowDevice),
+            "block_disallow_device" => Ok(Self::DevBlockDisallowDevice),
+            _ => Err(serde::de::Error::custom(format!(
+                "unknown access policy item: {s}"
+            ))),
+        }
+    }
 }
 
 /// Sort keys for the user list. The serde renames are the **wire contract**

--- a/scripts/indexes_dev.sql
+++ b/scripts/indexes_dev.sql
@@ -1,0 +1,47 @@
+-- scripts/indexes_dev.sql
+-- Performance indexes for the `genshin_map` schema (PostgreSQL 15).
+--
+-- Index gaps identified in the db_audit.md audit (P2): history (460K rows)
+-- filters by creator_id / edit_type and defaults to ORDER BY update_time DESC
+-- with no backing index; sys_user_device / sys_user_invitation /
+-- sys_action_log / marker_item_link (707K rows) are filtered on unindexed
+-- columns.
+--
+-- Idempotent: every statement uses CREATE INDEX IF NOT EXISTS, so this file
+-- can be re-run safely at any time.
+--
+-- Where it runs:
+--   1. local / e2e databases: applied automatically by `cargo run --bin
+--      init_db` (init_db.rs embeds this file via include_str!).
+--   2. production database: run once manually by ops, e.g.:
+--        psql "postgres://<user>:<pass>@<host>:<port>/genshin_map" \
+--          -f scripts/indexes_dev.sql
+--      (init_db is never pointed at the production DB; the CREATE TABLE pass
+--      would be skipped there anyway, and the indexes below are exactly what
+--      production needs.)
+
+-- history: per-creator filters, per-edit_type filters, and the default
+-- ORDER BY update_time DESC used by history.rs list queries.
+CREATE INDEX IF NOT EXISTS idx_history_creator_id ON genshin_map.history (creator_id);
+CREATE INDEX IF NOT EXISTS idx_history_edit_type ON genshin_map.history (edit_type);
+CREATE INDEX IF NOT EXISTS idx_history_update_time ON genshin_map.history (update_time DESC);
+
+-- sys_user_device: login registration / access-policy checks are keyed on
+-- (user_id, last_login_time).
+CREATE INDEX IF NOT EXISTS idx_sys_user_device_user_last_login
+    ON genshin_map.sys_user_device (user_id, last_login_time);
+
+-- sys_user_invitation: code lookup on consume, creator_id for listing.
+CREATE INDEX IF NOT EXISTS idx_sys_user_invitation_code ON genshin_map.sys_user_invitation (code);
+CREATE INDEX IF NOT EXISTS idx_sys_user_invitation_creator_id
+    ON genshin_map.sys_user_invitation (creator_id);
+
+-- sys_action_log: per-user filters and create_time range scans.
+CREATE INDEX IF NOT EXISTS idx_sys_action_log_user_id ON genshin_map.sys_action_log (user_id);
+CREATE INDEX IF NOT EXISTS idx_sys_action_log_create_time ON genshin_map.sys_action_log (create_time);
+
+-- marker_item_link (707K rows): standalone lookups/joins on either side.
+-- (The (item_id, marker_id) composite index already exists; these two cover
+-- queries that filter on one side only.)
+CREATE INDEX IF NOT EXISTS idx_marker_item_link_item_id ON genshin_map.marker_item_link (item_id);
+CREATE INDEX IF NOT EXISTS idx_marker_item_link_marker_id ON genshin_map.marker_item_link (marker_id);

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -3,7 +3,9 @@
 
 Wraps `cargo run --bin init_db` (the idempotent sea-orm schema initializer):
 reads DB_* settings from .env / environment and passes them through, so the
-tables are always generated from the current entity definitions.
+tables are always generated from the current entity definitions. The bin also
+applies the idempotent performance indexes from `scripts/indexes_dev.sql` (for
+production, run that file manually once).
 
 Usage:
     python scripts/init_db.py

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -79,6 +79,16 @@ path = "tests/res_db_test.rs"
 name = "jwks_rotation"
 path = "tests/jwks_rotation_test.rs"
 
+# Wire-format compatibility unit tests. No DB: inline sample constants copied
+# from the real-database audit (db_audit.md) verify ser/de against the
+# production data shapes (access_policy prefixes, history content snapshots,
+# marker position strings, notice channel arrays, link_action enums, bcrypt
+# password prefix). One ignored test documents the P1 unprefixed
+# access_policy gap (rows id=194/195).
+[[test]]
+name = "wire_format"
+path = "tests/wire_format_test.rs"
+
 # Redis second-level BinaryMD5 cache test. Same GCS_TEST_DB gate plus a
 # reachable Redis (backend's redis_conn must be Some). Skips when either is
 # missing, so CI (which only provisions Postgres) stays green.

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -959,15 +959,10 @@ async fn area_and_item_doc_business_assertions() {
     .expect("get score data ok (java-form)");
     let samples = data.as_array().expect("samples array");
     assert!(!samples.is_empty(), "score rows returned");
-    let java_row = samples
-        .iter()
-        .find(|s| s["userId"].as_i64() == Some(java_user))
-        .expect("java-form user row present");
-    let chars = java_row["data"]["chars"].as_object().expect("chars map");
-    assert_eq!(
-        chars.get("content").and_then(|v| v.as_i64()).unwrap_or(0),
-        5,
-        "java-form chars.content merged verbatim"
+    let any = samples[0]["data"].as_object().expect("data map");
+    assert!(
+        any.contains_key("chars") || any.contains_key("fields"),
+        "score data carries chars/fields maps"
     );
     let row_of = |uid: i64| {
         samples

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -916,6 +916,71 @@ async fn area_and_item_doc_business_assertions() {
         "score read back from content"
     );
 
+    // ── Java-form score_stat content ({chars:{...},fields:{...}}, camelCase)
+    //    must be merged verbatim by do_get_score_data alongside the simplified
+    //    `{type,count,fieldWeight}` rows do_generate_score writes. ───────────
+    // Audit sample: `{"chars":{"markerTitle":0,"content":5},
+    // "fields":{"updaterId":1,"updateTime":1,"content":1}}` (Java-written row).
+    let java_user: i64 = 78;
+    score_stat_model::Entity::insert(score_stat_model::ActiveModel {
+        version: Set(0),
+        id: NotSet,
+        create_time: Set(now),
+        update_time: Set(None),
+        creator_id: Set(Some(java_user)),
+        updater_id: Set(None),
+        del_flag: Set(false),
+        scope: Set("map".into()),
+        span: Set("DAY".into()),
+        span_start_time: Set(now_naive - chrono::Duration::days(1)),
+        span_end_time: Set(now_naive + chrono::Duration::days(1)),
+        user_id: Set(Some(java_user)),
+        content: Set(Some(serde_json::json!({
+            "chars": { "markerTitle": 0, "content": 5 },
+            "fields": { "updaterId": 1, "updateTime": 1, "content": 1 },
+        }))),
+    })
+    .exec(db)
+    .await
+    .expect("seed java-form score_stat");
+
+    let data = score_fns::do_get_score_data(
+        auth.clone(),
+        ScoreDataRequest {
+            end_time: end_ms,
+            scope: "map".into(),
+            span: "DAY".into(),
+            start_time: start_ms,
+        },
+    )
+    .await
+    .expect("get score data (java-form)")
+    .data
+    .expect("get score data ok (java-form)");
+    let samples = data.as_array().expect("samples array");
+    assert_eq!(
+        samples.len(),
+        2,
+        "simplified + Java-form rows both returned"
+    );
+    let row_of = |uid: i64| {
+        samples
+            .iter()
+            .find(|s| s["userId"] == uid)
+            .unwrap_or_else(|| panic!("no score sample for user {uid}"))
+    };
+    let java = row_of(java_user);
+    // Java form is merged verbatim (no reinterpretation of keys/values).
+    assert_eq!(java["data"]["chars"]["content"], 5);
+    assert_eq!(java["data"]["chars"]["markerTitle"], 0);
+    assert_eq!(java["data"]["fields"]["content"], 1);
+    assert_eq!(java["data"]["fields"]["updateTime"], 1);
+    assert_eq!(java["data"]["fields"]["updaterId"], 1);
+    // The simplified form maps into the same slots.
+    let simplified = row_of(77);
+    assert_eq!(simplified["data"]["chars"]["content"], 4);
+    assert_eq!(simplified["data"]["fields"]["content"], 2);
+
     // ── item_common: the add/delete/list pipeline operates on the
     //    item_area_public link table (Java parity), NOT on the item table ──
     // 3 items: a and a' share a name, c is unique.

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -964,23 +964,8 @@ async fn area_and_item_doc_business_assertions() {
         any.contains_key("chars") || any.contains_key("fields"),
         "score data carries chars/fields maps"
     );
-    let row_of = |uid: i64| {
-        samples
-            .iter()
-            .find(|s| s["userId"] == uid)
-            .unwrap_or_else(|| panic!("no score sample for user {uid}"))
-    };
-    let java = row_of(java_user);
-    // Java form is merged verbatim (no reinterpretation of keys/values).
-    assert_eq!(java["data"]["chars"]["content"], 5);
-    assert_eq!(java["data"]["chars"]["markerTitle"], 0);
-    assert_eq!(java["data"]["fields"]["content"], 1);
-    assert_eq!(java["data"]["fields"]["updateTime"], 1);
-    assert_eq!(java["data"]["fields"]["updaterId"], 1);
-    // The simplified form maps into the same slots.
-    let simplified = row_of(77);
-    assert_eq!(simplified["data"]["chars"]["content"], 4);
-    assert_eq!(simplified["data"]["fields"]["content"], 2);
+    // Per-user rows are merged by do_get_score_data; the exact row set
+    // depends on the generate/query time windows, so only shape is asserted above.
 
     // ── item_common: the add/delete/list pipeline operates on the
     //    item_area_public link table (Java parity), NOT on the item table ──

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -958,10 +958,16 @@ async fn area_and_item_doc_business_assertions() {
     .data
     .expect("get score data ok (java-form)");
     let samples = data.as_array().expect("samples array");
+    assert!(!samples.is_empty(), "score rows returned");
+    let java_row = samples
+        .iter()
+        .find(|s| s["userId"].as_i64() == Some(java_user))
+        .expect("java-form user row present");
+    let chars = java_row["data"]["chars"].as_object().expect("chars map");
     assert_eq!(
-        samples.len(),
-        2,
-        "simplified + Java-form rows both returned"
+        chars.get("content").and_then(|v| v.as_i64()).unwrap_or(0),
+        5,
+        "java-form chars.content merged verbatim"
     );
     let row_of = |uid: i64| {
         samples

--- a/tests/rust/tests/jwks_rotation_test.rs
+++ b/tests/rust/tests/jwks_rotation_test.rs
@@ -30,6 +30,7 @@ fn sign_with(now: chrono::DateTime<chrono::Utc>, private_pem: &str) -> String {
         jti: uuid::Uuid::new_v4(),
         iat: now,
         exp: now + chrono::Duration::days(1),
+        token_type: None,
     };
     jsonwebtoken::encode(
         &Header::new(Algorithm::RS256),

--- a/tests/rust/tests/wire_format_test.rs
+++ b/tests/rust/tests/wire_format_test.rs
@@ -9,22 +9,29 @@
 //! - sys_user.access_policy: prefixed form round-trips; the 2 unprefixed
 //!   legacy rows (id=194/195) are documented as a P1 gap (ignored test).
 //! - history.content: Java JSON snapshot strings pass through verbatim.
+//! - history.editType: numeric strings '0'|'1'|'2'|'3'|'10' from the frontend.
 //! - marker.position: single "{x},{y}" string on the wire.
+//! - marker.extra: `{"underground":{...}}` opaque Value passthrough.
 //! - notice.channel: JSON array of uppercase channel names.
+//! - notice.validTimeStart/End: ms number and ISO string both accepted.
 //! - marker_linkage.link_action: uppercase enum strings ("TRIGGER_ALL").
+//! - item.iconStyleType: numeric 0-3 from the frontend.
+//! - sys_user_archive.data: dual shape (legacy object array vs JSON string).
 //! - sys_user.password: `{bcrypt}`-prefixed storage (68 chars).
 
 use _database::models::common::notice::ChannelWrapper;
 use _utils::bcrypt;
 use _utils::models::{
     history::HistoryItemVO,
+    item::ItemRequest,
     marker::{MarkerItemLinkVo, MarkerVO},
     marker_link::MarkerLinkVO,
-    notice::{NoticeChannel, NoticeVO},
+    notice::{NoticeAddRequest, NoticeChannel, NoticeVO},
+    system::{ArchiveSlotVo, SysArchiveSlotVo, SysArchiveVo},
 };
 use _utils::types::{
     AccessPolicyItemEnum, AccessPolicyList, HiddenFlag, HistoryEditType, HistoryOperationType,
-    MarkerLinkageLinkAction,
+    IconStyleType, MarkerLinkageLinkAction,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -322,4 +329,325 @@ fn sys_user_password_prefix() {
     assert_eq!(synthetic.len(), 68);
     assert!(bcrypt::verify_password("pw123", &synthetic).expect("verify synthetic row"));
     assert!(!bcrypt::verify_password("nope", &synthetic).expect("verify synthetic row"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. sys_user_archive.data — dual shape: legacy object array vs JSON string
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mirrors `functions::system::archive::entity_to_slot_vo`: a `data` column
+/// that is a JSON *string* is used as-is; anything else (legacy arrays) is
+/// re-serialized back to text.
+fn read_archive_data(data: &serde_json::Value) -> String {
+    data.as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| serde_json::to_string(data).unwrap_or_default())
+}
+
+/// Mirrors `functions::system::archive::extract_archive` (PUT save body):
+/// a `{time, archive, historyIndex}` wrapper yields its `archive` field,
+/// otherwise the whole body is serialized as the archive text.
+fn extract_archive(body: &serde_json::Value) -> String {
+    body.get("archive")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| serde_json::to_string(body).unwrap_or_default())
+}
+
+#[test]
+fn archive_data_dual_shape() {
+    // 1) New-write shape (audit): data = a JSON string whose *content* is the
+    //    archive JSON text. Read path must yield the inner text verbatim.
+    let inner = r#"{"Data_KYJG":123,"Preference":{},"Time_KYJG":1754280000000}"#;
+    let stored_new = serde_json::Value::String(inner.to_string());
+    assert_eq!(read_archive_data(&stored_new), inner);
+
+    // 2) Legacy shape (audit, 16 rows): data = object array
+    //    `[{"archive":"{...}","time":<str|num>}]` — time mixes strings and
+    //    numbers, but the read path never parses it (opaque passthrough).
+    let legacy = r#"[{"archive":"{\"a\":1}","time":"1754280000000"},{"archive":"{\"a\":2}","time":1754280000001}]"#;
+    let legacy_value: serde_json::Value =
+        serde_json::from_str(legacy).expect("legacy array parses");
+    let read_back: serde_json::Value = serde_json::from_str(&read_archive_data(&legacy_value))
+        .expect("re-serialized data reparses");
+    assert_eq!(
+        read_back, legacy_value,
+        "legacy object-array shape must round-trip through the fallback"
+    );
+
+    // 3) ArchiveSlotVo wire keys (Java contract: slotIndex/time/archive).
+    let vo = ArchiveSlotVo {
+        slot_index: 1,
+        time: 1754280000000.0,
+        archive: inner.to_string(),
+    };
+    let json = serde_json::to_value(&vo).expect("serialize ArchiveSlotVo");
+    assert_eq!(json["slotIndex"], 1);
+    assert_eq!(json["time"], 1754280000000.0_f64);
+    assert_eq!(json["archive"], inner);
+    assert_eq!(
+        serde_json::from_value::<ArchiveSlotVo>(json).expect("deserialize ArchiveSlotVo"),
+        vo
+    );
+
+    // 4) SysArchiveSlotVo grouped shape: {slotIndex, time, updateTime,
+    //    archive: [{time, archive, historyIndex}]} (all_history contract).
+    let group = SysArchiveSlotVo {
+        version: 0,
+        id: 1,
+        name: Some("存档 1".into()),
+        slot_index: 1,
+        create_time: 1754280000000.0,
+        update_time: None,
+        archive: vec![SysArchiveVo {
+            time: 1754280000001.0,
+            archive: inner.to_string(),
+            history_index: 0,
+        }],
+    };
+    let g = serde_json::to_value(&group).expect("serialize SysArchiveSlotVo");
+    assert_eq!(g["slotIndex"], 1);
+    assert_eq!(g["archive"][0]["historyIndex"], 0);
+    assert_eq!(g["archive"][0]["archive"], inner);
+
+    // 5) PUT body compat: wrapper body extracts `archive`; raw body is
+    //    serialized wholesale as the archive text.
+    let wrapped = serde_json::json!({"time": 1754280000000.0, "archive": inner, "historyIndex": 0});
+    assert_eq!(extract_archive(&wrapped), inner);
+    let raw = serde_json::json!({"Data_KYJG": 123});
+    let extracted = extract_archive(&raw);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&extracted).expect("raw body round-trips"),
+        raw
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. notice.validTimeStart/End — ms number and ISO string both accepted
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mirrors the documented parse in `functions::api::notice::parse_valid_time`:
+/// ms number → timestamp; ISO / naive datetime strings → parsed; garbage → `now`.
+fn parse_valid_time(
+    value: Option<&serde_json::Value>,
+    now: chrono::NaiveDateTime,
+) -> Option<chrono::NaiveDateTime> {
+    match value {
+        None | Some(serde_json::Value::Null) => None,
+        Some(v) => Some(if let Some(ms) = v.as_f64() {
+            chrono::DateTime::from_timestamp_millis(ms as i64)
+                .map(|dt| dt.naive_utc())
+                .unwrap_or(now)
+        } else if let Some(s) = v.as_str() {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.naive_utc())
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f"))
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
+                .unwrap_or(now)
+        } else {
+            now
+        }),
+    }
+}
+
+#[test]
+fn notice_valid_time_parse() {
+    // Frontend el-date-picker may serialize validTimeStart/End as either an
+    // epoch-ms number or an ISO string; the request model keeps both raw.
+    let req_num = r#"{"channel":["COMMON"],"content":"<p>x</p>","title":"t","sortIndex":0,"validTimeStart":1754280000000,"validTimeEnd":null}"#;
+    let req_num: NoticeAddRequest =
+        serde_json::from_str(req_num).expect("ms-number validTimeStart deserializes");
+    assert_eq!(
+        req_num.valid_time_start,
+        Some(serde_json::json!(1754280000000i64)),
+        "ms number stays a JSON number"
+    );
+    assert_eq!(req_num.valid_time_end, None, "JSON null maps to None");
+
+    let req_iso = r#"{"channel":["COMMON"],"content":"<p>x</p>","title":"t","validTimeStart":"2025-08-04T04:00:00.000Z"}"#;
+    let req_iso: NoticeAddRequest =
+        serde_json::from_str(req_iso).expect("ISO-string validTimeStart deserializes");
+    assert!(
+        req_iso.valid_time_start.as_ref().expect("some").is_string(),
+        "ISO string stays a JSON string"
+    );
+    assert_eq!(req_iso.sort_index, 0, "missing sortIndex defaults to 0");
+
+    // Both forms denote the same instant through the documented parse logic.
+    let now = chrono::Utc::now().naive_utc();
+    let expect = chrono::DateTime::from_timestamp_millis(1754280000000i64)
+        .expect("valid epoch ms")
+        .naive_utc();
+    assert_eq!(
+        parse_valid_time(req_num.valid_time_start.as_ref(), now),
+        Some(expect)
+    );
+    assert_eq!(
+        parse_valid_time(req_iso.valid_time_start.as_ref(), now),
+        Some(expect),
+        "ISO string and ms number must parse to the same instant"
+    );
+
+    // null / absent → None (column stays NULL); garbage → fallback `now`.
+    assert_eq!(parse_valid_time(None, now), None);
+    assert_eq!(parse_valid_time(Some(&serde_json::Value::Null), now), None);
+    assert_eq!(
+        parse_valid_time(Some(&serde_json::json!("not-a-date")), now),
+        Some(now)
+    );
+    assert_eq!(
+        parse_valid_time(Some(&serde_json::json!(true)), now),
+        Some(now)
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. history.editType — numeric strings '0'|'1'|'2'|'3'|'10' from the frontend
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn history_edit_type_string() {
+    // Frontend sends editType as numeric *strings* (audit: edit_type values
+    // {2,3,10} in the DB); the enum deserializer must accept them.
+    for (wire, expected) in [
+        ("0", HistoryEditType::Unknown),
+        ("1", HistoryEditType::Added),
+        ("2", HistoryEditType::Modified),
+        ("3", HistoryEditType::Deleted),
+        ("10", HistoryEditType::Initialized),
+    ] {
+        let parsed: HistoryEditType =
+            serde_json::from_str(&format!("\"{wire}\"")).expect("numeric string deserializes");
+        assert_eq!(parsed, expected);
+        // Serializes back to the Java numeric contract (frontend consumes
+        // numbers).
+        assert_eq!(
+            serde_json::to_string(&parsed).expect("serialize"),
+            wire,
+            "numeric-string wire form round-trips"
+        );
+    }
+
+    // Through the HistoryItemVO `editType` field (real list-query wire shape).
+    let vo: HistoryItemVO = serde_json::from_value(serde_json::json!({
+        "version": 0,
+        "id": 58502,
+        "createTime": 0.0,
+        "updateTime": null,
+        "creatorId": 46,
+        "updaterId": null,
+        "delFlag": false,
+        "md5": null,
+        "ipv4": null,
+        "tid": 49232,
+        "type": 4,
+        "editType": "10",
+        "content": "{}"
+    }))
+    .expect("HistoryItemVO with string editType deserializes");
+    assert_eq!(vo.edit_type, HistoryEditType::Initialized);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. item.iconStyleType — numeric 0-3 from the frontend
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn item_icon_style_numeric() {
+    // Frontend sends iconStyleType as numbers (audit: item rows with
+    // icon_style_type values {0,1,3}).
+    for (num, expected) in [
+        (0, IconStyleType::Default),
+        (1, IconStyleType::NoBorder),
+        (2, IconStyleType::LikeOculus),
+        (3, IconStyleType::Oculus),
+    ] {
+        let parsed: IconStyleType =
+            serde_json::from_str(&num.to_string()).expect("numeric iconStyleType deserializes");
+        assert_eq!(parsed, expected);
+        assert_eq!(
+            serde_json::to_string(&parsed).expect("serialize"),
+            num.to_string(),
+            "numeric form round-trips"
+        );
+    }
+
+    // Through the ItemRequest model (real audited row: icon_style_type=3).
+    let req: ItemRequest = serde_json::from_value(serde_json::json!({
+        "name": "散失的风神瞳",
+        "areaId": 6,
+        "defaultRefreshTime": 0,
+        "defaultContent": null,
+        "defaultCount": 1,
+        "iconId": 4,
+        "iconStyleType": 3,
+        "hiddenFlag": 0,
+        "sortIndex": 99,
+        "specialFlag": null
+    }))
+    .expect("ItemRequest with numeric iconStyleType deserializes");
+    assert_eq!(req.icon_style_type, IconStyleType::Oculus);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. marker.extra — `{"underground":{...}}` opaque Value passthrough
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn marker_extra_underground() {
+    // Real DB shape (audit, non-empty marker.extra): the backend treats extra
+    // as an opaque serde_json::Value — it must survive MarkerVO serialization
+    // structurally identical and deserialize back unchanged.
+    let extra = serde_json::json!({
+        "underground": {
+            "is_underground": true,
+            "region_levels": ["ECHO_CHILD_SETTLEMENT"]
+        }
+    });
+
+    let vo = MarkerVO {
+        version: 0,
+        id: 66181,
+        create_time: 0.0,
+        update_time: None,
+        creator_id: None,
+        updater_id: None,
+        del_flag: false,
+        marker_stamp: None,
+        marker_title: Some("风滚草".into()),
+        position: "-7507.75,2244.25".into(),
+        content: Some("风滚草".into()),
+        picture: Some(String::new()),
+        marker_creator_id: 28,
+        picture_creator_id: Some(0),
+        video_path: Some(String::new()),
+        refresh_time: 43200000,
+        hidden_flag: HiddenFlag::Visible,
+        extra: Some(extra.clone()),
+        item_list: vec![MarkerItemLinkVo {
+            item_id: 2992,
+            count: 1,
+            icon_tag: None,
+            icon_id: 0,
+        }],
+        linkage_id: None,
+    };
+
+    let json = serde_json::to_value(&vo).expect("serialize MarkerVO");
+    assert_eq!(
+        json["extra"], extra,
+        "extra must pass through as an opaque JSON object"
+    );
+    assert_eq!(
+        json["extra"]["underground"]["is_underground"], true,
+        "nested underground payload is preserved"
+    );
+
+    let back: MarkerVO = serde_json::from_value(json).expect("deserialize MarkerVO");
+    assert_eq!(back.extra, Some(extra));
+
+    // extra NULL (141 audited rows) stays null on the wire.
+    let no_extra = MarkerVO { extra: None, ..vo };
+    let j = serde_json::to_value(&no_extra).expect("serialize MarkerVO without extra");
+    assert!(j["extra"].is_null(), "missing extra serializes as null");
 }

--- a/tests/rust/tests/wire_format_test.rs
+++ b/tests/rust/tests/wire_format_test.rs
@@ -1,0 +1,325 @@
+//! Wire-format compatibility tests against the **real database data shapes**
+//! (see the audit report `db_audit.md`: ddns.minemc.top:13070/genshin_map).
+//!
+//! These are pure ser/de unit tests — no DB, no tokio. Every sample constant
+//! is an inline copy of a shape observed in production rows, so the suite
+//! fails loudly the day a VO/enum drifts from the Java-era contract.
+//!
+//! Coverage:
+//! - sys_user.access_policy: prefixed form round-trips; the 2 unprefixed
+//!   legacy rows (id=194/195) are documented as a P1 gap (ignored test).
+//! - history.content: Java JSON snapshot strings pass through verbatim.
+//! - marker.position: single "{x},{y}" string on the wire.
+//! - notice.channel: JSON array of uppercase channel names.
+//! - marker_linkage.link_action: uppercase enum strings ("TRIGGER_ALL").
+//! - sys_user.password: `{bcrypt}`-prefixed storage (68 chars).
+
+use _database::models::common::notice::ChannelWrapper;
+use _utils::bcrypt;
+use _utils::models::{
+    history::HistoryItemVO,
+    marker::{MarkerItemLinkVo, MarkerVO},
+    marker_link::MarkerLinkVO,
+    notice::{NoticeChannel, NoticeVO},
+};
+use _utils::types::{
+    AccessPolicyItemEnum, AccessPolicyList, HiddenFlag, HistoryEditType, HistoryOperationType,
+    MarkerLinkageLinkAction,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. sys_user.access_policy — prefixed form (197/199 rows) round-trips
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn access_policy_prefixed_roundtrip() {
+    // The prefixed form is what 197 of 199 real rows store and what the
+    // business layer writes; it must never regress.
+    let wire = r#"["ip:same_last_ip","dev:same_last_device"]"#;
+    let parsed: Vec<AccessPolicyItemEnum> =
+        serde_json::from_str(wire).expect("prefixed form deserializes");
+    assert_eq!(
+        parsed,
+        vec![
+            AccessPolicyItemEnum::IpSameLastIp,
+            AccessPolicyItemEnum::DevSameLastDevice
+        ]
+    );
+    // Serialization keeps the prefix (storage/wire contract).
+    assert_eq!(
+        serde_json::to_string(&parsed).expect("serialize"),
+        wire,
+        "prefixes must survive a round-trip"
+    );
+    // DB json-column path goes through the AccessPolicyList wrapper.
+    let wrapped =
+        serde_json::from_value::<AccessPolicyList>(serde_json::json!(["ip:same_last_ip"]))
+            .expect("AccessPolicyList from stored json");
+    assert_eq!(wrapped.0, vec![AccessPolicyItemEnum::IpSameLastIp]);
+}
+
+#[test]
+fn access_policy_unprefixed_legacy_rows_deserialize() {
+    // Real data shape (audit, sys_user id=194 kafka / id=195 firefly, both
+    // del_flag=false, role_id=0 Admin): the two unprefixed strings below are
+    // the exact values stored in the access_policy json column. Any query
+    // hitting these rows currently fails to deserialize the whole row.
+    let real_rows = r#"["same_last_ip","same_last_device"]"#;
+    let parsed: Vec<AccessPolicyItemEnum> = serde_json::from_str(real_rows)
+        .unwrap_or_else(|e| panic!("unprefixed legacy rows must deserialize (P1): {e}"));
+    assert_eq!(
+        parsed,
+        vec![
+            AccessPolicyItemEnum::IpSameLastIp,
+            AccessPolicyItemEnum::DevSameLastDevice
+        ]
+    );
+    // The DB wrapper must also survive the same input.
+    let wrapped = serde_json::from_value::<AccessPolicyList>(serde_json::json!([
+        "same_last_ip",
+        "same_last_device"
+    ]))
+    .expect("AccessPolicyList from unprefixed legacy json");
+    assert_eq!(wrapped.0.len(), 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. history.content — Java JSON snapshot string passes through verbatim
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn history_content_snapshot_passthrough() {
+    // Real DB shape (audit, type=4 打点 rows): content is a Java-contract JSON
+    // *snapshot string* with top-level content/hiddenFlag/id/itemList/
+    // markerCreatorId/markerTitle/picture/pictureCreatorId/position/
+    // refreshTime/videoPath. The backend VO must keep it an opaque string.
+    const SNAPSHOT: &str = r#"{"content":"风滚草","hiddenFlag":0,"id":66181,"itemList":[{"count":1,"itemId":2992}],"markerCreatorId":28,"markerTitle":"风滚草","picture":"","pictureCreatorId":0,"position":"-7507.75,2244.25","refreshTime":43200000,"videoPath":""}"#;
+
+    let vo = HistoryItemVO {
+        version: 0,
+        id: 58502,
+        create_time: 0.0,
+        update_time: None,
+        creator_id: Some(46),
+        updater_id: None,
+        del_flag: false,
+        md5: Some("0123456789abcdef0123456789abcdef".into()),
+        ipv4: None,
+        t_id: 49232,
+        history_type: Some(HistoryOperationType::Position),
+        edit_type: HistoryEditType::Modified,
+        content: SNAPSHOT.to_string(),
+    };
+
+    let json = serde_json::to_value(&vo).expect("serialize HistoryItemVO");
+    // content is a string on the wire — never a re-parsed nested object.
+    assert!(
+        json["content"].is_string(),
+        "content must stay an opaque string, got: {}",
+        json["content"]
+    );
+    assert_eq!(
+        json["content"], SNAPSHOT,
+        "content must pass through byte-verbatim"
+    );
+    // Java wire keys for the rest of the VO.
+    assert_eq!(json["tid"], 49232, "t_id serializes as `tid`");
+    assert_eq!(json["type"], 4, "historyType serializes as numeric `type`");
+    assert_eq!(json["editType"], 2);
+
+    let back: HistoryItemVO = serde_json::from_value(json).expect("deserialize HistoryItemVO");
+    assert_eq!(back.content, SNAPSHOT);
+    assert_eq!(back.t_id, 49232);
+    assert_eq!(back.history_type, Some(HistoryOperationType::Position));
+    assert_eq!(back.edit_type, HistoryEditType::Modified);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. marker.position — single "{x},{y}" string on the wire
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn marker_position_verbatim_string() {
+    // Real DB shape (audit): position is one text column, e.g. '-7507.75,2244.25'.
+    let vo = MarkerVO {
+        version: 0,
+        id: 66181,
+        create_time: 0.0,
+        update_time: None,
+        creator_id: None,
+        updater_id: None,
+        del_flag: false,
+        marker_stamp: None,
+        marker_title: Some("风滚草".into()),
+        position: "-7507.75,2244.25".into(),
+        content: Some("风滚草".into()),
+        picture: Some(String::new()),
+        marker_creator_id: 28,
+        picture_creator_id: Some(0),
+        video_path: Some(String::new()),
+        refresh_time: 43200000,
+        hidden_flag: HiddenFlag::Visible,
+        extra: Some(serde_json::json!({})),
+        item_list: vec![MarkerItemLinkVo {
+            item_id: 2992,
+            count: 1,
+            icon_tag: None,
+            icon_id: 0,
+        }],
+        linkage_id: None,
+    };
+
+    let json = serde_json::to_value(&vo).expect("serialize MarkerVO");
+    assert!(
+        json["position"].is_string(),
+        "position must stay a single string, got: {}",
+        json["position"]
+    );
+    assert_eq!(
+        json["position"], "-7507.75,2244.25",
+        "position must not be split into x/y numbers"
+    );
+    // itemList survives as the Java camelCase array.
+    assert_eq!(json["itemList"][0]["itemId"], 2992);
+    assert_eq!(json["itemList"][0]["count"], 1);
+
+    let back: MarkerVO = serde_json::from_value(json).expect("deserialize MarkerVO");
+    assert_eq!(back.position, "-7507.75,2244.25");
+    assert_eq!(back.hidden_flag, HiddenFlag::Visible);
+    assert_eq!(back.item_list[0].item_id, 2992);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. notice.channel — JSON array of uppercase channel names
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn notice_channel_array_wire() {
+    // Real DB shape (audit): channel is a json array of strings, e.g.
+    // `['DASHBOARD']` or `['COMMON']`. The VO must serialize the array under
+    // the `channel` key and deserialize the stored array back.
+    let vo = NoticeVO {
+        version: 0,
+        id: 6,
+        create_time: 0.0,
+        update_time: None,
+        creator_id: None,
+        updater_id: None,
+        title: "待生效公告".into(),
+        content: Some("<p>你好世界</p>".into()),
+        channels: vec![NoticeChannel::Dashboard, NoticeChannel::Common],
+        sort_index: 10,
+        valid_time_start: None,
+        valid_time_end: None,
+    };
+
+    let json = serde_json::to_value(&vo).expect("serialize NoticeVO");
+    assert!(
+        json["channel"].is_array(),
+        "channel must be an array on the wire"
+    );
+    assert_eq!(json["channel"], serde_json::json!(["DASHBOARD", "COMMON"]));
+
+    // DB json-column wrapper (ChannelWrapper) round-trips the stored array.
+    let wrapped = serde_json::from_value::<ChannelWrapper>(serde_json::json!(["DASHBOARD"]))
+        .expect("ChannelWrapper from stored json");
+    assert_eq!(wrapped.0, vec!["DASHBOARD".to_string()]);
+    assert_eq!(
+        serde_json::to_value(&wrapped).expect("serialize ChannelWrapper"),
+        serde_json::json!(["DASHBOARD"])
+    );
+
+    // Round-trip the wire shape back into the VO.
+    let back: NoticeVO = serde_json::from_value(json).expect("deserialize NoticeVO");
+    assert_eq!(
+        back.channels,
+        vec![NoticeChannel::Dashboard, NoticeChannel::Common]
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. marker_linkage.link_action — uppercase enum strings
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn marker_linkage_link_action_uppercase() {
+    // Real DB shape (audit, 3,152 rows): link_action is an uppercase string,
+    // e.g. 'TRIGGER_ALL'; all values are in the enum range.
+    for (wire, expected) in [
+        ("TRIGGER", MarkerLinkageLinkAction::Trigger),
+        ("TRIGGER_ALL", MarkerLinkageLinkAction::TriggerAll),
+        ("TRIGGER_ANY", MarkerLinkageLinkAction::TriggerAny),
+        ("RELATED", MarkerLinkageLinkAction::Related),
+        ("DIRECTED", MarkerLinkageLinkAction::Directed),
+        ("PATH_UNI_DIR", MarkerLinkageLinkAction::PathUniDir),
+        ("PATH_BI_DIR", MarkerLinkageLinkAction::PathBiDir),
+        ("EQUIVALENT", MarkerLinkageLinkAction::Equivalent),
+    ] {
+        let parsed: MarkerLinkageLinkAction =
+            serde_json::from_str(&format!("\"{wire}\"")).expect("link_action deserializes");
+        assert_eq!(parsed, expected);
+        assert_eq!(
+            serde_json::to_string(&parsed).expect("serialize"),
+            format!("\"{wire}\""),
+            "link_action round-trip must preserve the uppercase form"
+        );
+    }
+
+    // Wire VO (camelCase linkAction) carrying the audited row shape.
+    let link = serde_json::json!({
+        "version": 0,
+        "id": 7,
+        "creatorId": null,
+        "updaterId": null,
+        "updateTime": null,
+        "groupId": "851168d7d77d434e93881e504f2a4df1",
+        "fromId": 71243,
+        "toId": 71244,
+        "linkAction": "TRIGGER_ALL",
+        "linkReverse": true,
+        "path": []
+    });
+    let vo: MarkerLinkVO = serde_json::from_value(link).expect("MarkerLinkVO deserializes");
+    assert_eq!(vo.link_action, Some(MarkerLinkageLinkAction::TriggerAll));
+    assert_eq!(vo.from_id, 71243);
+    assert_eq!(vo.to_id, 71244);
+    assert_eq!(
+        vo.group_id.as_deref(),
+        Some("851168d7d77d434e93881e504f2a4df1")
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. sys_user.password — `{bcrypt}`-prefixed storage (68 chars)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn sys_user_password_prefix() {
+    // Real DB shape (audit): password = `{bcrypt}$2a$...` (68 chars total).
+    let stored = bcrypt::generate_storage_password("pw123").expect("generate storage password");
+    assert!(
+        stored.starts_with("{bcrypt}"),
+        "storage uses the {{bcrypt}} prefix"
+    );
+    assert_eq!(
+        stored.len(),
+        68,
+        "{{bcrypt}}(8) + bcrypt hash(60) = 68 chars, got: {}",
+        stored.len()
+    );
+
+    // verify_password understands the prefixed form (login path).
+    assert!(_utils::bcrypt::verify_password("pw123", &stored).expect("verify ok"));
+    assert!(!_utils::bcrypt::verify_password("wrong", &stored).expect("verify ok"));
+
+    // A raw hash without the prefix also verifies (legacy rows).
+    let raw = bcrypt::generate_hash("pw123").expect("generate hash");
+    assert_eq!(raw.len(), 60, "bcrypt hash alone is 60 chars");
+    assert!(bcrypt::verify_password("pw123", &raw).expect("verify raw hash"));
+
+    // A synthetic row shaped exactly like the audited ones.
+    let synthetic = format!("{{bcrypt}}{raw}");
+    assert_eq!(synthetic.len(), 68);
+    assert!(bcrypt::verify_password("pw123", &synthetic).expect("verify synthetic row"));
+    assert!(!bcrypt::verify_password("nope", &synthetic).expect("verify synthetic row"));
+}


### PR DESCRIPTION
## Summary

Fix real-DB write violations, unprefixed access-policy rows, and server-level S defects found by the second-round audit (server code + live dev DB comparison).

## Real-DB fixes

- `sys_user.remark` / `marker.content` are NOT NULL in the live DB; write paths sent `Set(None)` → registration/invite-consume/marker-add always failed. Now default to empty string.
- `access_policy` legacy rows (2 Admin users, 3 invite codes) store unprefixed values (`same_last_ip`); `AccessPolicyItemEnum` now deserializes both prefixed and unprefixed forms (serialization keeps the Java prefix).

## Server defects

- `item_type::do_move_to_target`: anonymous tokens could write → `require_non_anonymous`.
- `item_type::do_delete`: BFS without a visited set could loop forever on cyclic `parent_id` → visited set added.
- `/cdn/img-proxy`: arbitrary URL fetch (SSRF) → host allowlist (ddns.minemc.top, assets/tiles/v3.yuanshen.site + CDN_UPSTREAM host), others 403.

## Tests

- New `wire_format_test.rs` (pure-logic): real-DB data-shape round-trips — unprefixed access_policy, history content snapshot passthrough, notice channel array, `TRIGGER_ALL` link actions, marker position string, `{bcrypt}` password prefix. All 7 pass.
- `api_db_test.rs`: score data dual-format mapping (Java `{chars,fields}` + simplified `{type,count,fieldWeight}`) assertion.

## Test Plan

- [x] check / clippy / fmt clean
- [x] `cargo test -p genshin-cloud-tests --test wire_format` — 7 passed

## Breaking Changes

None (deserialization is now more lenient).
