### PR TITLE
🐛 Harden JWT with issuer/audience claims, HS256 opt-in, and longer refresh TTL.

### DIFF
--- a/packages/functions/src/functions/api/binary_doc.rs
+++ b/packages/functions/src/functions/api/binary_doc.rs
@@ -277,9 +277,15 @@ pub async fn get_result_cached(
         RESULT_CACHE.insert(key.clone(), entries.clone()).await;
         return Ok(entries);
     }
+    // compute 前记录 epoch：compute 期间若有写操作 invalidate（bump epoch），
+    // 计算结果是陈旧数据，复检不一致则丢弃回填（下次请求自然重新计算），
+    // 防止「失效 = 没失效」竞态把旧结果写进新 epoch 键。
+    let epoch_before = redis_epoch().await;
     let result = compute.await?;
-    RESULT_CACHE.insert(key.clone(), result.clone()).await;
-    redis_store(&key, &result).await;
+    if redis_epoch().await == epoch_before {
+        RESULT_CACHE.insert(key.clone(), result.clone()).await;
+        redis_store(&key, &result).await;
+    }
     Ok(result)
 }
 

--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -405,6 +405,10 @@ pub async fn do_copy_to_area(
             am.area_id = Set(area_id);
             am.create_time = Set(chrono::Utc::now().naive_utc());
             am.update_time = Set(None);
+            // 新行乐观锁从 0 起步，创建/更新人归 None（与 do_add 语义一致）
+            am.version = Set(0);
+            am.creator_id = Set(None);
+            am.updater_id = Set(None);
             let res = am.insert(&DB_CONN.wait().pg_conn).await?;
             let new_id = res.id;
             // 复制类型关联

--- a/packages/functions/src/functions/api/marker_link.rs
+++ b/packages/functions/src/functions/api/marker_link.rs
@@ -62,6 +62,9 @@ pub async fn do_link(
                 if let Some(action) = p.link_action {
                     am.link_action = Set(action);
                 }
+                if let Some(reverse) = p.link_reverse {
+                    am.link_reverse = Set(reverse);
+                }
                 am.path = Set(p.path.and_then(|v| serde_json::to_value(v).ok()));
                 linkage_model::Entity::update_safety(am)?.exec(db).await?;
                 continue;
@@ -85,7 +88,7 @@ pub async fn do_link(
             link_action: Set(p
                 .link_action
                 .unwrap_or(_utils::types::MarkerLinkageLinkAction::Trigger)),
-            link_reverse: Set(false),
+            link_reverse: Set(p.link_reverse.unwrap_or(false)),
             path: Set(p.path.and_then(|v| serde_json::to_value(v).ok())),
             extra: Set(None),
         };

--- a/packages/functions/src/functions/system/archive.rs
+++ b/packages/functions/src/functions/system/archive.rs
@@ -44,7 +44,7 @@ fn extract_archive(body: &serde_json::Value) -> String {
 pub async fn do_get_last(
     _auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
 ) -> Result<CommonResponse<Option<ArchiveSlotVo>>> {
     let db = &DB_CONN.wait().pg_conn;
     let archive = archive_model::Entity::find_safety()
@@ -60,7 +60,7 @@ pub async fn do_get_last(
 pub async fn do_get_history(
     _auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
 ) -> Result<CommonResponse<Vec<serde_json::Value>>> {
     let db = &DB_CONN.wait().pg_conn;
     let items = archive_model::Entity::find_safety()
@@ -150,7 +150,7 @@ const MAX_HISTORY_PER_SLOT: u64 = 20;
 async fn prune_slot_history(
     db: &sea_orm::DatabaseConnection,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
 ) -> Result<()> {
     let keep_ids: Vec<i64> = archive_model::Entity::find_safety()
         .filter(archive_model::Column::UserId.eq(user_id))
@@ -184,13 +184,16 @@ async fn prune_slot_history(
 pub async fn do_save(
     auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
     name: Option<String>,
     body: serde_json::Value,
 ) -> Result<CommonResponse<serde_json::Value>> {
     // 写操作：匿名（client_credentials，uid=0）一律拒绝——否则所有匿名
     // 客户端共享 uid=0 档案，互相覆盖/读取。
     auth.require_non_anonymous()?;
+    // 槽位列类型为 i32：路由层已限定 0..=4，此处兜底做收窄校验，不做截断
+    let slot_index: i32 =
+        i32::try_from(slot_index).map_err(|_| anyhow!("slot_index out of range"))?;
     let db = &DB_CONN.wait().pg_conn;
     let archive = extract_archive(&body);
     // create_time 由服务端定，不信任客户端传入的 time（防止时间戳伪造/脏数据）
@@ -211,7 +214,7 @@ pub async fn do_save(
     };
     let res = archive_model::Entity::insert(am).exec(db).await?;
     // 写入后按上限清理最旧历史
-    prune_slot_history(db, user_id, slot_index).await?;
+    prune_slot_history(db, user_id, slot_index.into()).await?;
     Ok(CommonResponse::new(Ok(serde_json::json!({
         "id": res.last_insert_id
     }))))
@@ -239,7 +242,7 @@ pub async fn do_rename(auth: AuthInfo, id: i64, name: String) -> Result<CommonRe
 pub async fn do_rename_by_slot(
     auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
     new_name: String,
 ) -> Result<CommonResponse<()>> {
     auth.require_non_anonymous()?;
@@ -277,7 +280,7 @@ pub async fn do_restore(auth: AuthInfo, id: i64) -> Result<CommonResponse<serde_
 pub async fn do_restore_slot(
     auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
 ) -> Result<CommonResponse<Option<ArchiveSlotVo>>> {
     // 恢复即删除最新一条历史，属写操作
     auth.require_non_anonymous()?;
@@ -307,7 +310,7 @@ pub async fn do_restore_slot(
 pub async fn do_delete_slot(
     auth: AuthInfo,
     user_id: i64,
-    slot_index: i32,
+    slot_index: i64,
 ) -> Result<CommonResponse<()>> {
     auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;

--- a/packages/functions/src/functions/system/invitation.rs
+++ b/packages/functions/src/functions/system/invitation.rs
@@ -204,10 +204,12 @@ pub async fn do_consume(
     let username = username
         .filter(|u| !u.is_empty())
         .unwrap_or_else(|| code.clone());
-    // 前端注册流程必带密码；缺省时生成随机密码（邀请人可再通过管理员改密）
+    // 前端注册流程必带密码；缺省时生成随机密码（邀请人可再通过管理员改密）。
+    // 随机短串（uuid 前 12 位）替代 `{code}_{timestamp}`：后者可从邀请码与
+    // 时间戳推算，随机串不可推算。
     let password = password
         .filter(|p| !p.is_empty())
-        .unwrap_or_else(|| format!("{}_{}", code, now.and_utc().timestamp()));
+        .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string()[..12].to_string());
 
     // 事务内完成「查邀请 → 抢占消费 → 建用户」，防并发重复消费
     let txn = db.begin().await?;

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -178,8 +178,22 @@ async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLogi
     let access_jti = Uuid::now_v7();
     let refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, item.id, access_jti, "access").await?;
-    let refresh_token = generate_token(now, item.id, refresh_jti, "refresh").await?;
+    let access_token = generate_token(
+        now,
+        item.id,
+        access_jti,
+        "access",
+        chrono::Duration::days(15),
+    )
+    .await?;
+    let refresh_token = generate_token(
+        now,
+        item.id,
+        refresh_jti,
+        "refresh",
+        chrono::Duration::days(30),
+    )
+    .await?;
 
     let id = item.id;
     let vo: SysUserVO = item.clone().into();
@@ -525,8 +539,10 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
     let access_jti = Uuid::now_v7();
     let refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, id, access_jti, "access").await?;
-    let _refresh_token = generate_token(now, id, refresh_jti, "refresh").await?;
+    let access_token =
+        generate_token(now, id, access_jti, "access", chrono::Duration::days(15)).await?;
+    let _refresh_token =
+        generate_token(now, id, refresh_jti, "refresh", chrono::Duration::days(30)).await?;
 
     // Redis 不可用时静默跳过（与 issue_token 一致）：降级模式下
     // `oauth_parse_token` 对 sub=0 特判构造匿名 VO，不发 Redis 键也能解析；
@@ -652,8 +668,22 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
     let new_access_jti = Uuid::now_v7();
     let new_refresh_jti = Uuid::now_v7();
     let now = chrono::Utc::now();
-    let access_token = generate_token(now, claims.sub, new_access_jti, "access").await?;
-    let refresh_token_new = generate_token(now, claims.sub, new_refresh_jti, "refresh").await?;
+    let access_token = generate_token(
+        now,
+        claims.sub,
+        new_access_jti,
+        "access",
+        chrono::Duration::days(15),
+    )
+    .await?;
+    let refresh_token_new = generate_token(
+        now,
+        claims.sub,
+        new_refresh_jti,
+        "refresh",
+        chrono::Duration::days(30),
+    )
+    .await?;
 
     // 写入新的 access/refresh 条目（payload 取 DB 最新用户信息，
     // 不再依赖旧 access key 的缓存内容）

--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -13,7 +13,7 @@ use _database::{DB_CONN, models};
 use _utils::{
     bcrypt::verify_password,
     db_operations::SafeEntityTrait,
-    jwt::{Claims, EXPIRED_APPEND_DURATION, generate_token, verify_token},
+    jwt::{Claims, EXPIRED_APPEND_DURATION, REFRESH_APPEND_DURATION, generate_token, verify_token},
     models::SysUserVO,
     types::{
         AccessPolicyItemEnum, AccessPolicyList, SystemActionLogAction, SystemUserRole,
@@ -222,7 +222,7 @@ async fn issue_token(item: &models::system::sys_user::Model) -> Result<OauthLogi
                 SetOptions::default()
                     .conditional_set(redis::ExistenceCheck::NX)
                     .with_expiration(redis::SetExpiry::EX(
-                        EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
+                        REFRESH_APPEND_DURATION.as_seconds_f32() as u64,
                     )),
             )
             .await;
@@ -571,7 +571,7 @@ pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousRes
                 SetOptions::default()
                     .conditional_set(redis::ExistenceCheck::NX)
                     .with_expiration(redis::SetExpiry::EX(
-                        EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
+                        REFRESH_APPEND_DURATION.as_seconds_f32() as u64,
                     )),
             )
             .await;
@@ -710,7 +710,7 @@ pub async fn oauth_refresh(refresh_token: String) -> Result<OauthLoginResponse> 
             SetOptions::default()
                 .conditional_set(redis::ExistenceCheck::NX)
                 .with_expiration(redis::SetExpiry::EX(
-                    EXPIRED_APPEND_DURATION.as_seconds_f32() as u64,
+                    REFRESH_APPEND_DURATION.as_seconds_f32() as u64,
                 )),
         )
         .await

--- a/packages/router/src/middlewares/auth_extrator.rs
+++ b/packages/router/src/middlewares/auth_extrator.rs
@@ -26,11 +26,14 @@ where
             TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state).await
         {
             let token = bearer.token().to_string();
-            let (info, claims) = oauth_parse_token(token).await.map_err(|err| {
+            // 401 固定文案：不回显 verify_token 的内部错误（算法/签名细节）
+            let (info, claims) = oauth_parse_token(token).await.map_err(|_| {
                 (
                     StatusCode::UNAUTHORIZED,
-                    serde_json::to_string(&CommonResponse::<()>::new(Err(err)))
-                        .expect("Failed to serialize error response"),
+                    serde_json::to_string(&CommonResponse::<()>::new(Err(anyhow!(
+                        "Invalid or expired token"
+                    ))))
+                    .expect("Failed to serialize error response"),
                 )
                     .into_response()
             })?;

--- a/packages/router/src/routes/system/archive.rs
+++ b/packages/router/src/routes/system/archive.rs
@@ -8,6 +8,18 @@ use axum::{
 
 use crate::middlewares::ExtractAuthInfo;
 
+/// 槽位范围校验（route 层收口）：前端契约固定 5 个存档槽位（0..=4），
+/// 超限直接返回 400。校验通过后 i64 原值透传 do_*，不做 `as i32` 截断。
+fn check_slot_index(slot_index: i64) -> Result<(), (StatusCode, String)> {
+    if !(0..=4).contains(&slot_index) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "slot_index must be in range 0..=4".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// 获取指定槽位的最新存档
 /// GET /archive/last/{slot_index}
 #[tracing::instrument(skip(auth))]
@@ -15,10 +27,9 @@ pub async fn get_last(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
-    match _functions::functions::system::archive::do_get_last(auth, user_id, slot_index as i32)
-        .await
-    {
+    match _functions::functions::system::archive::do_get_last(auth, user_id, slot_index).await {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err(crate::routes::internal_error(e)),
     }
@@ -31,10 +42,9 @@ pub async fn get_history(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
-    match _functions::functions::system::archive::do_get_history(auth, user_id, slot_index as i32)
-        .await
-    {
+    match _functions::functions::system::archive::do_get_history(auth, user_id, slot_index).await {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err(crate::routes::internal_error(e)),
     }
@@ -62,11 +72,12 @@ pub async fn put(
     Path((slot_index, name)): Path<(i64, String)>,
     Json(payload): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_save(
         auth,
         user_id,
-        slot_index as i32,
+        slot_index,
         Some(name),
         payload,
     )
@@ -85,15 +96,10 @@ pub async fn save(
     Path(slot_index): Path<i64>,
     Json(payload): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
-    match _functions::functions::system::archive::do_save(
-        auth,
-        user_id,
-        slot_index as i32,
-        None,
-        payload,
-    )
-    .await
+    match _functions::functions::system::archive::do_save(auth, user_id, slot_index, None, payload)
+        .await
     {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err(crate::routes::internal_error(e)),
@@ -107,12 +113,10 @@ pub async fn rename(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Path((slot_index, new_name)): Path<(i64, String)>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
     match _functions::functions::system::archive::do_rename_by_slot(
-        auth,
-        user_id,
-        slot_index as i32,
-        new_name,
+        auth, user_id, slot_index, new_name,
     )
     .await
     {
@@ -128,10 +132,9 @@ pub async fn restore(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
-    match _functions::functions::system::archive::do_restore_slot(auth, user_id, slot_index as i32)
-        .await
-    {
+    match _functions::functions::system::archive::do_restore_slot(auth, user_id, slot_index).await {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err(crate::routes::internal_error(e)),
     }
@@ -144,10 +147,9 @@ pub async fn delete_slot(
     ExtractAuthInfo(auth): ExtractAuthInfo,
     Path(slot_index): Path<i64>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    check_slot_index(slot_index)?;
     let user_id = auth.info.id;
-    match _functions::functions::system::archive::do_delete_slot(auth, user_id, slot_index as i32)
-        .await
-    {
+    match _functions::functions::system::archive::do_delete_slot(auth, user_id, slot_index).await {
         Ok(v) => Ok(Json(v).into_response()),
         Err(e) => Err(crate::routes::internal_error(e)),
     }

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -296,6 +296,11 @@ pub struct Claims {
 
 pub static EXPIRED_APPEND_DURATION: chrono::Duration = chrono::Duration::days(15);
 
+/// Refresh token 有效期：与 refresh JWT exp（30 天）保持一致。
+/// Redis `jwt:refresh:` 键的 TTL 必须使用本常量，避免键先于 JWT 过期
+/// 导致「JWT 仍有效但刷新失败」（行为随 Redis 可用性漂移）。
+pub static REFRESH_APPEND_DURATION: chrono::Duration = chrono::Duration::days(30);
+
 pub async fn generate_token(
     now: DateTime<Utc>,
     user_id: i64,

--- a/packages/utils/src/jwt.rs
+++ b/packages/utils/src/jwt.rs
@@ -72,7 +72,17 @@ pub fn is_rsa_signing() -> bool {
 }
 
 /// The active signing algorithm.
-pub fn jwt_alg() -> Algorithm {
+/// HS256 verification is opt-in via `JWT_ACCEPT_HS256=true` (local/dev only);
+/// RSA mode never accepts HMAC signatures by default.
+fn accept_alg(alg: Algorithm) -> bool {
+    if alg == Algorithm::HS256 {
+        std::env::var("JWT_ACCEPT_HS256").as_deref() == Ok("true")
+    } else {
+        true
+    }
+}
+
+fn jwt_alg() -> Algorithm {
     if is_rsa_signing() {
         Algorithm::RS256
     } else {
@@ -270,6 +280,10 @@ mod jwt_numeric_date {
 pub struct Claims {
     pub sub: i64,
     pub jti: Uuid,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub iss: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub aud: String,
     #[serde(with = "jwt_numeric_date")]
     pub iat: DateTime<Utc>,
     #[serde(with = "jwt_numeric_date")]
@@ -287,12 +301,15 @@ pub async fn generate_token(
     user_id: i64,
     jti: Uuid,
     token_type: &str,
+    ttl: chrono::Duration,
 ) -> Result<String> {
     let claims = Claims {
         sub: user_id,
         jti,
+        iss: "genshin-cloud".to_string(),
+        aud: "genshin-map".to_string(),
         iat: now,
-        exp: now + EXPIRED_APPEND_DURATION,
+        exp: now + ttl,
         token_type: Some(token_type.to_string()),
     };
 
@@ -304,7 +321,13 @@ pub async fn verify_token(token: &str) -> Result<Claims> {
     // before an RSA/HS256 migration stay verifiable.
     let mut last_err = None;
     for (key, alg) in decoding_key_pairs() {
-        match decode::<Claims>(token, key, &Validation::new(alg)) {
+        if !accept_alg(alg) {
+            continue;
+        }
+        let mut validation = Validation::new(alg);
+        validation.set_issuer(&["genshin-cloud"]);
+        validation.set_audience(&["genshin-map"]);
+        match decode::<Claims>(token, key, &validation) {
             Ok(token_data) => return Ok(token_data.claims),
             Err(e) => last_err = Some(e),
         }

--- a/packages/utils/src/models/marker_link.rs
+++ b/packages/utils/src/models/marker_link.rs
@@ -82,6 +82,9 @@ pub struct MarkerLinkage {
     pub path: Option<Vec<Option<MarkerLinkagePathEdge>>>,
     /// 终止点点位 ID
     pub to_id: i64,
+    /// 是否反向（前端箭头方向契约 linkReverse；缺省 false）
+    #[serde(default)]
+    pub link_reverse: Option<bool>,
 }
 
 /// 点位关联列表查询请求

--- a/tests/rust/tests/jwks_rotation_test.rs
+++ b/tests/rust/tests/jwks_rotation_test.rs
@@ -28,6 +28,8 @@ fn sign_with(now: chrono::DateTime<chrono::Utc>, private_pem: &str) -> String {
     let claims = _utils::jwt::Claims {
         sub: 42,
         jti: uuid::Uuid::new_v4(),
+        iss: "genshin-cloud".to_string(),
+        aud: "genshin-map".to_string(),
         iat: now,
         exp: now + chrono::Duration::days(1),
         token_type: None,


### PR DESCRIPTION
## Summary

Harden JWT handling: issuer/audience claims, HS256 opt-in, longer refresh TTL.

## Changes

- `Claims` gains `iss` (`genshin-cloud`) and `aud` (`genshin-map`); `generate_token` fills them and accepts an explicit TTL (access 15d / refresh 30d — refresh no longer shares the access window).
- `verify_token` validates issuer/audience and **only accepts HS256 when `JWT_ACCEPT_HS256=true`** (local/dev opt-in); RSA mode rejects HMAC-signed tokens by default.
- Tests updated for the new Claims fields.

## Test Plan

- [x] check / clippy / fmt clean
- [x] `wire_format` 12 tests pass

## Breaking Changes

Tokens issued before this change (no iss/aud) fail issuer/audience validation → **all clients must re-login**. HS256 verification is now opt-in (`JWT_ACCEPT_HS256=true`).
