### PR TITLE
✨ Add WebSocket push channel aligned with the Java reference implementation.

### DIFF
--- a/packages/functions/src/functions/api/app.rs
+++ b/packages/functions/src/functions/api/app.rs
@@ -15,5 +15,6 @@ use super::binary_doc;
 pub async fn do_trigger_update(auth: AuthInfo) -> Result<CommonResponse<bool>> {
     auth.require_non_anonymous()?;
     binary_doc::invalidate_all().await;
+    super::super::ws::ws_broadcast("AppUpdated", serde_json::Value::Null);
     Ok(CommonResponse::new(Ok(true)))
 }

--- a/packages/functions/src/functions/api/cache.rs
+++ b/packages/functions/src/functions/api/cache.rs
@@ -26,6 +26,7 @@ pub async fn do_delete_area_cache(auth: AuthInfo) -> Result<CommonResponse<Empty
 pub async fn do_delete_item_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
     binary_doc::invalidate_all().await;
+    super::super::ws::ws_broadcast("ItemBinaryPurged", serde_json::Value::Null);
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -42,6 +43,7 @@ pub async fn do_delete_icon_tag_cache(
     _tags: Vec<String>,
 ) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
+    super::super::ws::ws_broadcast("IconTagBinaryPurged", serde_json::Value::Null);
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -49,6 +51,7 @@ pub async fn do_delete_icon_tag_cache(
 pub async fn do_delete_marker_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
     binary_doc::invalidate_all().await;
+    super::super::ws::ws_broadcast("MarkerBinaryPurged", serde_json::Value::Null);
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -56,6 +59,7 @@ pub async fn do_delete_marker_cache(auth: AuthInfo) -> Result<CommonResponse<Emp
 pub async fn do_delete_marker_link_cache(auth: AuthInfo) -> Result<CommonResponse<EmptyResponse>> {
     auth.require_non_anonymous()?;
     binary_doc::invalidate_all().await;
+    super::super::ws::ws_broadcast("MarkerLinkageBinaryPurged", serde_json::Value::Null);
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -411,6 +411,7 @@ pub async fn do_tweak(
         return Ok(CommonResponse::new(Ok(vec![])));
     }
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast("MarkerTweaked", serde_json::json!(touched_ids));
     let item_map = marker_item_map(db, &touched_ids).await?;
     let mut arr = Vec::new();
     for chunk in touched_ids.chunks(1000) {
@@ -621,6 +622,7 @@ pub async fn do_add_single(
     }
     super::binary_doc::invalidate_doc_cache().await;
     // 直接返回裸 id，前端期望 data 为 number
+    super::super::ws::ws_broadcast("MarkerAdded", serde_json::json!(res.id));
     Ok(CommonResponse::new(Ok(res.id)))
 }
 
@@ -676,6 +678,7 @@ pub async fn do_update_single(
     txn.commit().await?;
 
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast("MarkerUpdated", serde_json::json!(payload.id));
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
 }
 
@@ -920,5 +923,6 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<MarkerE
     }
 
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast("MarkerDeleted", serde_json::json!(id));
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
 }

--- a/packages/functions/src/functions/api/marker_link.rs
+++ b/packages/functions/src/functions/api/marker_link.rs
@@ -49,12 +49,25 @@ pub async fn do_link(
     auth.require_non_anonymous()?;
     let db = &DB_CONN.wait().pg_conn;
     let group_id = uuid::Uuid::new_v4().simple().to_string();
+    // 受影响组与点位（对齐 Java `LinkChangeVo`：broadcast MarkerLinked 的 data）
+    let mut affected_groups: Vec<String> = vec![group_id.clone()];
+    let mut affected_markers: Vec<i64> = Vec::new();
+    let mut collect_markers = |id: i64| {
+        if id > 0 && !affected_markers.contains(&id) {
+            affected_markers.push(id);
+        }
+    };
     for p in payload {
         if let Some(id) = p.id
             && id > 0
         {
             // 尝试更新
             if let Some(existing) = linkage_model::Entity::find_safety_by_id(id).one(db).await? {
+                if !existing.group_id.is_empty() && !affected_groups.contains(&existing.group_id) {
+                    affected_groups.push(existing.group_id.clone());
+                }
+                collect_markers(existing.from_id);
+                collect_markers(existing.to_id);
                 let mut am: linkage_model::ActiveModel = existing.into();
                 am.group_id = Set(group_id.clone());
                 am.from_id = Set(p.from_id);
@@ -71,6 +84,8 @@ pub async fn do_link(
             }
         }
 
+        collect_markers(p.from_id);
+        collect_markers(p.to_id);
         // 插入新记录
         let now = chrono::Utc::now().naive_utc();
         let active = linkage_model::ActiveModel {
@@ -95,6 +110,13 @@ pub async fn do_link(
         active.insert(db).await?;
     }
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast(
+        "MarkerLinked",
+        serde_json::json!({
+            "groups": affected_groups,
+            "markers": affected_markers
+        }),
+    );
     Ok(CommonResponse::new(Ok(group_id)))
 }
 
@@ -200,6 +222,13 @@ pub async fn do_delete(
         }
     }
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast(
+        "MarkerLinkageDeleted",
+        serde_json::json!({
+            "groups": groups,
+            "markers": markers
+        }),
+    );
     Ok(CommonResponse::new(Ok(serde_json::json!({
         "groups": groups,
         "markers": markers

--- a/packages/functions/src/functions/api/notice.rs
+++ b/packages/functions/src/functions/api/notice.rs
@@ -90,6 +90,7 @@ pub async fn do_update_notice(
     am.valid_time_end = Set(parse_valid_time(payload.valid_time_end.as_ref(), now));
 
     notice_model::Entity::update_safety(am)?.exec(db).await?;
+    super::super::ws::ws_broadcast("NoticeUpdated", serde_json::json!(payload.id));
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -202,6 +203,7 @@ pub async fn do_delete_notice(auth: AuthInfo, id: i64) -> Result<CommonResponse<
     let mut am: notice_model::ActiveModel = n.into();
     am.del_flag = Set(true);
     notice_model::Entity::delete_safety(am)?.exec(db).await?;
+    super::super::ws::ws_broadcast("NoticeDeleted", serde_json::json!(id));
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -240,5 +242,6 @@ pub async fn do_add_notice(
     };
 
     let res = active.insert(&DB_CONN.wait().pg_conn).await?;
+    super::super::ws::ws_broadcast("NoticeAdded", serde_json::json!(res.id));
     Ok(CommonResponse::new(Ok(res.id)))
 }

--- a/packages/functions/src/functions/mod.rs
+++ b/packages/functions/src/functions/mod.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod system;
+pub mod ws;

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -416,7 +416,10 @@ pub async fn do_kick_out(_auth: AuthInfo, work_id: String) -> Result<()> {
     let user_id = work_id
         .parse::<i64>()
         .map_err(|_| anyhow!("Invalid user id"))?;
-    revoke_user_sessions(user_id).await
+    revoke_user_sessions(user_id).await?;
+    // 通知该用户的在线连接立即下线（对齐 Java SysUserController）
+    super::super::ws::ws_send_to_users(&[work_id], "UserKickedOut", serde_json::Value::Null);
+    Ok(())
 }
 
 /// 用 SCAN 游标分批收集匹配 pattern 的 key（不阻塞 Redis 主线程）。

--- a/packages/functions/src/functions/ws.rs
+++ b/packages/functions/src/functions/ws.rs
@@ -1,0 +1,161 @@
+//! WebSocket 连接注册表与事件推送。
+//!
+//! 对齐 Java 参考实现 `WebSocketEntrypoint`（`/ws/{userId}`）：
+//! - 服务端接收 `{"action":"Ping"}`，回推 `{"event":"Pong",...}` 心跳；
+//! - 业务事件统一由服务端推送 `{event, message, data, time}` 结构
+//!   （`W<T>`），推送通道与 Java 一致：
+//!   - `ws_broadcast` —— 全员广播（`broadcast`）；
+//!   - `ws_send_to_users` —— 定向发送（`sendToUsers`）。
+//!
+//! 连接按 userId 分组管理（同一用户多标签页/多设备各自独立会话），
+//! 断开时自动从注册表移除。与 Java 一致，连接本身不做鉴权
+//! （前端仅在已登录时发起连接，服务端信任路径中的 userId）。
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use tokio::sync::mpsc;
+
+use serde_json::{Value, json};
+
+/// 会话注册表：userId → 该用户的全部连接（发送端）。
+static WS_SESSIONS: Lazy<Mutex<HashMap<String, Vec<mpsc::UnboundedSender<String>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// 单个连接的生命周期守卫：drop 时把自身从注册表移除。
+pub struct WsGuard {
+    user_id: String,
+    sender: mpsc::UnboundedSender<String>,
+}
+
+impl Drop for WsGuard {
+    fn drop(&mut self) {
+        let mut sessions = match WS_SESSIONS.lock() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        if let Some(list) = sessions.get_mut(&self.user_id) {
+            list.retain(|s| !s.same_channel(&self.sender));
+            if list.is_empty() {
+                sessions.remove(&self.user_id);
+            }
+        }
+    }
+}
+
+/// 注册一个连接（返回事件接收端与守卫；守卫释放即断开）。
+pub fn ws_register(user_id: String) -> (mpsc::UnboundedReceiver<String>, WsGuard) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut sessions = WS_SESSIONS.lock().unwrap_or_else(|e| e.into_inner());
+    sessions
+        .entry(user_id.clone())
+        .or_default()
+        .push(tx.clone());
+    (
+        rx,
+        WsGuard {
+            user_id,
+            sender: tx,
+        },
+    )
+}
+
+/// 构造 Java `W<T>` 结构的 JSON 文本：`{event, message, data, time}`。
+fn ws_payload(event: &str, data: Value) -> String {
+    let time = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    json!({
+        "event": event,
+        "message": "",
+        "data": data,
+        "time": time,
+    })
+    .to_string()
+}
+
+/// 向所有连接广播事件（Java `broadcast`）。
+pub fn ws_broadcast(event: &str, data: Value) {
+    let payload = ws_payload(event, data);
+    let sessions = WS_SESSIONS.lock().unwrap_or_else(|e| e.into_inner());
+    let mut dead: Vec<(String, mpsc::UnboundedSender<String>)> = Vec::new();
+    for (user_id, list) in sessions.iter() {
+        for s in list {
+            if s.send(payload.clone()).is_err() {
+                dead.push((user_id.clone(), s.clone()));
+            }
+        }
+    }
+    // 清理已断开的发送端（避免死连接占位导致注册表膨胀）
+    if !dead.is_empty() {
+        drop(sessions);
+        if let Ok(mut sessions) = WS_SESSIONS.lock() {
+            for (user_id, sender) in dead {
+                if let Some(list) = sessions.get_mut(&user_id) {
+                    list.retain(|s| !s.same_channel(&sender));
+                    if list.is_empty() {
+                        sessions.remove(&user_id);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// 向指定用户推送事件（Java `sendToUsers`；无此连接时静默忽略）。
+pub fn ws_send_to_users(user_ids: &[String], event: &str, data: Value) {
+    let payload = ws_payload(event, data);
+    let sessions = WS_SESSIONS.lock().unwrap_or_else(|e| e.into_inner());
+    for uid in user_ids {
+        if let Some(list) = sessions.get(uid) {
+            for s in list {
+                let _ = s.send(payload.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_broadcast_and_guard_removal() {
+        let (mut rx1, guard1) = ws_register("u1".into());
+        let (mut rx2, guard2) = ws_register("u2".into());
+
+        ws_broadcast("NoticeAdded", json!(42));
+        assert_eq!(
+            rx1.try_recv().expect("u1 should receive"),
+            ws_payload("NoticeAdded", json!(42))
+        );
+        assert_eq!(
+            rx2.try_recv().expect("u2 should receive"),
+            ws_payload("NoticeAdded", json!(42))
+        );
+
+        ws_send_to_users(&["u1".into()], "UserKickedOut", Value::Null);
+        assert_eq!(
+            rx1.try_recv().expect("u1 should receive kick"),
+            ws_payload("UserKickedOut", Value::Null)
+        );
+        assert!(rx2.try_recv().is_err(), "u2 should not receive kick");
+
+        drop(guard1);
+        drop(guard2);
+        // 注册表清空后广播不再投递
+        ws_broadcast("AppUpdated", Value::Null);
+        assert!(rx1.try_recv().is_err());
+        assert!(rx2.try_recv().is_err());
+        assert!(WS_SESSIONS.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn payload_matches_java_w_shape() {
+        let raw = ws_payload("MarkerAdded", json!(7));
+        let v: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["event"], "MarkerAdded");
+        assert_eq!(v["data"], 7);
+        assert_eq!(v["message"], "");
+        assert!(v["time"].as_str().unwrap().len() >= 19);
+    }
+}

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod system;
+mod ws;
 
 use anyhow::Result;
 
@@ -53,6 +54,7 @@ pub async fn router() -> Result<Router> {
         .route("/oauth/qq", post(system::oauth::qq_login))
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/system", system::router().await?)
+        .route("/ws/{user_id}", get(ws::ws_handler))
         // The domain endpoints live under /api/* (Java contract — the
         // frontend's production build and direct clients call these paths).
         // They are ALSO merged at the root: the Vite dev proxy rewrites

--- a/packages/router/src/routes/ws.rs
+++ b/packages/router/src/routes/ws.rs
@@ -1,0 +1,60 @@
+//! WebSocket 端点（`GET /ws/{userId}`），对齐 Java `WebSocketEntrypoint`。
+//!
+//! 连接建立后：
+//! - 客户端心跳 `{"action":"Ping"}` → 服务端定向回推 `Pong`；
+//! - 服务端业务事件（公告/点位/缓存刷新等）经 `_functions::functions::ws`
+//!   注册表转发到对应连接。
+
+use axum::{
+    extract::{
+        Path,
+        ws::{Message, Utf8Bytes, WebSocket, WebSocketUpgrade},
+    },
+    response::Response,
+};
+use serde_json::Value;
+
+/// `GET /ws/{userId}` 升级握手。
+pub async fn ws_handler(ws: WebSocketUpgrade, Path(user_id): Path<String>) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, user_id))
+}
+
+/// 单连接生命周期：注册进连接池，循环处理上行消息与下行事件。
+async fn handle_socket(mut socket: WebSocket, user_id: String) {
+    let (mut rx, _guard) = _functions::functions::ws::ws_register(user_id.clone());
+
+    loop {
+        tokio::select! {
+            // 上行：仅处理心跳 Ping（对齐 Java handlerMap）
+            incoming = socket.recv() => {
+                let Some(Ok(msg)) = incoming else {
+                    break;
+                };
+                match msg {
+                    Message::Text(text) => {
+                        if let Ok(v) = serde_json::from_str::<Value>(&text)
+                            && v.get("action").and_then(Value::as_str) == Some("Ping")
+                        {
+                            _functions::functions::ws::ws_send_to_users(
+                                std::slice::from_ref(&user_id),
+                                "Pong",
+                                Value::Null,
+                            );
+                        }
+                    },
+                    Message::Close(_) => break,
+                    _ => {},
+                }
+            },
+            // 下行：业务事件转发到该连接
+            event = rx.recv() => {
+                let Some(payload) = event else {
+                    break;
+                };
+                if socket.send(Message::Text(Utf8Bytes::from(payload))).await.is_err() {
+                    break;
+                }
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implement the WebSocket push channel that the Rust backend was missing. The Java reference backend (`/ws/{userId}`, `javax.websocket`) and the frontend worker (`socket.worker.ts`, heartbeat every 15s / timeout 30s) already speak this protocol — this PR makes the Rust side connect them.

### Protocol (aligned 1:1 with Java `WebSocketEntrypoint`)

- Endpoint: `GET /ws/{userId}` (axum `WebSocketUpgrade`), no auth (same trust model as Java: frontend only connects when logged in).
- Heartbeat: client `{"action":"Ping"}` → server replies `{"event":"Pong",...}` to that user's connections.
- Downlink events use the Java `W<T>` shape: `{event, message, data, time}`.

### Push channels (`packages/functions/src/functions/ws.rs`)

- `ws_broadcast` (Java `broadcast`) and `ws_send_to_users` (Java `sendToUsers`), session registry keyed by userId (multi-tab/multi-device safe), auto-cleanup of dead connections.

### Event sources wired (matching Java controllers)

| Event | Data | Source |
|---|---|---|
| `NoticeAdded/Updated/Deleted` | id | `api/notice.rs` |
| `MarkerAdded/Updated/Deleted` | id | `api/marker.rs` |
| `MarkerTweaked` | ids | `api/marker.rs` |
| `MarkerLinked` / `MarkerLinkageDeleted` | `{groups, markers}` | `api/marker_link.rs` |
| `ItemBinaryPurged` / `MarkerBinaryPurged` / `MarkerLinkageBinaryPurged` | null | `api/cache.rs` |
| `IconTagBinaryPurged` | null | `api/cache.rs` |
| `AppUpdated` | null | `api/app.rs` |
| `UserKickedOut` | null (targeted) | `system/user.rs` |

### Tests

- 2 unit tests in `ws.rs`: registry register/broadcast/guard removal, payload shape (`W` shape, `event`/`data`/`message`/`time`).
- Full workspace test suite green; clippy `-D warnings` + fmt clean.
