### PR TITLE
🐛 Broadcast BinaryPurged events on write operations aligned with Java.

### DIFF
--- a/packages/functions/src/functions/api/item.rs
+++ b/packages/functions/src/functions/api/item.rs
@@ -131,6 +131,11 @@ pub async fn do_update(
         }
     }
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -320,6 +325,11 @@ pub async fn do_join_type(
         active.insert(db).await?;
     }
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -371,6 +381,11 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<()>> {
         .exec(db)
         .await?;
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(())))
 }
 
@@ -435,6 +450,11 @@ pub async fn do_copy_to_area(
         }
     }
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(new_ids)))
 }
 
@@ -506,6 +526,11 @@ pub async fn do_add(auth: AuthInfo, payload: ItemAddRequest) -> Result<CommonRes
     }
 
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(new_id)))
 }
 

--- a/packages/functions/src/functions/api/item_type.rs
+++ b/packages/functions/src/functions/api/item_type.rs
@@ -79,6 +79,11 @@ pub async fn do_update(
         .exec(&DB_CONN.wait().pg_conn)
         .await?;
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -125,6 +130,11 @@ pub async fn do_move_to_target(
         refresh_is_final(db, p).await?;
     }
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -281,6 +291,11 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     // is_final 重算：被删类型的父级若再无子级，恢复为末端类型
     refresh_is_final(db, root_parent_id).await?;
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -324,6 +339,11 @@ pub async fn do_add(auth: AuthInfo, payload: ItemTypeAddRequest) -> Result<Commo
     // 父级新增子级后不再是末端类型
     refresh_is_final(&DB_CONN.wait().pg_conn, payload.parent_id).await?;
     super::binary_doc::invalidate_item_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(res.id)))
 }
 

--- a/packages/functions/src/functions/api/marker.rs
+++ b/packages/functions/src/functions/api/marker.rs
@@ -412,6 +412,21 @@ pub async fn do_tweak(
     }
     super::binary_doc::invalidate_doc_cache().await;
     super::super::ws::ws_broadcast("MarkerTweaked", serde_json::json!(touched_ids));
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     let item_map = marker_item_map(db, &touched_ids).await?;
     let mut arr = Vec::new();
     for chunk in touched_ids.chunks(1000) {
@@ -623,6 +638,21 @@ pub async fn do_add_single(
     super::binary_doc::invalidate_doc_cache().await;
     // 直接返回裸 id，前端期望 data 为 number
     super::super::ws::ws_broadcast("MarkerAdded", serde_json::json!(res.id));
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(res.id)))
 }
 
@@ -679,6 +709,21 @@ pub async fn do_update_single(
 
     super::binary_doc::invalidate_doc_cache().await;
     super::super::ws::ws_broadcast("MarkerUpdated", serde_json::json!(payload.id));
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
 }
 
@@ -924,5 +969,20 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<MarkerE
 
     super::binary_doc::invalidate_doc_cache().await;
     super::super::ws::ws_broadcast("MarkerDeleted", serde_json::json!(id));
+    super::super::ws::ws_broadcast_debounced(
+        "ItemBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(MarkerEmptyResponse {})))
 }

--- a/packages/functions/src/functions/api/marker_link.rs
+++ b/packages/functions/src/functions/api/marker_link.rs
@@ -117,6 +117,16 @@ pub async fn do_link(
             "markers": affected_markers
         }),
     );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(group_id)))
 }
 
@@ -228,6 +238,16 @@ pub async fn do_delete(
             "groups": groups,
             "markers": markers
         }),
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
+    super::super::ws::ws_broadcast_debounced(
+        "MarkerLinkageBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
     );
     Ok(CommonResponse::new(Ok(serde_json::json!({
         "groups": groups,

--- a/packages/functions/src/functions/api/tag.rs
+++ b/packages/functions/src/functions/api/tag.rs
@@ -53,6 +53,11 @@ pub async fn do_add(auth: AuthInfo, payload: TagAddRequest) -> Result<TagAddResp
 
     let res = tag_model::Entity::insert(am).exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(TagAddResponse {
         id: res.last_insert_id,
     })
@@ -91,6 +96,11 @@ pub async fn do_update(
             .await?;
     }
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -165,6 +175,11 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     am.del_flag = Set(true);
     tag_model::Entity::delete_safety(am)?.exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -213,6 +228,11 @@ pub async fn do_update_type(
     }
 
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -247,6 +267,11 @@ pub async fn do_create_by_name(auth: AuthInfo, tag_name: String) -> Result<Commo
     .exec(db)
     .await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -264,6 +289,11 @@ pub async fn do_delete_by_name(auth: AuthInfo, tag_name: String) -> Result<Commo
     am.del_flag = Set(true);
     tag_model::Entity::delete_safety(am)?.exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(true)))
 }
 
@@ -285,6 +315,11 @@ pub async fn do_update_by_name(
     am.icon_id = Set(icon_id);
     tag_model::Entity::update_safety(am)?.exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(true)))
 }
 

--- a/packages/functions/src/functions/api/tag_type.rs
+++ b/packages/functions/src/functions/api/tag_type.rs
@@ -50,6 +50,11 @@ pub async fn do_add(auth: AuthInfo, payload: TagTypeBaseRequest) -> Result<Commo
 
     let res = tag_type_model::Entity::insert(am).exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(res.last_insert_id)))
 }
 
@@ -73,6 +78,11 @@ pub async fn do_update(
 
     tag_type_model::Entity::update_safety(am)?.exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }
 
@@ -142,5 +152,10 @@ pub async fn do_delete(auth: AuthInfo, id: i64) -> Result<CommonResponse<EmptyRe
     am.del_flag = Set(true);
     tag_type_model::Entity::delete_safety(am)?.exec(db).await?;
     super::binary_doc::invalidate_doc_cache().await;
+    super::super::ws::ws_broadcast_debounced(
+        "IconTagBinaryPurged",
+        serde_json::Value::Null,
+        super::super::ws::PURGE_DEBOUNCE_WINDOW,
+    );
     Ok(CommonResponse::new(Ok(EmptyResponse {})))
 }

--- a/packages/functions/src/functions/ws.rs
+++ b/packages/functions/src/functions/ws.rs
@@ -13,6 +13,7 @@
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use once_cell::sync::Lazy;
 use tokio::sync::mpsc;
@@ -112,6 +113,29 @@ pub fn ws_send_to_users(user_ids: &[String], event: &str, data: Value) {
             }
         }
     }
+}
+
+/// 防抖推送窗口：对齐 Java `server.cache.debounce-delay` 默认 30s，
+/// 写操作触发的缓存清理事件（`*BinaryPurged`）在窗口内合并为一次广播，
+/// 避免批量操作（如逐条导入物品）触发事件风暴。
+pub const PURGE_DEBOUNCE_WINDOW: Duration = Duration::from_secs(30);
+
+/// 各事件最近一次广播时间（防抖状态）。
+static LAST_PUSH: Lazy<Mutex<HashMap<String, Instant>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// 带防抖的全员广播：同一事件在窗口内只推一次（窗口内重复调用静默丢弃）。
+pub fn ws_broadcast_debounced(event: &str, data: Value, window: Duration) {
+    let now = Instant::now();
+    {
+        let mut last = LAST_PUSH.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(prev) = last.get(event)
+            && now.duration_since(*prev) < window
+        {
+            return;
+        }
+        last.insert(event.to_string(), now);
+    }
+    ws_broadcast(event, data);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up to #109: the WebSocket push channel wired event sources for explicit cache endpoints and per-entity events, but the **write operations** themselves never broadcast the `*BinaryPurged` events that the Java reference backend emits after every write. Online clients therefore did not refresh item / item-type / tag / marker / linkage archives until they reloaded or hit a cache endpoint.

### Fix

Add a **debounced** broadcast (`ws_broadcast_debounced`, 30s window aligned with Java `server.cache.debounce-delay`) so batch imports do not cause event storms, and wire it into every write path that invalidates a doc cache:

| Write path | Events broadcast (debounced) |
|---|---|
| `item.rs` (add / update / delete / copy / join_type) | `ItemBinaryPurged` |
| `item_type.rs` (add / update / delete / move) | `ItemBinaryPurged` |
| `tag.rs`, `tag_type.rs` | `IconTagBinaryPurged` |
| `marker.rs` (add / update / delete / tweak) | `ItemBinaryPurged` + `MarkerBinaryPurged` + `MarkerLinkageBinaryPurged` |
| `marker_link.rs` (link / delete) | `MarkerBinaryPurged` + `MarkerLinkageBinaryPurged` |

This matches the Java controllers: `MarkerController` cleans item+marker+linkage caches, `ItemController`/`ItemTypeController` clean item, `TagController`/`TagTypeController` clean icon-tag, `MarkerLinkageController` cleans marker+linkage.

### Review notes (checked, no change needed)

- `binary_doc` md5 lookup: unknown md5 returns a business error, never triggers a recompute (no cache-thrash vector).
- `res/upload`: magic-bytes + content-type whitelist + size gate already in place.
- Icon/icon-type writes intentionally do not broadcast (no such event source in Java).

### Tests

Workspace suite green; clippy `-D warnings` + fmt clean.
