### PR TITLE
🐛 Align QQ registration with Java and drop the insecure openid login endpoint.

### DIFF
--- a/packages/functions/src/functions/system/oauth.rs
+++ b/packages/functions/src/functions/system/oauth.rs
@@ -564,46 +564,6 @@ pub fn map_scope(scope: &str) -> Result<OauthScopeType> {
     }
 }
 
-/// QQ 第三方登录：客户端完成 QQ 授权后，用拿到的 openid 换取本站 token。
-///
-/// 按 `sys_user.qq` 匹配用户；未注册的 openid 返回明确错误（注册走
-/// `/user/register/qq`，把 openid 写入 `qq` 字段）。与密码登录一致地执行
-/// access_policy 检查、设备登记与登录日志。
-pub async fn oauth_qq_login(
-    qq_openid: String,
-    ip: SocketAddr,
-    user_agent: String,
-) -> Result<OauthLoginResponse> {
-    let db = &DB_CONN.wait().pg_conn;
-    let item = match models::system::sys_user::Entity::find()
-        .filter(models::system::sys_user::Column::DelFlag.eq(false))
-        .filter(models::system::sys_user::Column::Qq.eq(Some(qq_openid)))
-        .one(db)
-        .await
-        .map_err(internal_error)?
-    {
-        Some(item) => item,
-        // QQ 未注册：写失败审计日志（user_id 未知，记 None）后拒绝
-        None => {
-            let _ = record_login_log(None, ip, &user_agent, true).await;
-            return Err(anyhow!("QQ account not registered"));
-        },
-    };
-    let user_id = item.id;
-
-    // 身份由 openid 提供；同样校验登录环境
-    let policy: Vec<_> = item.access_policy.clone().map(|a| a.0).unwrap_or_default();
-    check_access_policy(item.id, &policy, ip, &user_agent).await?;
-    let ret = issue_token(&item).await;
-
-    if ret.is_ok() {
-        let _ = record_device(user_id, ip, &user_agent).await;
-    }
-    record_login_log(Some(user_id), ip, &user_agent, ret.is_err()).await?;
-
-    ret
-}
-
 pub async fn oauth_client_credentials(scope: String) -> Result<OauthAnonymousResponse> {
     // 使用系统匿名用户 id = 0 表示客户端凭据/匿名访问
     let id: i64 = 0;

--- a/packages/functions/src/functions/system/user.rs
+++ b/packages/functions/src/functions/system/user.rs
@@ -77,11 +77,12 @@ pub async fn do_register_qq(
     remark: Option<String>,
     username: String,
     password: String,
-    // 公开接口不信任客户端自报的 qq 绑定：真实场景应由 QQ OAuth 回调传入
-    // openid 并落库，此处仅做必填校验（缺省则 serde 反序列化直接失败）。
-    qq: String,
+    // 与 Java 契约一致：username 即 QQ 号；qq 字段缺省时取 username。
+    // 不做腾讯 OAuth openid 语义（openid 需服务端授权码换取，客户端自报不可信）。
+    qq: Option<String>,
 ) -> Result<CommonResponse<i64>> {
     let db = &DB_CONN.wait().pg_conn;
+    let qq = qq.unwrap_or_else(|| username.clone());
 
     // 注册前查重（应用层）：username / qq 任一已被占用（未软删）则拒绝，
     // 防公开接口批量注册重复账号；数据库唯一索引作为最终兜底。

--- a/packages/router/src/routes/mod.rs
+++ b/packages/router/src/routes/mod.rs
@@ -51,7 +51,6 @@ pub fn internal_error<E: Into<anyhow::Error>>(e: E) -> (StatusCode, String) {
 pub async fn router() -> Result<Router> {
     let ret = Router::new()
         .route("/oauth/token", post(system::oauth::oauth))
-        .route("/oauth/qq", post(system::oauth::qq_login))
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/system", system::router().await?)
         .route("/ws/{user_id}", get(ws::ws_handler))

--- a/packages/router/src/routes/system/oauth.rs
+++ b/packages/router/src/routes/system/oauth.rs
@@ -10,30 +10,8 @@ use axum::{
 
 use crate::middlewares::{ExtractIP, ExtractUserAgent};
 use _functions::functions::system::oauth::{
-    oauth_client_credentials, oauth_password_login, oauth_qq_login, oauth_refresh,
+    oauth_client_credentials, oauth_password_login, oauth_refresh,
 };
-
-#[derive(Debug, Deserialize)]
-pub struct QqLoginParams {
-    /// QQ 授权后客户端拿到的 openid
-    pub qq_openid: String,
-}
-
-/// QQ 第三方登录
-/// POST /oauth/qq
-#[tracing::instrument(skip(params))]
-pub async fn qq_login(
-    ConnectInfo(native_ip): ConnectInfo<SocketAddr>,
-    ExtractIP(ip): ExtractIP,
-    ExtractUserAgent(user_agent): ExtractUserAgent,
-    Json(params): Json<QqLoginParams>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let ip = ip.unwrap_or(native_ip);
-    let ret = oauth_qq_login(params.qq_openid, ip, user_agent)
-        .await
-        .map_err(crate::routes::internal_error)?;
-    Ok(Json(ret).into_response())
-}
 
 #[derive(Debug, Deserialize)]
 pub struct LoginQuery {

--- a/packages/router/src/routes/system/user.rs
+++ b/packages/router/src/routes/system/user.rs
@@ -37,12 +37,13 @@ pub struct UserRegisterQQParams {
     pub logo: Option<String>,
     /// 备注
     pub remark: Option<String>,
-    /// 用户名
+    /// 用户名（QQ 号）
     pub username: String,
     /// 初始密码
     pub password: String,
-    /// QQ openid（必填；公开接口不信任客户端自报，应由 QQ OAuth 回调传入）
-    pub qq: String,
+    /// QQ 号（与 Java 契约一致：注册时 username 即 QQ 号，缺省时与
+    /// username 相同；不做腾讯 OAuth 的 openid 语义）
+    pub qq: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tests/rust/tests/api_db_test.rs
+++ b/tests/rust/tests/api_db_test.rs
@@ -826,25 +826,33 @@ async fn area_and_item_doc_business_assertions() {
     // The RSA round-trip is proven by every login above (password + QQ):
     // tokens were RS256-signed and verified through the same key material.
 
-    // ── Assertion 8: QQ login resolves the bound openid ──────────────────────
-    seed_user(db, "qq_user", vec![], Some("OPENID_123".into()), now)
+    // ==== Assertion 8: QQ registration stores the QQ number ====
+    // Java 契约：`/user/register/qq` 的 username 即 QQ 号，qq 字段缺省时
+    // 取 username（不做 openid 语义；openid 需服务端授权码换取）。
+    let qq_id = user_fns::do_register_qq(None, None, None, "10001".into(), "pw123".into(), None)
         .await
-        .expect("seed qq user");
-
-    // Registered openid → token issued
-    let resp = oauth_fns::oauth_qq_login("OPENID_123".into(), ip_a, ua.into())
+        .expect("qq register succeeds")
+        .data
+        .expect("qq register returns id");
+    let qq_row = sys_user_model::Entity::find_by_id(qq_id)
+        .one(db)
         .await
-        .expect("qq login succeeds for a bound openid");
-    assert!(!resp.access_token.is_empty());
-
-    // Unregistered openid → error
-    assert!(
-        oauth_fns::oauth_qq_login("OPENID_UNKNOWN".into(), ip_a, ua.into())
-            .await
-            .is_err(),
-        "unregistered openid must fail"
+        .expect("find qq user");
+    let qq_row = qq_row.expect("qq user exists");
+    assert_eq!(qq_row.username, "10001");
+    assert_eq!(
+        qq_row.qq.as_deref(),
+        Some("10001"),
+        "qq field defaults to username"
     );
 
+    // 重复注册同 QQ 号：username 占用被拒
+    assert!(
+        user_fns::do_register_qq(None, None, None, "10001".into(), "pw123".into(), None)
+            .await
+            .is_err(),
+        "duplicate qq register must fail"
+    );
     // ── Assertion 9: score generation weights by field count ────────────────
     // Seed three history rows: two Position (打点) rows with 3-field and
     // 1-field content, and one Area row that must be filtered out.


### PR DESCRIPTION
## Summary

Reviewed the QQ login story against the Java reference and the Tencent QQ Connect OAuth spec. Found two contract breaks and one security flaw:

### 1. `/user/register/qq` was broken for the real frontend

The frontend (`registerUserByQQ`) sends `SysUserRegisterVo = {username, password}` where `username` **is the QQ number** (qqCheck validation) — matching the Java contract (`SysUserService.registerByQQ`: username = QQ number, verified via the public `r.qzone.qq.com` portrait endpoint, nickname/logo filled from QQ public data). The Rust handler required a mandatory `qq` field and documented it as an **openid**, so every real registration call failed with a 400.

**Fix**: `qq` is now optional and defaults to `username` (the QQ number), matching Java semantics. No openid meaning.

### 2. `/oauth/qq` (client-supplied openid) removed

The endpoint let the client hand over an openid directly in exchange for a token. This **does not satisfy the Tencent QQ Connect OAuth 2.0 authorization-code flow**: an openid must be obtained server-side by exchanging the authorization code (`graph.qq.com/oauth2.0/token`) plus client_secret, then querying `/oauth2.0/me`. Accepting a client-claimed openid cannot be verified, letting anyone impersonate a user whose openid is known. The Java backend has no such endpoint, and no frontend code calls it — so it is removed.

### 3. `oauth_qq_login` function and its test removed/rewritten

Assertion 8 in `api_db_test.rs` now verifies the real contract instead: `do_register_qq` with `qq = None` stores `qq = username`, and duplicate registration is rejected.

### Tencent QQ Connect compliance (for the record)

True compliance requires: configured appid/client_secret, `graph.qq.com/oauth2.0/authorize` redirect with state, server-side code→token exchange, server-side openid lookup, then `get_user_info`. No Tencent app credentials exist in `.env`; the current registration flow (QQ number + password) is the Java contract and is what the frontend implements. If real QQ OAuth is wanted, it should be added as a server-side authorization-code flow with credentials configured — out of scope here.

### Tests

Workspace suite green (api_db assertion 8 rewritten); clippy `-D warnings` + fmt clean.
